### PR TITLE
chore: add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ Thumbs.db
 .env.*
 *.log
 
+# Python
+__pycache__/
+
 # Temp/build artifacts (only if created)
 dist/
 build/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__ to .gitignore for shared Python dev tooling

## Issue Linkage

- Fixes #38

## Testing

- markdownlint
- actionlint
- shellcheck

## Notes

- -
