### PR TITLE
feat(ci): add category prefixes to CI job names

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,8 @@
 ## Testing
 
 - markdownlint
-- actionlint
-- shellcheck
+- ci: actionlint
+- ci: shellcheck
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   docs-only:
-    name: docs-only
+    name: "ci: docs-only"
     runs-on: ubuntu-latest
     outputs:
       docs-only: ${{ steps.detect.outputs.docs-only }}
@@ -28,7 +28,7 @@ jobs:
         uses: ./actions/docs-only-detect
 
   standards-compliance:
-    name: standards-compliance
+    name: "ci: standards-compliance"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
           commit-cutoff-sha: "0ea4d08325a3aa175884456b9d53b69d2489def6"
 
   actionlint:
-    name: actionlint
+    name: "ci: actionlint"
     runs-on: ubuntu-latest
     needs: docs-only
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: actionlint
 
   shellcheck:
-    name: shellcheck
+    name: "ci: shellcheck"
     runs-on: ubuntu-latest
     needs: docs-only
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,41 @@ Shared lint scripts in `actions/standards-compliance/scripts/` are kept synchron
 - **Release PRs** target `main` with regular merge: `gh pr merge --auto --merge --delete-branch`
 - **Pre-flight**: Always check branch with `git status -sb` before modifying files. If on `develop`, create a `feature/*` branch first.
 
+## Commit and PR Scripts
+
+**NEVER use raw `git commit`** — always use `scripts/dev/commit.sh`.
+**NEVER use raw `gh pr create`** — always use `scripts/dev/submit-pr.sh`.
+
+### Committing
+
+```bash
+scripts/dev/commit.sh --type feat --scope ci --message "add category prefixes" --agent claude
+scripts/dev/commit.sh --type fix --message "correct action input name" --agent claude
+scripts/dev/commit.sh --type docs --message "update README" --body "Expanded usage section" --agent claude
+```
+
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--message` (required): commit description
+- `--agent` (required): `claude` or `codex` — resolves the correct `Co-Authored-By` identity
+- `--scope` (optional): conventional commit scope
+- `--body` (optional): detailed commit body
+
+### Submitting PRs
+
+```bash
+scripts/dev/submit-pr.sh --issue 42 --summary "Add category prefixes to CI job names"
+scripts/dev/submit-pr.sh --issue 42 --linkage Ref --summary "Update docs" --docs-only
+scripts/dev/submit-pr.sh --issue 42 --summary "Fix action input" --notes "Tested locally"
+```
+
+- `--issue` (required): GitHub issue number (just the number)
+- `--summary` (required): one-line PR summary
+- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
+- `--title` (optional): PR title (default: most recent commit subject)
+- `--notes` (optional): additional notes
+- `--docs-only` (optional): applies docs-only testing exception
+- `--dry-run` (optional): print generated PR without executing
+
 ## Key References
 
 **Canonical Standards**: <https://github.com/wphillipmoore/standards-and-conventions>


### PR DESCRIPTION
# Pull Request

## Summary

- Add ci: category prefix to all four CI job display names so checks cluster naturally in the GitHub status list

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#198

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Phase 1 of standardize-job-names initiative. Also adds commit/PR wrapper warnings to CLAUDE.md (Ref wphillipmoore/standards-and-conventions#267).