### PR TITLE
fix: replace mapfile with bash 3.2-compatible alternative

### DIFF
--- a/scripts/dev/validate_actions.sh
+++ b/scripts/dev/validate_actions.sh
@@ -10,12 +10,12 @@ else
 fi
 
 if command -v shellcheck >/dev/null 2>&1; then
-  mapfile -t shell_files < <(
+  shell_files=$(
     find "$root_dir" \( -path "$root_dir/.git" -o -path "$root_dir/.venv" \) -prune -o \
       -type f \( -path "$root_dir/actions/*/scripts/*.sh" -o -path "$root_dir/scripts/*.sh" \) -print
   )
-  if [ "${#shell_files[@]}" -gt 0 ]; then
-    shellcheck "${shell_files[@]}"
+  if [ -n "$shell_files" ]; then
+    echo "$shell_files" | xargs shellcheck
   fi
 else
   echo "warning: shellcheck not found; skipping shell lint" >&2


### PR DESCRIPTION
# Pull Request

## Summary

- Replace mapfile with bash 3.2-compatible alternative in validate_actions.sh

## Issue Linkage

- Fixes wphillipmoore/standards-and-conventions#271

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -
