### PR TITLE
feat: add initial standard actions

### DIFF
--- a/actions/docs-only-detect/action.yml
+++ b/actions/docs-only-detect/action.yml
@@ -1,0 +1,56 @@
+name: Detect docs-only changes
+description: >-
+  Detects whether a pull request contains only documentation changes.
+  For non-PR events, always outputs false.
+
+inputs:
+  docs-patterns:
+    description: >-
+      Space-separated glob patterns that identify documentation files.
+    required: false
+    default: "docs/** README.md CHANGELOG.md *.md"
+
+outputs:
+  docs-only:
+    description: "'true' if all changed files match docs patterns, 'false' otherwise"
+    value: ${{ steps.detect.outputs.docs-only }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect docs-only changes
+      id: detect
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        DOCS_PATTERNS: ${{ inputs.docs-patterns }}
+      run: |
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')
+        if [ -z "$files" ]; then
+          echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        read -ra patterns <<< "$DOCS_PATTERNS"
+
+        docs_only=true
+        for file in $files; do
+          matched=false
+          for pattern in "${patterns[@]}"; do
+            # shellcheck disable=SC2254
+            case "$file" in
+              $pattern) matched=true; break ;;
+            esac
+          done
+          if [ "$matched" = "false" ]; then
+            docs_only=false
+            break
+          fi
+        done
+
+        echo "docs-only=$docs_only" >> "$GITHUB_OUTPUT"

--- a/actions/python/setup/action.yml
+++ b/actions/python/setup/action.yml
@@ -1,0 +1,36 @@
+name: Python setup
+description: >-
+  Sets up Python, installs uv, and configures dependency caching.
+
+inputs:
+  python-version:
+    description: Python version to install (e.g. "3.14").
+    required: true
+  uv-version:
+    description: uv version to install.
+    required: false
+    default: "0.9.26"
+  cache-prefix:
+    description: Cache key prefix for uv dependency cache.
+    required: false
+    default: "uv"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      shell: bash
+      run: python3 -m pip install uv==${{ inputs.uv-version }}
+
+    - name: Cache uv dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -1,0 +1,52 @@
+name: Standards compliance
+description: >-
+  Validates repository standards: markdown formatting, commit messages,
+  PR issue linkage, and repository profile.
+
+inputs:
+  commit-cutoff-sha:
+    description: >-
+      Skip commits at or before this SHA.  Repos that adopted conventional
+      commits after their initial history pass their cutoff here.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install markdownlint-cli
+      shell: bash
+      run: npm install --global markdownlint-cli
+
+    - name: Fetch base branch for commit linting
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: git fetch origin ${{ github.base_ref }} --depth=1
+
+    - name: Validate repository profile
+      shell: bash
+      run: ${{ github.action_path }}/scripts/repo-profile.sh
+
+    - name: Validate markdown standards
+      shell: bash
+      run: ${{ github.action_path }}/scripts/markdown-standards.sh
+
+    - name: Validate commit messages
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        COMMIT_CUTOFF_SHA: ${{ inputs.commit-cutoff-sha }}
+      run: >-
+        ${{ github.action_path }}/scripts/commit-messages.sh
+        ${{ github.event.pull_request.base.sha }}
+        ${{ github.event.pull_request.head.sha }}
+
+    - name: Validate pull request issue linkage
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: ${{ github.action_path }}/scripts/pr-issue-linkage.sh

