### PR TITLE
fix: sync lint scripts from standards-and-conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Validate standards
         uses: ./actions/standards-compliance
+        with:
+          commit-cutoff-sha: "0ea4d08325a3aa175884456b9d53b69d2489def6"
 
   actionlint:
     name: actionlint

--- a/actions/standards-compliance/scripts/commit-messages.sh
+++ b/actions/standards-compliance/scripts/commit-messages.sh
@@ -32,6 +32,10 @@ while IFS= read -r commit_sha; do
     continue
   fi
   subject_line="$(git log -n 1 --format=%s "$commit_sha")"
+  # Accept git-generated Revert "..." messages verbatim.
+  if [[ "$subject_line" =~ ^Revert\ \" ]]; then
+    continue
+  fi
   if [[ ! "$subject_line" =~ $conventional_regex ]]; then
     echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2
     echo "Expected: <type>(optional-scope): <description>" >&2

--- a/actions/standards-compliance/scripts/pr-issue-linkage.sh
+++ b/actions/standards-compliance/scripts/pr-issue-linkage.sh
@@ -18,7 +18,7 @@ if [[ -z "$pr_body" ]]; then
   exit 1
 fi
 
-if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+#[0-9]+'; then
-  echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123)." >&2
+if ! printf '%s\n' "$pr_body" | grep -Eq '^[[:space:]]*[-*]?[[:space:]]*(Fixes|Closes|Resolves|Ref):?[[:space:]]+([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+'; then
+  echo "ERROR: pull request body must include primary issue linkage (Fixes #123, Closes #123, Resolves #123, or Ref #123). Cross-repo owner/repo#123 is also accepted." >&2
   exit 1
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Accept git-generated Revert commit messages in commit-messages.sh CI validator
- Support cross-repo owner/repo#123 issue linkage in pr-issue-linkage.sh

## Issue Linkage

- Fixes #29
- Ref wphillipmoore/mq-rest-admin-common#62

## Testing

- CI validates the updated scripts

## Notes

- Source: wphillipmoore/standards-and-conventions#257
- Without this fix, PRs with cross-repo issue references fail the standards-compliance check in all consuming repos

Generated with Claude Code
