### PR TITLE
feat: make standard-actions a first-class repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,22 @@
 # Pull Request
 
 ## Summary
-- 
+
+-
 
 ## Issue Linkage
-- Fixes #
+
+- Fixes # (default; use when no acceptance criteria exist)
+- Ref # (use when acceptance criteria exist)
 - Work is not complete until the issue is closed.
-- If no issue exists, state why and open one before merge.
+- If no issue exists, open one before any work begins.
 
 ## Testing
-- No canonical validation command yet (update when defined).
+
+- markdownlint
+- actionlint
+- shellcheck
 
 ## Notes
-- 
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI - Test and Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-only:
+    name: docs-only
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect docs-only changes
+        id: detect
+        uses: ./actions/docs-only-detect
+
+  standards-compliance:
+    name: standards-compliance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate standards
+        uses: ./actions/standards-compliance
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping actionlint."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Install actionlint
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          echo "$PWD" >> "$GITHUB_PATH"
+
+      - name: Run actionlint
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: actionlint
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    needs: docs-only
+    steps:
+      - name: Docs-only short-circuit
+        if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes detected; skipping shellcheck."
+
+      - name: Checkout code
+        if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        if: needs.docs-only.outputs.docs-only != 'true'
+        run: |
+          files=$(find . -path ./.git -prune -o -type f \( \
+            -path './actions/*/scripts/*.sh' -o \
+            -path './scripts/*.sh' -o \
+            -path './scripts/**/*.sh' \
+          \) -print)
+          if [ -n "$files" ]; then
+            echo "$files" | xargs shellcheck
+          else
+            echo "No shell scripts found."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working in this repository.
+
+## Documentation Strategy
+
+This repository uses two complementary approaches for AI agent guidance:
+
+- **AGENTS.md**: Generic AI agent instructions using include directives to force documentation indexing. Contains canonical standards references, shared skills loading, and user override support.
+- **CLAUDE.md** (this file): Claude Code-specific guidance with prescriptive commands, architecture details, and development workflows optimized for `/init`.
+
+<!-- include: docs/standards-and-conventions.md -->
+<!-- include: docs/repository-standards.md -->
+
+## Project Overview
+
+This is a shared GitHub Actions library providing reusable composite actions for CI/CD across all managed repositories. Actions are consumed by pinning to a tag or branch reference.
+
+**Project name**: standard-actions
+
+**Status**: Pre-release (0.x)
+
+**Canonical Standards**: This repository follows standards at <https://github.com/wphillipmoore/standards-and-conventions> (local path: `../standards-and-conventions` if available)
+
+## Development Commands
+
+### Environment Setup
+
+- **Git hooks**: `git config core.hooksPath scripts/git-hooks` (required before committing)
+- **markdownlint**: `npm install --global markdownlint-cli`
+- **actionlint**: `brew install actionlint`
+- **shellcheck**: `brew install shellcheck`
+
+### Validation
+
+```bash
+scripts/dev/validate_local.sh    # Canonical validation (runs all checks below)
+scripts/dev/validate_actions.sh  # actionlint + shellcheck
+scripts/dev/validate_docs.sh     # markdownlint on docs/ and README.md
+```
+
+## Architecture
+
+### Composite Actions
+
+All actions live under `actions/` as composite GitHub Actions:
+
+- `actions/docs-only-detect` — Detects documentation-only PRs to short-circuit expensive CI jobs
+- `actions/standards-compliance` — Validates repo profile, markdown, commit messages, PR linkage, and shared tooling staleness
+- `actions/python/setup` — Python environment setup with uv and caching
+- `actions/security/codeql` — CodeQL static analysis
+- `actions/security/semgrep` — Semgrep SAST scanning
+- `actions/security/trivy` — Trivy vulnerability scanning (filesystem, SBOM, container image)
+
+### Self-Referencing CI
+
+This repository's CI workflow uses **local paths** (`./actions/...`) rather than remote references. This enables self-testing: changes to an action are validated by the same PR that modifies them.
+
+### Sync Mechanism
+
+Shared lint scripts in `actions/standards-compliance/scripts/` are kept synchronized with `standard-tooling` via `scripts/dev/sync-tooling.sh --actions-compat`. The standards-compliance action validates this staleness in consuming repos.
+
+## Branching and PR Workflow
+
+- **Protected branches**: `main`, `develop` — no direct commits (enforced by pre-commit hook)
+- **Branch naming**: `feature/*`, `bugfix/*`, or `hotfix/*` only
+- **Feature/bugfix PRs** target `develop` with squash merge: `gh pr merge --auto --squash --delete-branch`
+- **Release PRs** target `main` with regular merge: `gh pr merge --auto --merge --delete-branch`
+- **Pre-flight**: Always check branch with `git status -sb` before modifying files. If on `develop`, create a `feature/*` branch first.
+
+## Key References
+
+**Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions>
+
+- Local path (preferred): `../standards-and-conventions`
+- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
+
+**User Overrides**: `~/AGENTS.md` (optional, applied if present and readable)

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -10,6 +10,12 @@ inputs:
       commits after their initial history pass their cutoff here.
     required: false
     default: ""
+  skip-sync-check:
+    description: >-
+      Skip the shared tooling staleness check.  Set to true for repositories
+      that ARE the canonical source for synced scripts (e.g. standard-tooling).
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -53,6 +59,7 @@ runs:
 
     - name: Validate shared tooling is up to date
       if: >-
+        inputs.skip-sync-check != 'true' &&
         github.event_name == 'pull_request' &&
         github.base_ref == 'develop'
       shell: bash


### PR DESCRIPTION
## Summary

- Add self-referencing CI workflow with docs-only, standards-compliance, actionlint, and shellcheck jobs
- Add `skip-sync-check` input to standards-compliance action for repos that are the canonical tooling source
- Create CLAUDE.md with project overview, development commands, architecture, and workflow documentation
- Update PR template with actual validation commands
- Create `main` branch for library-release branching model

## Issue Linkage

- Fixes #23

## Testing

- markdownlint
- actionlint
- shellcheck

## Notes

- CI uses local paths (`./actions/...`) for self-testing
- `skip-sync-check` input is needed by standard-tooling (Phase 2) to avoid circular staleness detection
