### PR TITLE
fix: bootstrap standards documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Standard Actions Agent Instructions
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: ./docs/repository-standards.md -->
+
+## User Overrides (Optional)
+
+If `~/AGENTS.md` exists and is readable, load it and apply it as a
+user-specific overlay for this session. If it cannot be read, say so
+briefly and continue.
+
+## Canonical Standards
+
+This repository follows the canonical standards and conventions in the
+`standards-and-conventions` repository.
+
+Resolve the local path (preferred):
+- `../standards-and-conventions`
+
+If the local path is unavailable, use the canonical web source:
+- https://github.com/wphillipmoore/standards-and-conventions
+
+If the canonical standards cannot be retrieved, treat it as a fatal
+exception and stop.
+
+## Shared Skills
+
+Replace `<standards-repo-path>` with the resolved local path when available.
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+- Treat every skill found under that directory as available and active.
+
+## Local Overrides
+
+None.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Shared GitHub Actions library for reusable CI and automation across
 repositories.
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Repository layout](#repository-layout)
 - [Branching and releases](#branching-and-releases)
@@ -11,11 +12,13 @@ repositories.
 - [Validation](#validation)
 
 ## Purpose
+
 Provide a centralized, versioned set of GitHub Actions that can be reused across
 application and library repositories without workflow drift.
 
 ## Repository layout
-```
+
+```text
 actions/
   <action-name>/
     action.yml
@@ -24,14 +27,17 @@ actions/
 ```
 
 ## Branching and releases
+
 - `develop` is the integration branch.
 - Release branches are named `release/<major>.<minor>.x`.
 - Releases are tagged on the release branch.
 
 ## Versioning
+
 - Repository-level SemVer tags (for example, `v1`, `v1.2.0`).
 - Consumers must pin actions by tag or commit SHA.
 
 ## Validation
+
 - Full validation: `scripts/dev/validate_local.sh`
 - Docs-only validation: `scripts/dev/validate_docs.sh`

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -1,11 +1,14 @@
 # Environment and Tooling
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [External tooling dependencies](#external-tooling-dependencies)
 
 ## Purpose
+
 Define the minimal external tooling required for development and validation.
 
 ## External tooling dependencies
+
 See [tooling-dependencies.md](tooling-dependencies.md).

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,13 +1,16 @@
 # Development Standards Overview
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Document map](#document-map)
 
 ## Purpose
+
 Define development workflow standards for this repository.
 
 ## Document map
+
 - Environment and tooling: [environment-and-tooling.md](environment-and-tooling.md)
 - Tooling dependencies: [tooling-dependencies.md](tooling-dependencies.md)
 - Validation: [validation.md](validation.md)

--- a/docs/development/tooling-dependencies.md
+++ b/docs/development/tooling-dependencies.md
@@ -1,13 +1,16 @@
 # Tooling Dependencies
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Required tools](#required-tools)
 
 ## Purpose
+
 List external tools required for validation and daily workflow.
 
 ## Required tools
+
 - `actionlint`
 - `shellcheck`
 - `markdownlint`

--- a/docs/development/validation.md
+++ b/docs/development/validation.md
@@ -1,18 +1,22 @@
 # Validation
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Canonical commands](#canonical-commands)
 - [Tooling dependencies](#tooling-dependencies)
 
 ## Purpose
+
 Define the required local validation commands for this repository.
 
 ## Canonical commands
+
 - Full validation: `scripts/dev/validate_local.sh`
 - Docs-only validation: `scripts/dev/validate_docs.sh`
 
 ## Tooling dependencies
+
 - `actionlint`
 - `shellcheck`
 - `markdownlint`

--- a/docs/operations/2026-01-20-bootstrap-log.md
+++ b/docs/operations/2026-01-20-bootstrap-log.md
@@ -1,6 +1,7 @@
 # Standard Actions bootstrap log (2026-01-20)
 
 ## Table of Contents
+
 - [Purpose](#purpose)
 - [Scope](#scope)
 - [Actions taken](#actions-taken)
@@ -9,42 +10,67 @@
 - [Notes](#notes)
 
 ## Purpose
+
 Record the exact bootstrap steps used to initialize the standard-actions
 repository.
 
 ## Scope
+
 Bootstrap of the local repository at `/Users/pmoore/dev/github/standard-actions`.
 
 ## Actions taken
+
 1. Clone the repository.
+
    - Command: `gh repo clone wphillipmoore/standard-actions /Users/pmoore/dev/github/standard-actions`
-2. Confirm the default branch.
+
+1. Confirm the default branch.
+
    - Command: `git branch --show-current`
    - Result: `develop`
-3. Create a feature branch for the bootstrap work.
+
+1. Create a feature branch for the bootstrap work.
+
    - Command: `git checkout -b feature/bootstrap-repo`
-4. Create initial directories.
+
+1. Create initial directories.
+
    - Command: `mkdir -p .github actions docs/operations`
-5. Add a minimal `.gitignore`.
+
+1. Add a minimal `.gitignore`.
+
    - Command: `cat > .gitignore << 'EOF' ... EOF`
-6. Add a pull request template.
+
+1. Add a pull request template.
+
    - Command: `cat > .github/pull_request_template.md << 'EOF' ... EOF`
-7. Add repository standards overlay.
+
+1. Add repository standards overlay.
+
    - Command: `cat > docs/standards-and-conventions.md << 'EOF' ... EOF`
-8. Replace the README with the initial repository description.
+
+1. Replace the README with the initial repository description.
+
    - Command: `cat > README.md << 'EOF' ... EOF`
-9. Write this bootstrap log.
+
+1. Write this bootstrap log.
+
    - Command: `cat > docs/operations/2026-01-20-bootstrap-log.md << 'EOF' ... EOF`
-10. Run local validation.
+
+1. Run local validation.
+
    - Command: `scripts/dev/validate_local.sh`
    - Result: `actionlint`, `shellcheck`, and `markdownlint` not installed; warnings only.
-11. Add validation scripts and development documentation.
-    - Files: `scripts/dev/validate_local.sh`, `scripts/dev/validate_actions.sh`,
-      `scripts/dev/validate_docs.sh`, `docs/development/overview.md`,
-      `docs/development/validation.md`, `docs/development/tooling-dependencies.md`,
-      `docs/development/environment-and-tooling.md`
+
+1. Add validation scripts and development documentation.
+
+   - Files: `scripts/dev/validate_local.sh`, `scripts/dev/validate_actions.sh`,
+     `scripts/dev/validate_docs.sh`, `docs/development/overview.md`,
+     `docs/development/validation.md`, `docs/development/tooling-dependencies.md`,
+     `docs/development/environment-and-tooling.md`
 
 ## Files created or updated
+
 - `.gitignore`
 - `.github/pull_request_template.md`
 - `README.md`
@@ -52,8 +78,11 @@ Bootstrap of the local repository at `/Users/pmoore/dev/github/standard-actions`
 - `docs/operations/2026-01-20-bootstrap-log.md`
 
 ## Validation
-- 2026-01-20: Ran `scripts/dev/validate_local.sh` after adding validation scripts and docs (actionlint/shellcheck/markdownlint not installed, warnings only).
+
+- 2026-01-20: Ran `scripts/dev/validate_local.sh` after adding validation scripts
+  and docs (actionlint/shellcheck/markdownlint not installed, warnings only).
 
 ## Notes
+
 - No repository-specific `AGENTS.md` was present at bootstrap time.
 - No CI workflows or action implementations were added in this bootstrap step.

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -1,0 +1,29 @@
+# Standard Actions Repository Standards
+
+## Table of Contents
+
+- [Repository profile](#repository-profile)
+- [AI co-authors](#ai-co-authors)
+- [Local references](#local-references)
+- [Local deviations](#local-deviations)
+
+## Repository profile
+
+- repository_type: library
+- versioning_scheme: library
+- branching_model: library-release
+- release_model: artifact-publishing
+- supported_release_lines: 0.x (pre-release)
+
+## AI co-authors
+
+- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
+- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
+
+## Local references
+
+- docs/development/overview.md
+
+## Local deviations
+
+- Releases are distributed via GitHub Actions tags rather than a package registry.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -2,57 +2,39 @@
 
 This repository follows the canonical standards in the Standards and
 Conventions repository:
-https://github.com/wphillipmoore/standards-and-conventions/tree/develop
+[wphillipmoore/standards-and-conventions](https://github.com/wphillipmoore/standards-and-conventions/tree/develop)
 
 ## Table of Contents
+
 - [Canonical references](#canonical-references)
   - [Core references (always required)](#core-references-always-required)
   - [Repository-type references (required for the declared type)](#repository-type-references-required-for-the-declared-type)
   - [Additional required references](#additional-required-references)
 - [Project-specific overlay](#project-specific-overlay)
-  - [Repository profile](#repository-profile)
-  - [AI co-authors](#ai-co-authors)
-  - [Local references](#local-references)
-  - [Local deviations](#local-deviations)
 
 ## Canonical references
 
 ### Core references (always required)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/repository-types-and-attributes.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/github-issues.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md
+
+- [markdown-standards.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/foundation/markdown-standards.md)
+- [repository-types-and-attributes.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/repository-types-and-attributes.md)
+- [commit-messages-and-authorship.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/commit-messages-and-authorship.md)
+- [github-issues.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/github-issues.md)
+- [pull-request-workflow.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/pull-request-workflow.md)
+- [source-control-guidelines.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/source-control-guidelines.md)
 
 ### Repository-type references (required for the declared type)
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-branching-and-release.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-versioning-scheme.md
+
+- [library-branching-and-release.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-branching-and-release.md)
+- [library-versioning-scheme.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/library-versioning-scheme.md)
 
 ### Additional required references
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/overview.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md
-- https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/shared-actions-library.md
+
+- [overview.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/overview.md)
+- [release-versioning.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/release-versioning.md)
+- [shared-actions-library.md](https://github.com/wphillipmoore/standards-and-conventions/blob/develop/docs/code-management/shared-actions-library.md)
 
 ## Project-specific overlay
 
-### Repository profile
-
-- repository_type: library
-- versioning_scheme: library
-- branching_model: library-release
-- release_model: artifact-publishing
-- supported_release_lines: 0.x (pre-release)
-
-### AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-
-### Local references
-
-- docs/development/overview.md
-
-### Local deviations
-
-- Releases are distributed via GitHub Actions tags rather than a package registry.
+Project-specific content lives in `docs/repository-standards.md` and is
+included from `AGENTS.md` only.

--- a/scripts/dev/validate_docs.sh
+++ b/scripts/dev/validate_docs.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 if command -v markdownlint >/dev/null 2>&1; then
-  mapfile -t markdown_files < <(
+  markdown_files=()
+  while IFS= read -r file; do
+    markdown_files+=("$file")
+  done < <(
     find "$root_dir" \( -path "$root_dir/.git" -o -path "$root_dir/.venv" \) -prune -o \
       -type f \( -path "$root_dir/docs/*.md" -o -path "$root_dir/docs/**/*.md" -o -path "$root_dir/README.md" \) -print
   )


### PR DESCRIPTION
# Pull Request

## Summary
- Bootstrap AGENTS.md and repository standards overlay
- Normalize docs formatting for markdownlint
- Make docs validation compatible with macOS bash 3.2

## Issue Linkage
- Fixes #6

## Testing
- scripts/dev/validate_local.sh (warnings: actionlint, shellcheck not installed)

## Notes
- Docs-only: tests skipped (yes)
