### PR TITLE
feat: add ci and build to allowed conventional commit types

### DIFF
--- a/actions/standards-compliance/scripts/commit-messages.sh
+++ b/actions/standards-compliance/scripts/commit-messages.sh
@@ -17,7 +17,7 @@ if ! git rev-parse --verify --quiet "$base_ref" >/dev/null 2>&1; then
   fi
 fi
 
-conventional_regex='^(feat|fix|docs|style|refactor|test|chore)(\([^\)]+\))?: .+'
+conventional_regex='^(feat|fix|docs|style|refactor|test|chore|ci|build)(\([^\)]+\))?: .+'
 
 # Commits at or before the cutoff SHA predate the conventional commits
 # convention and are excluded from validation.  Consuming repos pass their
@@ -39,7 +39,7 @@ while IFS= read -r commit_sha; do
   if [[ ! "$subject_line" =~ $conventional_regex ]]; then
     echo "ERROR: commit $commit_sha does not follow Conventional Commits." >&2
     echo "Expected: <type>(optional-scope): <description>" >&2
-    echo "Allowed types: feat, fix, docs, style, refactor, test, chore" >&2
+    echo "Allowed types: feat, fix, docs, style, refactor, test, chore, ci, build" >&2
     echo "Got: $subject_line" >&2
     failed=1
   fi


### PR DESCRIPTION
# Pull Request

## Summary

- Add `ci` and `build` to the allowed conventional commit type list in `commit-messages.sh`
- Update the error message to include the new types
- Aligns with the broader Conventional Commits specification

## Issue Linkage

- Fixes #31

## Testing

- `shellcheck` passes
- markdownlint passes

## Notes

- This unblocks the `standards-compliance` gate on mq-rest-admin-go (blocked during v1.1.6 release by commit `ci: auto-add issues to GitHub Project`)
- Affects all consuming repos: mq-rest-admin-go, mq-rest-admin-python, mq-rest-admin-java