### PR TITLE
feat(docs): add MkDocs documentation site with action reference and CI gate specs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Documentation
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: "deploy: docs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./actions/docs-deploy
+        with:
+          version-command: cat VERSION | cut -d. -f1,2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ This is a shared GitHub Actions library providing reusable composite actions for
 
 - **Git hooks**: `git config core.hooksPath scripts/git-hooks` (required before committing)
 - **markdownlint**: `npm install --global markdownlint-cli`
+- **mkdocs-material**: `pip install mkdocs-material`
+- **mike**: `pip install mike`
 - **actionlint**: `brew install actionlint`
 - **shellcheck**: `brew install shellcheck`
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ actions/
 - Repository-level SemVer tags (for example, `v1`, `v1.2.0`).
 - Consumers must pin actions by tag or commit SHA.
 
+## Documentation
+
+Full documentation is available at
+<https://wphillipmoore.github.io/standard-actions/>.
+
 ## Validation
 
 - Full validation: `scripts/dev/validate_local.sh`

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -1,5 +1,9 @@
 # Environment and Tooling
 
+> **Note**: This document is superseded by the
+> [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/environment-and-tooling/).
+> It is retained for backward compatibility.
+
 ## Table of Contents
 
 - [Purpose](#purpose)

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -1,5 +1,9 @@
 # Development Standards Overview
 
+> **Note**: This document is superseded by the
+> [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/).
+> It is retained for backward compatibility.
+
 ## Table of Contents
 
 - [Purpose](#purpose)

--- a/docs/development/tooling-dependencies.md
+++ b/docs/development/tooling-dependencies.md
@@ -1,5 +1,9 @@
 # Tooling Dependencies
 
+> **Note**: This document is superseded by the
+> [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/environment-and-tooling/).
+> It is retained for backward compatibility.
+
 ## Table of Contents
 
 - [Purpose](#purpose)

--- a/docs/development/validation.md
+++ b/docs/development/validation.md
@@ -1,5 +1,9 @@
 # Validation
 
+> **Note**: This document is superseded by the
+> [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/validation/).
+> It is retained for backward compatibility.
+
 ## Table of Contents
 
 - [Purpose](#purpose)

--- a/docs/site/docs/actions/docs-deploy.md
+++ b/docs/site/docs/actions/docs-deploy.md
@@ -1,0 +1,85 @@
+# docs-deploy
+
+Deploys MkDocs documentation using mike for versioned documentation. Handles
+git configuration, version detection, and mike deploy/set-default.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+  with:
+    version-command: cat VERSION | cut -d. -f1,2
+    mkdocs-config: docs/site/mkdocs.yml
+    mike-command: mike
+    checkout-common: "false"
+    checkout-common-ref: develop
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `version-command` | **Yes** | — | Shell command to extract the version string on main (e.g. `cat VERSION`, `grep -oP ... version.go`). |
+| `mkdocs-config` | No | `docs/site/mkdocs.yml` | Path to mkdocs.yml configuration file. |
+| `mike-command` | No | `mike` | Command to run mike. Set to `uv run mike` for Python repos that manage their own dependencies. When not `mike`, the action skips Python setup and MkDocs installation. |
+| `checkout-common` | No | `false` | Whether to checkout mq-rest-admin-common. |
+| `checkout-common-ref` | No | `develop` | Ref to checkout for mq-rest-admin-common. |
+
+## Permissions
+
+- `contents: write` (required for pushing to the `gh-pages` branch)
+
+## Behavior
+
+1. **Checkout common** (optional) — If `checkout-common` is `true`, checks out
+   the `mq-rest-admin-common` repository for shared documentation fragments.
+2. **Set up Python 3.12** — Only when `mike-command` is `mike` (default).
+3. **Install MkDocs and mike** — `pip install mkdocs-material mike`. Skipped
+   when a custom `mike-command` is provided.
+4. **Configure git identity** — Sets the git user to `github-actions[bot]` for
+   the deploy commit.
+5. **Determine version** — On `main`, runs the `version-command` to extract the
+   version and sets `alias=latest`. On all other branches, sets `version=dev`
+   with no alias.
+6. **Deploy docs** — On `main`, runs `mike deploy --push --update-aliases
+   <version> latest` followed by `mike set-default --push latest`. On other
+   branches, runs `mike deploy --push dev`.
+
+## Examples
+
+### Standard library deployment
+
+```yaml
+name: Documentation
+on:
+  push:
+    branches: [develop, main]
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        with:
+          version-command: cat VERSION | cut -d. -f1,2
+```
+
+### Python repo with uv-managed dependencies
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+  with:
+    version-command: cat VERSION | cut -d. -f1,2
+    mike-command: uv run mike
+```
+
+## GitHub configuration
+
+- **GitHub Pages** — Enable GitHub Pages in repository settings with source set
+  to **Deploy from a branch** and branch set to `gh-pages`.
+- The `gh-pages` branch is created automatically by `mike deploy --push` on
+  first run.

--- a/docs/site/docs/actions/docs-only-detect.md
+++ b/docs/site/docs/actions/docs-only-detect.md
@@ -1,0 +1,80 @@
+# docs-only-detect
+
+Detects whether a pull request contains only documentation changes. For non-PR
+events, always outputs `false`.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+  id: detect
+  with:
+    docs-patterns: "docs/** README.md CHANGELOG.md *.md"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `docs-patterns` | No | `docs/** README.md CHANGELOG.md *.md` | Space-separated glob patterns that identify documentation files. |
+
+## Outputs
+
+| Name | Description |
+| ------ | ------------- |
+| `docs-only` | `true` if all changed files match docs patterns, `false` otherwise. |
+
+## Permissions
+
+- `contents: read` (default for `github.token`)
+
+## Behavior
+
+1. Checks if the triggering event is a `pull_request`. If not, outputs `false`
+   and exits.
+2. Fetches the list of changed files from the GitHub API using pagination.
+3. If no files are found, outputs `false`.
+4. Iterates through each changed file, matching against the configured glob
+   patterns using shell `case` matching.
+5. If any file does not match a docs pattern, outputs `false`. Otherwise
+   outputs `true`.
+
+## Examples
+
+### Gate expensive jobs on docs-only detection
+
+```yaml
+jobs:
+  docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  build:
+    needs: docs-only
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes; skipping build."
+      - if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+      # ... build steps with docs-only guards
+```
+
+### Custom docs patterns
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+  id: detect
+  with:
+    docs-patterns: "docs/** *.md LICENSE .github/ISSUE_TEMPLATE/**"
+```
+
+## GitHub configuration
+
+No special repository configuration is required. The action uses the default
+`github.token` to query the pull request files API.

--- a/docs/site/docs/actions/index.md
+++ b/docs/site/docs/actions/index.md
@@ -1,0 +1,45 @@
+# Action Reference
+
+All actions are composite GitHub Actions located under the `actions/` directory.
+Each action is self-contained with an `action.yml` definition and optional
+supporting scripts.
+
+## Available actions
+
+### CI & Validation
+
+- **[docs-only-detect](docs-only-detect.md)** — Detects whether a pull request
+  contains only documentation changes.
+- **[standards-compliance](standards-compliance.md)** — Validates repository
+  standards: markdown, commit messages, PR linkage, and repository profile.
+
+### Documentation
+
+- **[docs-deploy](docs-deploy.md)** — Deploys MkDocs documentation using mike
+  for versioned documentation.
+
+### Python
+
+- **[python/setup](python-setup.md)** — Sets up Python, installs uv, and
+  configures dependency caching.
+
+### Security
+
+- **[security/codeql](security-codeql.md)** — Runs GitHub CodeQL static
+  analysis for a single language.
+- **[security/semgrep](security-semgrep.md)** — Runs Semgrep SAST scanning with
+  language-specific and cross-cutting security rulesets.
+- **[security/trivy](security-trivy.md)** — Runs Trivy vulnerability scanning,
+  SBOM generation, or container image scanning.
+
+### Publishing
+
+- **[publish/tag-and-release](publish-tag-and-release.md)** — Creates annotated
+  git tags and GitHub Releases.
+- **[publish/version-bump-pr](publish-version-bump-pr.md)** — Automates
+  post-release version bump PRs.
+
+### Release Gates
+
+- **[release-gates/version-divergence](release-gates-version-divergence.md)** —
+  Verifies that the PR branch version differs from the main branch version.

--- a/docs/site/docs/actions/publish-tag-and-release.md
+++ b/docs/site/docs/actions/publish-tag-and-release.md
@@ -1,0 +1,81 @@
+# publish/tag-and-release
+
+Creates an annotated git tag, a develop changelog boundary tag, and a GitHub
+Release. All mutating steps are skipped when the tag already exists, making the
+action safe to re-run.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+  with:
+    version: "1.2.3"
+    release-title: mqrestadmin
+    release-notes: "Release notes markdown here"
+    release-artifacts: ""
+    tag-prefix: v
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `version` | **Yes** | — | Semver version string (e.g. `1.2.3`). |
+| `release-title` | **Yes** | — | Release title prefix (e.g. `mqrestadmin`, `pymqrest`). |
+| `release-notes` | **Yes** | — | Full markdown body for the GitHub Release. |
+| `release-artifacts` | No | `""` | Space-separated glob of files to attach to the GitHub Release. Leave empty for no artifacts. |
+| `tag-prefix` | No | `v` | Prefix prepended to the version to form the git tag. |
+
+## Outputs
+
+| Name | Description |
+| ------ | ------------- |
+| `tag` | The full tag name that was (or would be) created (e.g. `v1.2.3`). |
+| `tag-created` | `true` if a new tag was created, `false` if it already existed. |
+
+## Permissions
+
+- `contents: write` (required for creating tags and releases)
+
+## Behavior
+
+1. **Compute tag name** — Concatenates `tag-prefix` and `version` (e.g.
+   `v` + `1.2.3` = `v1.2.3`).
+2. **Check existing tag** — If the tag already exists, all subsequent steps are
+   skipped (idempotent re-run).
+3. **Configure git identity** — Sets the git user to `github-actions[bot]`.
+4. **Create annotated tag** — Creates and pushes `v<version>` with message
+   `Release <version>`.
+5. **Tag develop for changelog boundaries** — Fetches `develop` and creates a
+   `develop-v<version>` tag pointing at `origin/develop`, then pushes it. This
+   enables changelog generation between releases.
+6. **Create GitHub Release** — Uses `gh release create` with the provided title,
+   notes, and optional artifacts.
+
+## Examples
+
+### Standard library release
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+  with:
+    version: ${{ steps.version.outputs.version }}
+    release-title: mqrestadmin
+    release-notes: ${{ steps.changelog.outputs.notes }}
+```
+
+### Release with build artifacts
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+  with:
+    version: "2.0.0"
+    release-title: myapp
+    release-notes: "## What's New\n\nInitial v2 release."
+    release-artifacts: "dist/*.tar.gz dist/*.whl"
+```
+
+## GitHub configuration
+
+- **Branch protection** — The `GITHUB_TOKEN` must have permission to push tags.
+  If tag protection rules are configured, ensure the workflow token is allowed.

--- a/docs/site/docs/actions/publish-version-bump-pr.md
+++ b/docs/site/docs/actions/publish-version-bump-pr.md
@@ -1,0 +1,108 @@
+# publish/version-bump-pr
+
+Computes the next patch version, creates a branch from develop that merges main,
+updates the version file(s) via regex replacement, and opens an auto-merge PR.
+Skips if develop already has the expected next version.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+  with:
+    current-version: "1.2.3"
+    version-file: VERSION
+    version-regex: "^(\\d+\\.\\d+\\.)\\d+$"
+    version-replacement: "\\g<1>{version}"
+    develop-version-command: "cat"
+    app-token: ${{ steps.app-token.outputs.token }}
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `current-version` | **Yes** | — | The version that was just published (e.g. `1.2.3`). |
+| `version-file` | **Yes** | — | Path to the file containing the version string. |
+| `version-regex` | **Yes** | — | Python regex to match the version line. Use capture groups for parts to preserve. |
+| `version-replacement` | **Yes** | — | Python replacement string. Use `{version}` as a placeholder for the computed next version. |
+| `develop-version-command` | **Yes** | — | Shell command to extract the version from the version file on develop. Receives file content on stdin. |
+| `app-token` | **Yes** | — | GitHub App token for PR creation. Must be passed from the caller because composite actions cannot access secrets directly. |
+| `version-regex-multiline` | No | `false` | Set to `true` to pass `re.MULTILINE` to the regex substitution. |
+| `post-bump-command` | No | `""` | Shell command to run after version file edit and before commit (e.g. `uv lock --upgrade && uv export ...`). |
+| `extra-files` | No | `""` | Space-separated list of additional files to `git add` before committing. |
+| `pr-body-extra` | No | `""` | Additional text appended to the PR body. |
+
+## Outputs
+
+| Name | Description |
+| ------ | ------------- |
+| `next-version` | The computed next patch version. |
+| `pr-url` | URL of the created PR (empty if bump was not needed). |
+| `bump-needed` | `true` if a bump PR was created, `false` if skipped. |
+
+## Permissions
+
+- `contents: write` (required for branch creation and pushing)
+
+!!! note "App token required"
+    The `app-token` input must be a GitHub App installation token (not the
+    default `GITHUB_TOKEN`). This is necessary because PRs created by
+    `GITHUB_TOKEN` do not trigger CI workflows.
+
+## Behavior
+
+1. **Compute next version** — Increments the patch component of
+   `current-version` (e.g. `1.2.3` becomes `1.2.4`).
+2. **Check develop** — Fetches `origin/develop` and extracts the current version
+   using `develop-version-command`. If it already matches the next version,
+   skips all remaining steps.
+3. **Create bump branch** — Creates `chore/bump-version-<next>` from
+   `origin/develop` and merges `origin/main` to pick up release artifacts.
+4. **Update version file** — Uses Python regex substitution to replace the
+   version string in the specified file.
+5. **Post-bump command** — Optionally runs a command (e.g. lock file refresh).
+6. **Commit and push** — Commits the version file (and any extra files) with
+   message `chore: bump version to <next>`.
+7. **Create PR** — Opens a PR targeting `develop`, edits the body with context,
+   then closes/reopens to trigger CI. Enables auto-merge with merge commit
+   strategy.
+
+## Examples
+
+### Simple VERSION file bump
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+  with:
+    current-version: ${{ steps.release.outputs.version }}
+    version-file: VERSION
+    version-regex: "^(\\d+\\.\\d+\\.)\\d+$"
+    version-replacement: "\\g<1>{version}"
+    develop-version-command: "cat"
+    app-token: ${{ steps.app-token.outputs.token }}
+```
+
+### Python project with lock file refresh
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+  with:
+    current-version: "1.0.0"
+    version-file: pyproject.toml
+    version-regex: '(version\s*=\s*")[\d.]+(")'
+    version-replacement: '\g<1>{version}\2'
+    develop-version-command: "grep -oP 'version\\s*=\\s*\"\\K[^\"]+'"
+    post-bump-command: "uv lock --upgrade && uv export --no-hashes -o requirements.txt"
+    extra-files: "uv.lock requirements.txt"
+    app-token: ${{ steps.app-token.outputs.token }}
+```
+
+## GitHub configuration
+
+- **GitHub App** — A GitHub App installation token is required for the
+  `app-token` input. The app must have permissions to create branches, push
+  commits, and create/merge pull requests.
+- **Auto-merge** — Must be enabled in repository settings for the `--auto`
+  flag to work.
+- **Branch protection** — The `develop` branch must allow PR merges from the
+  GitHub App.

--- a/docs/site/docs/actions/python-setup.md
+++ b/docs/site/docs/actions/python-setup.md
@@ -1,0 +1,61 @@
+# python/setup
+
+Sets up Python, installs uv, and configures dependency caching.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/python/setup@develop
+  with:
+    python-version: "3.14"
+    uv-version: "0.9.26"
+    cache-prefix: "uv"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `python-version` | **Yes** | — | Python version to install (e.g. `3.14`). |
+| `uv-version` | No | `0.9.26` | uv version to install. |
+| `cache-prefix` | No | `uv` | Cache key prefix for uv dependency cache. |
+
+## Permissions
+
+- `contents: read` (default)
+
+## Behavior
+
+1. **Set up Python** — Uses `actions/setup-python@v5` to install the specified
+   Python version.
+2. **Install uv** — Runs `pip install uv==<version>` to install the pinned
+   version of uv.
+3. **Cache dependencies** — Uses `actions/cache@v4` to cache `~/.cache/uv`.
+   The cache key includes the OS, Python version, and a hash of `uv.lock` for
+   precise invalidation.
+
+## Examples
+
+### Basic Python setup
+
+```yaml
+- uses: actions/checkout@v6
+- uses: wphillipmoore/standard-actions/actions/python/setup@develop
+  with:
+    python-version: "3.14"
+- run: uv sync
+- run: uv run pytest
+```
+
+### Custom cache prefix for multiple Python versions
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/python/setup@develop
+  with:
+    python-version: "3.13"
+    cache-prefix: "uv-py313"
+```
+
+## GitHub configuration
+
+No special repository configuration is required.

--- a/docs/site/docs/actions/release-gates-version-divergence.md
+++ b/docs/site/docs/actions/release-gates-version-divergence.md
@@ -1,0 +1,72 @@
+# release-gates/version-divergence
+
+Verifies that the PR branch version differs from the main branch version. Fails
+the step if the two versions are identical.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+  with:
+    head-version-command: cat VERSION
+    main-version-command: git show origin/main:VERSION
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `head-version-command` | **Yes** | — | Shell command that prints the HEAD (PR branch) version to stdout. |
+| `main-version-command` | **Yes** | — | Shell command that prints the main branch version to stdout. |
+
+## Outputs
+
+| Name | Description |
+| ------ | ------------- |
+| `head-version` | The version extracted from the PR branch. |
+| `main-version` | The version extracted from the main branch. |
+| `diverged` | `true` if versions differ, `false` otherwise. |
+
+## Permissions
+
+- `contents: read` (default)
+
+## Behavior
+
+1. **Fetch main branch** — Runs `git fetch origin main --depth=1`.
+2. **Compare versions** — Executes both version commands and compares the
+   results. If the versions are identical, the step fails with exit code 1 and
+   a diagnostic message. If they differ, the step succeeds.
+
+## Examples
+
+### Simple VERSION file check
+
+```yaml
+jobs:
+  version-gate:
+    name: "release: version-divergence"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        with:
+          head-version-command: cat VERSION
+          main-version-command: git show origin/main:VERSION
+```
+
+### Python project version check
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+  with:
+    head-version-command: >-
+      grep -oP 'version\s*=\s*"\K[^"]+' pyproject.toml
+    main-version-command: >-
+      git show origin/main:pyproject.toml | grep -oP 'version\s*=\s*"\K[^"]+'
+```
+
+## GitHub configuration
+
+- **Required status check** — Add this as a required status check on the
+  `develop` branch to prevent PRs from merging without a version bump.

--- a/docs/site/docs/actions/security-codeql.md
+++ b/docs/site/docs/actions/security-codeql.md
@@ -1,0 +1,70 @@
+# security/codeql
+
+Runs GitHub CodeQL static analysis (init + autobuild + analyze) for a single
+language.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/codeql@develop
+  with:
+    language: python
+    queries: "+security-extended"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `language` | **Yes** | — | CodeQL language to analyze (e.g. `python`, `javascript`, `go`, `java`). |
+| `queries` | No | `+security-extended` | Query suite to run. |
+
+## Permissions
+
+- `security-events: write` (required for uploading SARIF results)
+- `contents: read`
+
+## Behavior
+
+1. **Initialize CodeQL** — Uses `github/codeql-action/init@v3` to set up the
+   CodeQL database for the specified language and query suite.
+2. **Autobuild** — Uses `github/codeql-action/autobuild@v3` to automatically
+   detect and build the project.
+3. **Run analysis** — Uses `github/codeql-action/analyze@v3` to perform the
+   analysis and upload results. Results are categorized by
+   `/language:<language>`.
+
+## Examples
+
+### Python CodeQL analysis
+
+```yaml
+jobs:
+  codeql:
+    name: "security: codeql"
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: wphillipmoore/standard-actions/actions/security/codeql@develop
+        with:
+          language: python
+```
+
+### Go CodeQL analysis
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/codeql@develop
+  with:
+    language: go
+```
+
+## GitHub configuration
+
+- **GitHub Advanced Security (GHAS)** — Must be enabled on the repository for
+  SARIF upload to work. For public repositories, GHAS is available by default.
+  For private repositories, a GHAS license is required.
+- **Code scanning alerts** — Results appear in the repository's **Security >
+  Code scanning alerts** tab.

--- a/docs/site/docs/actions/security-semgrep.md
+++ b/docs/site/docs/actions/security-semgrep.md
@@ -1,0 +1,71 @@
+# security/semgrep
+
+Runs Semgrep static analysis with language-specific and cross-cutting security
+rulesets.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
+  with:
+    language: python
+    extra-config: "p/owasp-top-ten"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `language` | **Yes** | — | Language ruleset to enable (maps to `p/<language>`, e.g. `python`, `java`, `golang`). |
+| `extra-config` | No | `""` | Additional Semgrep config strings, space-separated (e.g. `p/owasp-top-ten`). |
+
+## Permissions
+
+- `security-events: write` (required for uploading SARIF results)
+- `contents: read`
+
+## Behavior
+
+1. **Install Semgrep** — Runs `pip install semgrep`.
+2. **Run scan** — Executes `semgrep scan` with the following config rulesets:
+    - `p/<language>` — Language-specific rules
+    - `p/security-audit` — Cross-cutting security audit rules
+    - `p/secrets` — Secret detection rules
+    - Any additional rulesets from `extra-config`
+3. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
+   using `github/codeql-action/upload-sarif@v3`, categorized as `semgrep`.
+   This step runs even if the scan finds issues (`if: always()`).
+
+## Examples
+
+### Python Semgrep scan
+
+```yaml
+jobs:
+  semgrep:
+    name: "security: semgrep"
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
+        with:
+          language: python
+```
+
+### Go with additional OWASP rules
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
+  with:
+    language: golang
+    extra-config: "p/owasp-top-ten"
+```
+
+## GitHub configuration
+
+- **GitHub Advanced Security (GHAS)** — Must be enabled for SARIF upload.
+- **Code scanning alerts** — Results appear in the repository's **Security >
+  Code scanning alerts** tab alongside CodeQL results.

--- a/docs/site/docs/actions/security-trivy.md
+++ b/docs/site/docs/actions/security-trivy.md
@@ -1,0 +1,101 @@
+# security/trivy
+
+Runs Trivy vulnerability scanning, SBOM generation, or container image scanning.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+  with:
+    scan-type: fs
+    scan-ref: "."
+    severity: "CRITICAL,HIGH"
+    exit-code: "1"
+    scanners: "vuln"
+    output-file: "trivy-results.sarif"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `scan-type` | **Yes** | — | Scan mode: `fs` (filesystem vuln scan to SARIF), `sbom` (CycloneDX SBOM generation), or `image` (container image scan to SARIF). |
+| `scan-ref` | No | `.` | Filesystem path or container image reference to scan. |
+| `severity` | No | `CRITICAL,HIGH` | Comma-separated severity levels to report. |
+| `exit-code` | No | `1` | Exit code when vulnerabilities are found (`0` = advisory only). |
+| `scanners` | No | `vuln` | Comma-separated Trivy scanners to enable. |
+| `output-file` | No | `trivy-results.sarif` | Output file path for SARIF or SBOM results. |
+
+## Permissions
+
+- `security-events: write` (required for SARIF upload when `scan-type` is `fs`
+  or `image`)
+- `contents: read`
+
+## Behavior
+
+The action branches based on `scan-type`:
+
+### Filesystem scan (`fs`)
+
+1. Runs `aquasecurity/trivy-action@0.34.0` with `scan-type: fs` against the
+   specified `scan-ref`.
+2. Outputs results in SARIF format.
+3. Uploads the SARIF file to GitHub code scanning (category: `trivy-fs`).
+
+### Image scan (`image`)
+
+1. Runs `aquasecurity/trivy-action@0.34.0` with `scan-type: image` against the
+   specified image reference.
+2. Outputs results in SARIF format.
+3. Uploads the SARIF file to GitHub code scanning (category: `trivy-image`).
+
+### SBOM generation (`sbom`)
+
+1. Runs `aquasecurity/trivy-action@0.34.0` with `scan-type: fs` and
+   `format: cyclonedx`.
+2. Outputs the SBOM to the specified output file. No SARIF upload.
+
+## Examples
+
+### Filesystem vulnerability scan
+
+```yaml
+jobs:
+  trivy:
+    name: "security: trivy"
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+        with:
+          scan-type: fs
+```
+
+### Container image scan
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+  with:
+    scan-type: image
+    scan-ref: "myapp:latest"
+```
+
+### SBOM generation (advisory only)
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+  with:
+    scan-type: sbom
+    output-file: sbom.cdx.json
+```
+
+## GitHub configuration
+
+- **GitHub Advanced Security (GHAS)** — Must be enabled for SARIF upload
+  (`fs` and `image` scan types).
+- **Code scanning alerts** — Results appear in **Security > Code scanning
+  alerts** with categories `trivy-fs` or `trivy-image`.

--- a/docs/site/docs/actions/standards-compliance.md
+++ b/docs/site/docs/actions/standards-compliance.md
@@ -1,0 +1,77 @@
+# standards-compliance
+
+Validates repository standards: markdown formatting, commit messages, PR issue
+linkage, and repository profile.
+
+## Usage
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+  with:
+    commit-cutoff-sha: ""
+    skip-sync-check: "false"
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| ------ | ---------- | --------- | ------------- |
+| `commit-cutoff-sha` | No | `""` | Skip commits at or before this SHA. Repos that adopted conventional commits after their initial history pass their cutoff here. |
+| `skip-sync-check` | No | `false` | Skip the shared tooling staleness check. Set to `true` for repositories that ARE the canonical source for synced scripts (e.g. standard-tooling). |
+
+## Permissions
+
+- `contents: read` (default for `github.token`)
+
+## Behavior
+
+1. **Set up Node.js** — Installs Node.js 20 for markdownlint.
+2. **Install markdownlint-cli** — Global npm install.
+3. **Fetch base branch** — On pull requests, fetches the base branch for commit
+   range linting.
+4. **Validate repository profile** — Runs `repo-profile.sh` to check required
+   repository metadata files.
+5. **Validate markdown standards** — Runs `markdown-standards.sh` with
+   markdownlint against the repository.
+6. **Validate commit messages** — On pull requests, runs `commit-messages.sh` to
+   verify conventional commit format for all commits in the PR range.
+7. **Validate PR issue linkage** — On pull requests, runs `pr-issue-linkage.sh`
+   to verify the PR body references a GitHub issue.
+8. **Validate shared tooling** — On PRs targeting `develop`, checks whether
+   synced scripts are up to date by running `scripts/dev/sync-tooling.sh --check`
+   (if present).
+
+## Examples
+
+### Basic usage
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    fetch-depth: 0
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+```
+
+### With commit cutoff for legacy repos
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+  with:
+    commit-cutoff-sha: "abc123def456"
+```
+
+### Skip sync check for canonical tooling repo
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+  with:
+    skip-sync-check: "true"
+```
+
+## GitHub configuration
+
+- **Repository profile** — The repo must contain the files checked by
+  `repo-profile.sh` (typically `README.md`, `LICENSE`, `VERSION`, and standard
+  documentation files).
+- **Branch protection** — Recommended: require this check to pass on `develop`
+  and `main` branches.

--- a/docs/site/docs/ci-gates/docs-only-optimization.md
+++ b/docs/site/docs/ci-gates/docs-only-optimization.md
@@ -1,0 +1,74 @@
+# Docs-Only Optimization
+
+## How it works
+
+The [docs-only-detect](../actions/docs-only-detect.md) action examines the list
+of files changed in a pull request and determines whether all changes are
+documentation-only. When a PR is docs-only, expensive CI jobs (builds, tests,
+security scans) are skipped to reduce feedback time and CI cost.
+
+## Default docs patterns
+
+The default patterns match these files:
+
+```text
+docs/**
+README.md
+CHANGELOG.md
+*.md
+```
+
+These patterns can be customized per-repository using the `docs-patterns` input.
+
+## Which jobs are gated vs. always-run
+
+| Job | Docs-only behavior |
+| ----- | ------------------- |
+| `ci: docs-only` | Always runs (this is the detection job itself) |
+| `ci: standards-compliance` | **Always runs** — markdown linting and repo profile checks apply to docs changes |
+| `ci: actionlint` | Skipped on docs-only PRs |
+| `ci: shellcheck` | Skipped on docs-only PRs |
+| `test: unit` | Skipped on docs-only PRs |
+| `test: integration` | Skipped on docs-only PRs |
+| `security: codeql` | Skipped on docs-only PRs |
+| `security: semgrep` | Skipped on docs-only PRs |
+| `security: trivy` | Skipped on docs-only PRs |
+| `release: version-divergence` | Skipped on docs-only PRs |
+
+## Implementation pattern
+
+The docs-only detection runs as the first job and exports its result as a job
+output. Downstream jobs depend on this output:
+
+```yaml
+jobs:
+  docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  build:
+    needs: docs-only
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.docs-only.outputs.docs-only == 'true'
+        run: echo "Docs-only changes; skipping."
+      - if: needs.docs-only.outputs.docs-only != 'true'
+        uses: actions/checkout@v6
+      # ... remaining steps guarded by the same condition
+```
+
+!!! note "Required checks and docs-only"
+    Jobs that are required status checks must still **run** on docs-only PRs
+    (they cannot be skipped entirely with an `if` on the job). Instead, each
+    step within the job is guarded by the docs-only condition. This ensures
+    GitHub sees the check as passing.
+
+## Non-PR events
+
+For push events (e.g., pushes to `develop`), docs-only detection always returns
+`false`. All checks run on non-PR events regardless of the files changed.

--- a/docs/site/docs/ci-gates/index.md
+++ b/docs/site/docs/ci-gates/index.md
@@ -1,0 +1,36 @@
+# CI Gate Requirements
+
+This section defines the target-state CI gate specification for repositories
+consuming standard-actions. It documents which checks are required, how they
+interact with docs-only optimization, and the security scanning requirements.
+
+## Overview
+
+Every managed repository runs a common set of CI checks on pull requests and
+pushes to protected branches. These checks are organized by category using job
+name prefixes:
+
+| Prefix | Purpose | Example jobs |
+| -------- | --------- | ------------- |
+| `ci:` | Code quality and standards validation | `ci: standards-compliance`, `ci: actionlint` |
+| `security:` | SAST and vulnerability scanning | `security: codeql`, `security: semgrep` |
+| `test:` | Unit and integration tests | `test: unit`, `test: integration` |
+| `release:` | Release gate validations | `release: version-divergence` |
+
+## Key concepts
+
+- **Required status checks** — Configured in GitHub branch protection rules.
+  PRs cannot merge until all required checks pass.
+- **Docs-only optimization** — Documentation-only PRs skip expensive checks
+  (builds, tests, security scans) while still running standards compliance.
+- **Self-referencing CI** — The standard-actions repository tests its own
+  actions using local paths (`./actions/...`).
+
+## Pages in this section
+
+- [Required Checks](required-checks.md) — Matrix of checks by repository
+  category
+- [Docs-Only Optimization](docs-only-optimization.md) — How docs-only detection
+  works and which jobs are gated
+- [Security Scanning](security-scanning.md) — CodeQL, Semgrep, and Trivy
+  configuration details

--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -1,0 +1,68 @@
+# Required Checks
+
+## Check matrix
+
+The following table shows which CI checks apply to each repository category.
+Checks marked **Required** must be configured as required status checks in
+GitHub branch protection rules.
+
+| Check | Go Library | Python Library | Infrastructure | Documentation |
+| ------- | ----------- | --------------- | ---------------- | --------------- |
+| `ci: docs-only` | Required | Required | Required | Required |
+| `ci: standards-compliance` | Required | Required | Required | Required |
+| `ci: actionlint` | — | — | Required | — |
+| `ci: shellcheck` | — | — | Required | — |
+| `test: unit` | Required | Required | — | — |
+| `test: integration` | Required | Required | — | — |
+| `security: codeql` | Required | Required | — | — |
+| `security: semgrep` | Required | Required | — | — |
+| `security: trivy` | Required | Required | — | — |
+| `release: version-divergence` | Required | Required | — | — |
+
+## Job name prefix convention
+
+All CI job names use a category prefix followed by a colon and the job name.
+This convention enables clear identification in the GitHub checks UI and
+supports pattern-based branch protection rules.
+
+```yaml
+jobs:
+  docs-only:
+    name: "ci: docs-only"
+  standards:
+    name: "ci: standards-compliance"
+  unit-tests:
+    name: "test: unit"
+  codeql:
+    name: "security: codeql"
+  version-gate:
+    name: "release: version-divergence"
+```
+
+## Branch protection configuration
+
+### develop branch
+
+All checks from the matrix should be configured as required status checks.
+Enable:
+
+- **Require status checks to pass before merging**
+- **Require branches to be up to date before merging**
+- **Require pull request reviews before merging** (at least 1 approval)
+
+### main branch
+
+The `main` branch uses the same required checks as `develop`. Additionally:
+
+- **Require linear history** should be disabled (merge commits from release PRs
+  are expected)
+- **Allow merge commits** must be enabled for release PRs
+
+## Adding new required checks
+
+When adding a new check to a repository:
+
+1. Add the job to the CI workflow with the appropriate name prefix.
+2. Verify the check passes on a test PR.
+3. Add the check name to the branch protection required status checks list in
+   repository settings.

--- a/docs/site/docs/ci-gates/security-scanning.md
+++ b/docs/site/docs/ci-gates/security-scanning.md
@@ -1,0 +1,114 @@
+# Security Scanning
+
+## Overview
+
+Three security scanning tools provide layered coverage:
+
+| Tool | Purpose | Output |
+| ------ | --------- | -------- |
+| [CodeQL](../actions/security-codeql.md) | GitHub-native SAST with deep semantic analysis | SARIF uploaded to code scanning |
+| [Semgrep](../actions/security-semgrep.md) | Fast pattern-based SAST with community rulesets | SARIF uploaded to code scanning |
+| [Trivy](../actions/security-trivy.md) | Dependency vulnerability scanning and SBOM generation | SARIF uploaded to code scanning |
+
+## GHAS requirements
+
+All three tools upload results in SARIF format to GitHub Code Scanning, which
+requires **GitHub Advanced Security (GHAS)**:
+
+- **Public repositories** — GHAS is available by default at no cost.
+- **Private repositories** — A GHAS license is required. Contact your GitHub
+  administrator.
+
+## Viewing results
+
+Security scan results appear in the repository's **Security** tab:
+
+1. Navigate to **Security > Code scanning alerts**.
+2. Filter by tool: `CodeQL`, `semgrep`, or `trivy-fs` / `trivy-image`.
+3. Each alert shows the affected file, line number, severity, and a description
+   of the finding.
+
+## CodeQL
+
+CodeQL performs deep semantic analysis of source code. It understands data flow,
+control flow, and language-specific patterns.
+
+- **Languages supported**: Python, Go, Java, JavaScript/TypeScript, and more.
+- **Query suite**: `+security-extended` (default) includes the standard security
+  queries plus extended checks.
+- **Autobuild**: CodeQL automatically detects the build system and compiles the
+  project.
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/codeql@develop
+  with:
+    language: python
+```
+
+## Semgrep
+
+Semgrep provides fast, pattern-based static analysis with a large library of
+community-maintained rules.
+
+Default rulesets enabled for every scan:
+
+- `p/<language>` — Language-specific security rules
+- `p/security-audit` — Cross-cutting security audit rules
+- `p/secrets` — Secret detection (API keys, tokens, passwords)
+
+Additional rulesets can be added via `extra-config`:
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
+  with:
+    language: golang
+    extra-config: "p/owasp-top-ten"
+```
+
+## Trivy
+
+Trivy scans for known vulnerabilities in dependencies and container images.
+
+### Scan modes
+
+| Mode | Use case | SARIF category |
+| ------ | ---------- | --------------- |
+| `fs` | Scan project dependencies for known CVEs | `trivy-fs` |
+| `image` | Scan container images for OS and library CVEs | `trivy-image` |
+| `sbom` | Generate CycloneDX SBOM (no SARIF upload) | — |
+
+### Severity filtering
+
+By default, only `CRITICAL` and `HIGH` severity vulnerabilities are reported.
+This can be adjusted:
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+  with:
+    scan-type: fs
+    severity: "CRITICAL,HIGH,MEDIUM"
+```
+
+### Exit code behavior
+
+By default, Trivy exits with code `1` when vulnerabilities are found, failing
+the CI check. Set `exit-code: "0"` for advisory-only mode:
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+  with:
+    scan-type: fs
+    exit-code: "0"
+```
+
+## Workflow permissions
+
+All security scanning jobs require the `security-events: write` permission:
+
+```yaml
+jobs:
+  codeql:
+    permissions:
+      security-events: write
+      contents: read
+```

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -1,0 +1,89 @@
+# Contributing
+
+## Adding a new action
+
+1. Create a directory under `actions/` following the existing naming pattern:
+   `actions/<category>/<action-name>/action.yml`.
+2. Define the action as a **composite action** — no custom JavaScript or Docker
+   actions.
+3. Include clear `name`, `description`, `inputs`, and `outputs` in `action.yml`.
+4. Add supporting scripts under `actions/<action-name>/scripts/` if needed.
+5. Add the action to the CI workflow (`.github/workflows/ci.yml`) using a local
+   path reference (`./actions/<path>`).
+6. Add a documentation page under `docs/site/docs/actions/` and update the nav
+   in `docs/site/mkdocs.yml`.
+
+## Composite action design rules
+
+- **Shell steps only** — Use `shell: bash` for all `run` steps.
+- **No secrets access** — Composite actions cannot access secrets directly.
+  Callers must pass secrets as inputs.
+- **Idempotent when possible** — Actions should be safe to re-run (e.g.,
+  `publish/tag-and-release` skips if the tag exists).
+- **Environment variables for sensitive data** — Use `env` blocks rather than
+  inline interpolation for values that might contain special characters.
+
+## Testing via self-referencing CI
+
+This repository tests its own actions by using local path references in the CI
+workflow:
+
+```yaml
+- uses: ./actions/docs-only-detect   # Not the remote reference
+```
+
+When you modify an action, the PR's CI run uses your modified version. This
+provides integration testing without a separate test repository.
+
+## Branching workflow
+
+- **Protected branches**: `main` and `develop` — no direct commits.
+- **Branch naming**: `feature/*`, `bugfix/*`, or `hotfix/*` only.
+- Feature and bugfix PRs target `develop` with squash merge.
+- Release PRs target `main` with regular merge.
+
+## Committing
+
+Always use the commit script:
+
+```bash
+scripts/dev/commit.sh \
+  --type feat \
+  --scope ci \
+  --message "add new validation check" \
+  --agent claude
+```
+
+Required flags:
+
+- `--type`: `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--message`: Commit description
+- `--agent`: `claude` or `codex`
+
+Optional flags:
+
+- `--scope`: Conventional commit scope
+- `--body`: Detailed commit body
+
+## Submitting PRs
+
+Always use the PR script:
+
+```bash
+scripts/dev/submit-pr.sh \
+  --issue 42 \
+  --summary "Add new validation check"
+```
+
+Required flags:
+
+- `--issue`: GitHub issue number
+- `--summary`: One-line PR summary
+
+Optional flags:
+
+- `--linkage`: `Fixes|Closes|Resolves|Ref` (default: `Fixes`)
+- `--title`: PR title (default: most recent commit subject)
+- `--notes`: Additional notes
+- `--docs-only`: Apply docs-only testing exception
+- `--dry-run`: Print without executing

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -1,0 +1,45 @@
+# Environment and Tooling
+
+## Git hooks
+
+Configure the repository to use the shared git hooks:
+
+```bash
+git config core.hooksPath scripts/git-hooks
+```
+
+This enables the pre-commit hook that prevents direct commits to protected
+branches (`main`, `develop`).
+
+## External tooling
+
+The following tools are required for local development and validation:
+
+### Validation tools
+
+| Tool | Install command | Purpose |
+| ------ | ---------------- | --------- |
+| `actionlint` | `brew install actionlint` | GitHub Actions workflow linter |
+| `shellcheck` | `brew install shellcheck` | Shell script static analysis |
+| `markdownlint` | `npm install --global markdownlint-cli` | Markdown formatting linter |
+
+### Documentation tools
+
+| Tool | Install command | Purpose |
+| ------ | ---------------- | --------- |
+| `mkdocs-material` | `pip install mkdocs-material` | MkDocs with Material theme |
+| `mike` | `pip install mike` | Versioned documentation deployment |
+
+### Local documentation preview
+
+To preview the documentation site locally:
+
+```bash
+mkdocs serve -f docs/site/mkdocs.yml
+```
+
+To verify the build with strict mode (catches broken links and warnings):
+
+```bash
+mkdocs build -f docs/site/mkdocs.yml --strict
+```

--- a/docs/site/docs/development/index.md
+++ b/docs/site/docs/development/index.md
@@ -1,0 +1,13 @@
+# Development
+
+This section covers development workflow, environment setup, validation, and
+contribution guidelines for the standard-actions repository.
+
+## Pages in this section
+
+- [Environment and Tooling](environment-and-tooling.md) — External tool
+  dependencies and git hooks setup
+- [Validation](validation.md) — Local validation commands and the dispatch
+  architecture
+- [Contributing](contributing.md) — How to add or modify actions, testing via
+  self-referencing CI, and the commit/PR workflow

--- a/docs/site/docs/development/validation.md
+++ b/docs/site/docs/development/validation.md
@@ -1,0 +1,46 @@
+# Validation
+
+## Canonical command
+
+```bash
+scripts/dev/validate_local.sh
+```
+
+This is the single entry point for all local validation. Run it before
+committing to catch issues early.
+
+## Dispatch architecture
+
+`validate_local.sh` uses a dispatch architecture that separates common
+validation (shared across repositories) from repository-specific checks:
+
+1. **Common checks** — Sourced from `standard-tooling` via the sync mechanism.
+   These include markdownlint, shellcheck, and other universal validations.
+2. **Custom checks** — Repository-specific validations defined locally, such as
+   actionlint for this repository's workflow files.
+
+The sync mechanism (`scripts/dev/sync-tooling.sh`) keeps the common validation
+scripts in sync with the canonical versions in `standard-tooling`. The
+`standards-compliance` action validates this staleness in CI.
+
+## Docs-only validation
+
+For changes that only affect documentation:
+
+```bash
+scripts/dev/validate_docs.sh
+```
+
+This runs a subset of checks relevant to documentation changes (primarily
+markdownlint).
+
+## Tooling dependencies
+
+Validation requires the following tools to be installed:
+
+- `actionlint` — GitHub Actions workflow linting
+- `shellcheck` — Shell script static analysis
+- `markdownlint` — Markdown formatting
+
+See [Environment and Tooling](environment-and-tooling.md) for installation
+instructions.

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -1,0 +1,67 @@
+# Getting Started
+
+## Consuming actions
+
+Reference actions from this repository using the full path with a branch or tag
+pin:
+
+```yaml
+uses: wphillipmoore/standard-actions/actions/<action-path>@develop
+```
+
+!!! note "Branch pinning"
+    During the pre-release period (0.x), all consumers pin to `@develop`.
+    Versioned tag-based pinning will be available once publishing automation is
+    complete.
+
+## Minimal workflow example
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+jobs:
+  docs-only:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.detect.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: detect
+        uses: wphillipmoore/standard-actions/actions/docs-only-detect@develop
+
+  standards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+```
+
+## Permissions
+
+Each action documents its required workflow permissions. Common patterns:
+
+| Permission | Actions that require it |
+| ------------ | ---------------------- |
+| `contents: read` | docs-only-detect, standards-compliance |
+| `contents: write` | docs-deploy, publish/tag-and-release, publish/version-bump-pr |
+| `security-events: write` | security/codeql, security/semgrep, security/trivy |
+
+## Self-referencing CI
+
+This repository uses **local paths** (`./actions/...`) rather than remote
+references in its own CI workflow. This means changes to an action are validated
+by the same PR that modifies them — no separate integration testing step is
+needed.
+
+Consuming repositories use the full remote reference
+(`wphillipmoore/standard-actions/actions/...@develop`).

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,0 +1,36 @@
+# Standard Actions
+
+Shared GitHub Actions library providing reusable composite actions for CI/CD
+across all managed repositories.
+
+## Status
+
+**Pre-release (0.x)** — Actions are consumed by pinning to the `develop` branch.
+Versioned tag-based publishing is planned for a future release.
+
+## Action categories
+
+| Category | Actions | Purpose |
+| ---------- | --------- | --------- |
+| CI & Validation | [docs-only-detect](actions/docs-only-detect.md), [standards-compliance](actions/standards-compliance.md) | PR validation and docs-only short-circuiting |
+| Documentation | [docs-deploy](actions/docs-deploy.md) | MkDocs Material + mike versioned deployment |
+| Python | [python/setup](actions/python-setup.md) | Python environment with uv and caching |
+| Security | [security/codeql](actions/security-codeql.md), [security/semgrep](actions/security-semgrep.md), [security/trivy](actions/security-trivy.md) | SAST and vulnerability scanning |
+| Publishing | [publish/tag-and-release](actions/publish-tag-and-release.md), [publish/version-bump-pr](actions/publish-version-bump-pr.md) | Release tagging and post-release version bumps |
+| Release Gates | [release-gates/version-divergence](actions/release-gates-version-divergence.md) | Pre-merge version validation |
+
+## Design principles
+
+- **Composite actions only** — No custom JavaScript or Docker actions. Every
+  action is a composite `action.yml` with shell steps.
+- **Self-referencing CI** — This repository's own CI uses `./actions/...` local
+  paths, so changes to an action are tested by the same PR that modifies them.
+- **Centralized standards** — Workflow patterns and validation rules are defined
+  once here and consumed by all repositories.
+
+## Canonical standards
+
+This repository follows the
+[Standards and Conventions](https://github.com/wphillipmoore/standards-and-conventions)
+repository for commit messages, branching, versioning, and code management
+practices.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,0 +1,85 @@
+site_name: Standard Actions
+site_url: https://wphillipmoore.github.io/standard-actions/
+site_description: Shared GitHub Actions library for reusable CI and automation
+repo_url: https://github.com/wphillipmoore/standard-actions
+repo_name: standard-actions
+edit_uri: ""
+
+strict: true
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+extra:
+  version:
+    provider: mike
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - def_list
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Action Reference:
+      - Overview: actions/index.md
+      - CI & Validation:
+          - docs-only-detect: actions/docs-only-detect.md
+          - standards-compliance: actions/standards-compliance.md
+      - Documentation:
+          - docs-deploy: actions/docs-deploy.md
+      - Python:
+          - python/setup: actions/python-setup.md
+      - Security:
+          - security/codeql: actions/security-codeql.md
+          - security/semgrep: actions/security-semgrep.md
+          - security/trivy: actions/security-trivy.md
+      - Publishing:
+          - publish/tag-and-release: actions/publish-tag-and-release.md
+          - publish/version-bump-pr: actions/publish-version-bump-pr.md
+      - Release Gates:
+          - release-gates/version-divergence: actions/release-gates-version-divergence.md
+  - CI Gate Requirements:
+      - Overview: ci-gates/index.md
+      - Required Checks: ci-gates/required-checks.md
+      - Docs-Only Optimization: ci-gates/docs-only-optimization.md
+      - Security Scanning: ci-gates/security-scanning.md
+  - Development:
+      - Overview: development/index.md
+      - Environment and Tooling: development/environment-and-tooling.md
+      - Validation: development/validation.md
+      - Contributing: development/contributing.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add MkDocs documentation site with action reference and CI gate specifications

## Issue Linkage

- Fixes #17

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Deploys to dev version only until issue #18 adds versioned publishing. Manual step needed: enable GitHub Pages (gh-pages branch) in repo settings.