--- a/actions/standards-compliance/scripts/commit-messages.sh
+++ b/actions/standards-compliance/scripts/commit-messages.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-}"
+head_ref="${2:-}"
+
+if [[ -z "$base_ref" || -z "$head_ref" ]]; then
+  echo "ERROR: base and head refs are required." >&2
+  echo "Usage: commit-messages.sh <base-ref> <head-ref>" >&2
+  exit 2
+fi
+
+# Resolve bare branch names to origin/ when the local branch doesn't exist.
+if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
+  if git rev-parse --verify --quiet "origin/$base_ref" >/dev/null 2>&1; then
+    base_ref="origin/$base_ref"
+  fi
+fi
+
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+
+# Commits at or before the cutoff SHA predate the conventional commits
+# convention and are excluded from validation.  Consuming repos pass their
+# own cutoff via the COMMIT_CUTOFF_SHA environment variable.
+CUTOFF_SHA="${COMMIT_CUTOFF_SHA:-}"
+
+failed=0
+
+while IFS= read -r commit_sha; do
+  # Skip commits that predate the conventional commits convention.
+  if [[ -n "$CUTOFF_SHA" ]] && git merge-base --is-ancestor "$commit_sha" "$CUTOFF_SHA" 2>/dev/null; then
+    continue
+  fi
+  subject_line="$(git log -n 1 --format=%s "$commit_sha")"
+  if [[ ! "$subject_line" =~ $conventional_regex ]]; then
+    echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2
+    echo "Expected: <type>(optional-scope): <description>" >&2
+    echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+    echo "Got: $subject_line" >&2
+    failed=1
+  fi
+  if [[ $failed -ne 0 ]]; then
+    break
+  fi
+done < <(git rev-list --no-merges "${base_ref}..${head_ref}")
+
+exit $failed

