### PR TITLE
feat: add Trivy and Semgrep composite actions

### DIFF
--- a/actions/security/semgrep/action.yml
+++ b/actions/security/semgrep/action.yml
@@ -1,0 +1,50 @@
+name: Semgrep SAST scan
+description: >-
+  Runs Semgrep static analysis with language-specific and cross-cutting
+  security rulesets. The calling workflow must grant security-events: write
+  permission.
+
+inputs:
+  language:
+    description: >-
+      Language ruleset to enable (maps to "p/<language>", e.g. "python",
+      "java", "golang").
+    required: true
+  extra-config:
+    description: >-
+      Additional Semgrep config strings, space-separated (e.g.
+      "p/owasp-top-ten").
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Semgrep
+      shell: bash
+      run: pip install semgrep
+
+    - name: Run Semgrep scan
+      shell: bash
+      env:
+        LANGUAGE: ${{ inputs.language }}
+        EXTRA_CONFIG: ${{ inputs.extra-config }}
+      run: |
+        config="p/$LANGUAGE p/security-audit p/secrets"
+        if [ -n "$EXTRA_CONFIG" ]; then
+          config="$config $EXTRA_CONFIG"
+        fi
+
+        config_args=""
+        for c in $config; do
+          config_args="$config_args --config $c"
+        done
+
+        semgrep scan $config_args --sarif --output semgrep-results.sarif
+
+    - name: Upload SARIF
+      if: always()
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: semgrep-results.sarif
+        category: semgrep

--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -1,0 +1,82 @@
+name: Trivy security scan
+description: >-
+  Runs Trivy vulnerability scanning, SBOM generation, or container image
+  scanning. The calling workflow must grant security-events: write permission
+  when scan-type is "fs" or "image".
+
+inputs:
+  scan-type:
+    description: >-
+      Scan mode: "fs" (filesystem vuln scan → SARIF), "sbom" (CycloneDX SBOM
+      generation), or "image" (container image scan → SARIF).
+    required: true
+  scan-ref:
+    description: Filesystem path or container image reference to scan.
+    required: false
+    default: "."
+  severity:
+    description: Comma-separated severity levels to report.
+    required: false
+    default: "CRITICAL,HIGH"
+  exit-code:
+    description: Exit code when vulnerabilities are found (0 = advisory only).
+    required: false
+    default: "1"
+  scanners:
+    description: Comma-separated Trivy scanners to enable.
+    required: false
+    default: "vuln"
+  output-file:
+    description: Output file path for SARIF or SBOM results.
+    required: false
+    default: "trivy-results.sarif"
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy filesystem scan
+      if: inputs.scan-type == 'fs'
+      uses: aquasecurity/trivy-action@0.34.0
+      with:
+        scan-type: fs
+        scan-ref: ${{ inputs.scan-ref }}
+        severity: ${{ inputs.severity }}
+        exit-code: ${{ inputs.exit-code }}
+        scanners: ${{ inputs.scanners }}
+        format: sarif
+        output: ${{ inputs.output-file }}
+
+    - name: Upload SARIF (filesystem scan)
+      if: inputs.scan-type == 'fs' && always()
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.output-file }}
+        category: trivy-fs
+
+    - name: Run Trivy image scan
+      if: inputs.scan-type == 'image'
+      uses: aquasecurity/trivy-action@0.34.0
+      with:
+        scan-type: image
+        image-ref: ${{ inputs.scan-ref }}
+        severity: ${{ inputs.severity }}
+        exit-code: ${{ inputs.exit-code }}
+        scanners: ${{ inputs.scanners }}
+        format: sarif
+        output: ${{ inputs.output-file }}
+
+    - name: Upload SARIF (image scan)
+      if: inputs.scan-type == 'image' && always()
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.output-file }}
+        category: trivy-image
+
+    - name: Generate SBOM
+      if: inputs.scan-type == 'sbom'
+      uses: aquasecurity/trivy-action@0.34.0
+      with:
+        scan-type: fs
+        scan-ref: ${{ inputs.scan-ref }}
+        format: cyclonedx
+        output: ${{ inputs.output-file }}


### PR DESCRIPTION
## Summary

- Add Trivy composite action (`actions/security/trivy/`) supporting filesystem vulnerability scanning (SARIF), CycloneDX SBOM generation, and container image scanning via `aquasecurity/trivy-action@0.34.0`
- Add Semgrep composite action (`actions/security/semgrep/`) running language-specific rulesets plus cross-cutting `p/security-audit` and `p/secrets` rules
- Both actions upload SARIF results to the GitHub Security tab via `github/codeql-action/upload-sarif@v3`

## Test plan

- [ ] CI passes (action YAML validated)
- [ ] Trivy fs scan verified in downstream language repo CI after merge
- [ ] Semgrep scan verified in downstream language repo CI after merge
- [ ] SBOM generation verified in downstream publish workflows after merge

Ref mq-rest-admin-common#11

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)