### PR TITLE
fix(docs-deploy): set dev as default version when no default exists

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -78,4 +78,9 @@ runs:
           ${{ inputs.mike-command }} set-default -F ${{ inputs.mkdocs-config }} --push latest
         else
           ${{ inputs.mike-command }} deploy -F ${{ inputs.mkdocs-config }} --push ${{ steps.version.outputs.version }}
+          # Set dev as default if no default exists yet (pre-release repos)
+          CURRENT_DEFAULT=$(${{ inputs.mike-command }} list -F ${{ inputs.mkdocs-config }} 2>/dev/null | grep '\[default\]' || true)
+          if [ -z "$CURRENT_DEFAULT" ]; then
+            ${{ inputs.mike-command }} set-default -F ${{ inputs.mkdocs-config }} --push dev
+          fi
         fi


### PR DESCRIPTION
# Pull Request

## Summary

- Fix root URL 404 by setting dev as default mike version for pre-release repos

## Issue Linkage

- Ref #17

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -
