### PR TITLE
feat: exempt docs/site from structural markdown checks

### DIFF
--- a/actions/standards-compliance/scripts/markdown-standards.sh
+++ b/actions/standards-compliance/scripts/markdown-standards.sh
@@ -5,22 +5,25 @@ set -euo pipefail
 files=()
 while IFS= read -r file; do
   files+=("$file")
-done < <(find docs -path docs/sphinx -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
+done < <(find docs -path docs/sphinx -prune -o -path docs/site -prune -o -path docs/announcements -prune -o -type f -name "*.md" -print)
 
 if [[ -f README.md ]]; then
   files+=("README.md")
 fi
 
-# Collect Sphinx docs (markdownlint only — structural checks like
-# Table of Contents and single-H1 do not apply to MyST/Sphinx pages).
-sphinx_files=()
-if [[ -d docs/sphinx ]]; then
-  while IFS= read -r file; do
-    sphinx_files+=("$file")
-  done < <(find docs/sphinx -type f -name "*.md")
-fi
+# Collect doc-site files (markdownlint only — structural checks like
+# Table of Contents and single-H1 do not apply to pages built by
+# documentation site generators such as Sphinx, MkDocs, etc.).
+docsite_files=()
+for docsite_dir in docs/sphinx docs/site; do
+  if [[ -d "$docsite_dir" ]]; then
+    while IFS= read -r file; do
+      docsite_files+=("$file")
+    done < <(find "$docsite_dir" -type f -name "*.md")
+  fi
+done
 
-all_files=("${files[@]}" "${sphinx_files[@]}")
+all_files=("${files[@]}" "${docsite_files[@]}")
 
 # CHANGELOG.md gets markdownlint only — no structural checks (no TOC,
 # multiple H2 headings are expected, heading hierarchy differs).


### PR DESCRIPTION
## Summary
- Adds `docs/site/` alongside `docs/sphinx/` as exempt from structural markdown checks (TOC, single H1)
- Consolidates Sphinx-only exemption into a generic doc-site loop
- Markdownlint still runs on all doc-site files

## Issue Linkage
- No issue — infrastructure change to support MkDocs doc sites across the mq-rest-admin family

## Testing
- Verified locally against mq-rest-admin-java docs/site/ directory

## Notes
- Companion PR in standards-and-conventions documents the exception in the canonical standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)