### PR TITLE
fix: add autobuild step to CodeQL action for compiled languages

### DIFF
--- a/actions/security/codeql/action.yml
+++ b/actions/security/codeql/action.yml
@@ -21,6 +21,9 @@ runs:
         languages: ${{ inputs.language }}
         queries: ${{ inputs.queries }}
 
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
     - name: Run CodeQL analysis
       uses: github/codeql-action/analyze@v3
       with:


### PR DESCRIPTION
## Summary

- Adds `github/codeql-action/autobuild@v3` step between init and analyze
- Required for compiled languages (Java, Go, C++) — CodeQL needs to observe the build
- No-op for interpreted languages (Python, JavaScript)

## Test plan

- [ ] Verify Java CodeQL passes in mq-rest-admin-java CI
- [ ] Verify Go CodeQL continues to pass in mq-rest-admin-go CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)