### PR TITLE
feat: add CodeQL SAST composite action

### DIFF
--- a/actions/security/codeql/action.yml
+++ b/actions/security/codeql/action.yml
@@ -1,0 +1,27 @@
+name: CodeQL analysis
+description: >-
+  Runs GitHub CodeQL static analysis (init + analyze) for a single language.
+  The calling workflow must grant security-events: write permission.
+
+inputs:
+  language:
+    description: CodeQL language to analyze (e.g. "python", "javascript").
+    required: true
+  queries:
+    description: Query suite to run.
+    required: false
+    default: "+security-extended"
+
+runs:
+  using: composite
+  steps:
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ inputs.language }}
+        queries: ${{ inputs.queries }}
+
+    - name: Run CodeQL analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ inputs.language }}"


### PR DESCRIPTION
## Summary

- Adds `actions/security/codeql/action.yml` composite action wrapping `github/codeql-action/init@v3` and `github/codeql-action/analyze@v3`
- Inputs: `language` (required), `queries` (optional, defaults to `+security-extended`)
- Calling workflows provide `security-events: write` permission

## Context

Ref wphillipmoore/mq-rest-admin-common#20

## Test plan

- [ ] Verify action YAML is valid
- [ ] Consume from mq-rest-admin-python CI and verify CodeQL runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)