### PR TITLE
feat(publish): add reusable composite actions for tag-and-release, version-bump-pr, and version-divergence

### DIFF
--- a/actions/publish/tag-and-release/action.yml
+++ b/actions/publish/tag-and-release/action.yml
@@ -1,0 +1,92 @@
+name: Tag and release
+description: >-
+  Creates an annotated git tag, a develop changelog boundary tag, and a
+  GitHub Release.  All mutating steps are skipped when the tag already exists,
+  making the action safe to re-run.
+
+inputs:
+  version:
+    description: Semver version string (e.g. 1.2.3).
+    required: true
+  release-title:
+    description: Release title prefix (e.g. mqrestadmin, pymqrest).
+    required: true
+  release-notes:
+    description: Full markdown body for the GitHub Release.
+    required: true
+  release-artifacts:
+    description: >-
+      Space-separated glob of files to attach to the GitHub Release.
+      Leave empty to create a release with no artifacts.
+    required: false
+    default: ""
+  tag-prefix:
+    description: Prefix prepended to the version to form the git tag.
+    required: false
+    default: v
+
+outputs:
+  tag:
+    description: The full tag name that was (or would be) created.
+    value: ${{ steps.meta.outputs.tag }}
+  tag-created:
+    description: "'true' if a new tag was created, 'false' if it already existed."
+    value: ${{ steps.check.outputs.created }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute tag name
+      id: meta
+      shell: bash
+      run: |
+        echo "tag=${{ inputs.tag-prefix }}${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+
+    - name: Check if tag already exists
+      id: check
+      shell: bash
+      run: |
+        if git rev-parse "${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+          echo "created=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "created=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Configure git identity
+      if: steps.check.outputs.created == 'true'
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Create annotated tag
+      if: steps.check.outputs.created == 'true'
+      shell: bash
+      run: |
+        git tag -a "${{ steps.meta.outputs.tag }}" \
+          -m "Release ${{ inputs.version }}"
+        git push origin "${{ steps.meta.outputs.tag }}"
+
+    - name: Tag develop for changelog boundaries
+      if: steps.check.outputs.created == 'true'
+      shell: bash
+      run: |
+        git fetch origin develop
+        git tag "develop-${{ steps.meta.outputs.tag }}" origin/develop
+        git push origin "develop-${{ steps.meta.outputs.tag }}"
+
+    - name: Create GitHub Release
+      if: steps.check.outputs.created == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        release_args=(
+          "${{ steps.meta.outputs.tag }}"
+          --title "${{ inputs.release-title }} ${{ inputs.version }}"
+          --notes "${{ inputs.release-notes }}"
+        )
+        if [ -n "${{ inputs.release-artifacts }}" ]; then
+          release_args+=( ${{ inputs.release-artifacts }} )
+        fi
+        gh release create "${release_args[@]}"

--- a/actions/publish/version-bump-pr/action.yml
+++ b/actions/publish/version-bump-pr/action.yml
@@ -1,0 +1,182 @@
+name: Version bump PR
+description: >-
+  Computes the next patch version, creates a branch from develop that merges
+  main, updates the version file(s) via regex replacement, and opens an
+  auto-merge PR.  Skips if develop already has the expected next version.
+
+inputs:
+  current-version:
+    description: The version that was just published (e.g. 1.2.3).
+    required: true
+  version-file:
+    description: Path to the file containing the version string.
+    required: true
+  version-regex:
+    description: >-
+      Python regex to match the version line.  Use capture groups for the
+      parts you want to preserve (e.g. prefix and suffix around the version).
+    required: true
+  version-replacement:
+    description: >-
+      Python replacement string.  Use {version} as a placeholder for the
+      computed next version (e.g. '\g<1>{version}\2').
+    required: true
+  version-regex-multiline:
+    description: >-
+      Set to "true" to pass re.MULTILINE to the regex substitution.
+    required: false
+    default: "false"
+  develop-version-command:
+    description: >-
+      Shell command to extract the version from the version file on develop.
+      Receives the file content on stdin and must print the version to stdout.
+    required: true
+  post-bump-command:
+    description: >-
+      Shell command to run after version file edit and before commit
+      (e.g. "uv lock --upgrade && uv export ...").  Leave empty to skip.
+    required: false
+    default: ""
+  extra-files:
+    description: >-
+      Space-separated list of additional files to git add before committing
+      (e.g. "uv.lock requirements.txt").
+    required: false
+    default: ""
+  app-token:
+    description: >-
+      GitHub App token used for PR creation.  Must be passed from the caller
+      because composite actions cannot access secrets directly.
+    required: true
+  pr-body-extra:
+    description: >-
+      Additional text appended to the PR body (e.g. dependency refresh notes).
+    required: false
+    default: ""
+
+outputs:
+  next-version:
+    description: The computed next patch version.
+    value: ${{ steps.next.outputs.version }}
+  pr-url:
+    description: URL of the created PR (empty if bump was not needed).
+    value: ${{ steps.create-pr.outputs.pr-url }}
+  bump-needed:
+    description: "'true' if a bump PR was created, 'false' if skipped."
+    value: ${{ steps.check.outputs.needed }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python 3
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - name: Compute next patch version
+      id: next
+      shell: bash
+      run: |
+        next=$(python3 -c "
+        v = '${{ inputs.current-version }}'.split('.')
+        v[2] = str(int(v[2]) + 1)
+        print('.'.join(v))
+        ")
+        echo "version=$next" >> "$GITHUB_OUTPUT"
+        echo "branch=chore/bump-version-$next" >> "$GITHUB_OUTPUT"
+
+    - name: Check if develop already has next version
+      id: check
+      shell: bash
+      run: |
+        git fetch origin develop
+        current=$(git show "origin/develop:${{ inputs.version-file }}" \
+          | ${{ inputs.develop-version-command }})
+        if [ "$current" = "${{ steps.next.outputs.version }}" ]; then
+          echo "needed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Create bump branch and merge main
+      if: steps.check.outputs.needed == 'true'
+      shell: bash
+      run: |
+        git checkout -b "${{ steps.next.outputs.branch }}" origin/develop
+        git merge origin/main --no-edit
+
+    - name: Update version file
+      if: steps.check.outputs.needed == 'true'
+      shell: bash
+      run: |
+        python3 -c "
+        from pathlib import Path
+        import re
+        p = Path('${{ inputs.version-file }}')
+        content = p.read_text()
+        flags = re.MULTILINE if '${{ inputs.version-regex-multiline }}' == 'true' else 0
+        content = re.sub(
+            r'${{ inputs.version-regex }}',
+            r'${{ inputs.version-replacement }}'.replace('{version}', '${{ steps.next.outputs.version }}'),
+            content,
+            count=1,
+            flags=flags,
+        )
+        p.write_text(content)
+        "
+
+    - name: Run post-bump command
+      if: steps.check.outputs.needed == 'true' && inputs.post-bump-command != ''
+      shell: bash
+      run: ${{ inputs.post-bump-command }}
+
+    - name: Commit and push
+      if: steps.check.outputs.needed == 'true'
+      shell: bash
+      run: |
+        git add "${{ inputs.version-file }}"
+        if [ -n "${{ inputs.extra-files }}" ]; then
+          git add ${{ inputs.extra-files }}
+        fi
+        git commit -m "chore: bump version to ${{ steps.next.outputs.version }}"
+        git push origin "${{ steps.next.outputs.branch }}"
+
+    - name: Create and configure PR
+      id: create-pr
+      if: steps.check.outputs.needed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.app-token }}
+      run: |
+        pr_url=$(gh pr create \
+          --base develop \
+          --head "${{ steps.next.outputs.branch }}" \
+          --title "chore: bump version to ${{ steps.next.outputs.version }}" \
+          --body "Automated patch version bump after publishing ${{ inputs.current-version }}.")
+        echo "pr-url=$pr_url" >> "$GITHUB_OUTPUT"
+
+        pr_number="${pr_url##*/}"
+
+        extra=""
+        if [ -n "${{ inputs.pr-body-extra }}" ]; then
+          extra=$'\n'"${{ inputs.pr-body-extra }}"
+        fi
+
+        gh pr edit "$pr_number" --body "$(cat <<EOF
+        Automated patch version bump after publishing ${{ inputs.current-version }}.
+
+        Ref #${pr_number}
+
+        This merges \`main\` back into \`develop\` to pick up the release tag and any
+        other release-branch artifacts, then sets the working version to the next
+        expected patch release. Change this to a minor or major bump if the next
+        release warrants it.${extra}
+        EOF
+        )"
+
+        gh pr close "$pr_number"
+        gh pr reopen "$pr_number"
+
+        gh pr merge \
+          --auto --merge --delete-branch \
+          "${{ steps.next.outputs.branch }}"

--- a/actions/release-gates/version-divergence/action.yml
+++ b/actions/release-gates/version-divergence/action.yml
@@ -1,0 +1,51 @@
+name: Version divergence gate
+description: >-
+  Verifies that the PR branch version differs from the main branch version.
+  Fails the step if the two versions are identical.
+
+inputs:
+  head-version-command:
+    description: >-
+      Shell command that prints the HEAD (PR branch) version to stdout.
+    required: true
+  main-version-command:
+    description: >-
+      Shell command that prints the main branch version to stdout.
+    required: true
+
+outputs:
+  head-version:
+    description: The version extracted from the PR branch.
+    value: ${{ steps.compare.outputs.head-version }}
+  main-version:
+    description: The version extracted from the main branch.
+    value: ${{ steps.compare.outputs.main-version }}
+  diverged:
+    description: "'true' if versions differ, 'false' otherwise."
+    value: ${{ steps.compare.outputs.diverged }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch main branch
+      shell: bash
+      run: git fetch origin main --depth=1
+
+    - name: Compare versions
+      id: compare
+      shell: bash
+      run: |
+        head_version=$(${{ inputs.head-version-command }})
+        main_version=$(${{ inputs.main-version-command }})
+
+        echo "head-version=$head_version" >> "$GITHUB_OUTPUT"
+        echo "main-version=$main_version" >> "$GITHUB_OUTPUT"
+
+        if [ "$main_version" = "$head_version" ]; then
+          echo "diverged=false" >> "$GITHUB_OUTPUT"
+          echo "FAIL: PR version ($head_version) must differ from main ($main_version)."
+          exit 1
+        fi
+
+        echo "diverged=true" >> "$GITHUB_OUTPUT"
+        echo "OK: PR version ($head_version) differs from main ($main_version)."


### PR DESCRIPTION
# Pull Request

## Summary

- Add reusable composite actions for publish tag-and-release, version-bump-pr, and release-gates version-divergence

## Issue Linkage

- Fixes #40

## Testing

- markdownlint
- actionlint
- shellcheck

## Notes

- -