--- a/actions/standards-compliance/scripts/markdown-standards.sh
+++ b/actions/standards-compliance/scripts/markdown-standards.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect standard docs (structural checks + markdownlint).
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(find docs -path docs/sphinx -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+
+if [[ -f README.md ]]; then
+  files+=("README.md")
+fi
+
+# Collect Sphinx docs (markdownlint only — structural checks like
+# Table of Contents and single-H1 do not apply to MyST/Sphinx pages).
+sphinx_files=()
+if [[ -d docs/sphinx ]]; then
+  while IFS= read -r file; do
+    sphinx_files+=("$file")
+  done < <(find docs/sphinx -type f -name "*.md")
+fi
+
+all_files=("${files[@]}" "${sphinx_files[@]}")
+
+# CHANGELOG.md gets markdownlint only — no structural checks (no TOC,
+# multiple H2 headings are expected, heading hierarchy differs).
+if [[ -f CHANGELOG.md ]]; then
+  all_files+=("CHANGELOG.md")
+fi
+
+if [[ ${#all_files[@]} -eq 0 ]]; then
+  echo "ERROR: no markdown files found to lint." >&2
+  exit 2
+fi
+
+if command -v markdownlint >/dev/null 2>&1; then
+  markdownlint_cmd=(markdownlint)
+else
+  echo "ERROR: markdownlint not found. Install markdownlint-cli locally." >&2
+  exit 2
+fi
+
+markdownlint_failed=0
+if [[ -f ".markdownlint.yaml" ]]; then
+  if ! "${markdownlint_cmd[@]}" --config ".markdownlint.yaml" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
+else
+  if ! "${markdownlint_cmd[@]}" "${all_files[@]}"; then
+    markdownlint_failed=1
+  fi
+fi
+
+failed=0
+
+for file in "${files[@]}"; do
+  awk -v file="$file" '
+    BEGIN {
+      in_code = 0
+      toc_found = 0
+      h1_count = 0
+      last_level = 0
+      errors = 0
+    }
+    function report(message) {
+      printf "ERROR: %s (%s:%d)\n", message, file, NR > "/dev/stderr"
+      errors = 1
+    }
+    {
+      line = $0
+
+      if (match(line, /^```/) || match(line, /^~~~/)) {
+        in_code = !in_code
+      }
+
+      if (in_code) {
+        next
+      }
+
+      if (line ~ /^## Table of Contents[[:space:]]*$/) {
+        toc_found = 1
+      }
+
+      if (line ~ /^#{1,6} /) {
+        level = length(substr(line, 1, match(line, / /) - 1))
+        if (level == 1) {
+          h1_count += 1
+        }
+        if (last_level > 0 && level > last_level + 1) {
+          report("Heading level skips from " last_level " to " level)
+        }
+        last_level = level
+      }
+    }
+    END {
+      if (h1_count != 1) {
+        printf "ERROR: expected exactly one H1 heading, found %d (%s)\n", h1_count, file > "/dev/stderr"
+        errors = 1
+      }
+      if (toc_found != 1) {
+        printf "ERROR: missing ## Table of Contents (%s)\n", file > "/dev/stderr"
+        errors = 1
+      }
+      exit errors
+    }
+  ' "$file" || failed=1
+
+done
+
+exit $((failed || markdownlint_failed))

--- a/actions/standards-compliance/scripts/pr-issue-linkage.sh
+++ b/actions/standards-compliance/scripts/pr-issue-linkage.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then
+  echo "ERROR: GITHUB_EVENT_PATH is not set." >&2
+  exit 2
+fi
+
+if [[ ! -f "$GITHUB_EVENT_PATH" ]]; then
+  echo "ERROR: event payload not found at $GITHUB_EVENT_PATH" >&2
+  exit 2
+fi
+
+pr_body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+
+if [[ -z "$pr_body" ]]; then
+  echo "ERROR: pull request body is empty; issue linkage is required." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Ref):?[[:space:]]+#[0-9]+'; then
+  echo "ERROR: pull request body must include primary issue linkage (Fixes #123 or Ref #123)." >&2
+  exit 1
+fi

--- a/actions/standards-compliance/scripts/repo-profile.sh
+++ b/actions/standards-compliance/scripts/repo-profile.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Variables are read via indirect expansion (${!key}).
+set -euo pipefail
+
+profile_file="docs/repository-standards.md"
+
+if [[ ! -f "$profile_file" ]]; then
+  echo "ERROR: repository profile file not found at $profile_file" >&2
+  exit 2
+fi
+
+repository_type=""
+versioning_scheme=""
+branching_model=""
+release_model=""
+supported_release_lines=""
+
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[[:space:]-]*repository_type:[[:space:]]*(.+)$ ]]; then
+    repository_type="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*versioning_scheme:[[:space:]]*(.+)$ ]]; then
+    versioning_scheme="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*branching_model:[[:space:]]*(.+)$ ]]; then
+    branching_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*release_model:[[:space:]]*(.+)$ ]]; then
+    release_model="${BASH_REMATCH[1]}"
+  elif [[ "$line" =~ ^[[:space:]-]*supported_release_lines:[[:space:]]*(.+)$ ]]; then
+    supported_release_lines="${BASH_REMATCH[1]}"
+  fi
+done < "$profile_file"
+
+failed=0
+
+for key in repository_type versioning_scheme branching_model release_model supported_release_lines; do
+  value="${!key}"
+  if [[ -z "$value" ]]; then
+    echo "ERROR: repository profile missing required attribute '$key' in $profile_file" >&2
+    failed=1
+    continue
+  fi
+
+  if [[ "$value" == *"<"* || "$value" == *">"* || "$value" == *"|"* ]]; then
+    echo "ERROR: repository profile attribute '$key' appears to be a placeholder: $value" >&2
+    failed=1
+  fi
+done
+
+exit $failed


### PR DESCRIPTION
## Summary

- Add `docs-only-detect` composite action: detects documentation-only PRs via `gh api` file listing with configurable glob patterns
- Add `standards-compliance` composite action: validates markdown, commit messages, PR linkage, and repository profile using bundled lint scripts (with configurable `commit-cutoff-sha` input)
- Add `python/setup` composite action: sets up Python, installs `uv`, and configures dependency caching

Scripts are extracted from pymqrest's `scripts/lint/` with one change: `commit-messages.sh` reads the cutoff SHA from the `COMMIT_CUTOFF_SHA` env var instead of a hardcoded constant.

## Test plan

- [ ] Verify `shellcheck` passes on all bundled scripts
- [ ] Verify `validate_local.sh` passes
- [ ] Verify directory structure matches plan: `actions/{docs-only-detect,standards-compliance,python/setup}/`

Ref #212
