### PR TITLE
fix(version-bump-pr): remove redundant close/reopen cycle

### DIFF
--- a/actions/publish/version-bump-pr/action.yml
+++ b/actions/publish/version-bump-pr/action.yml
@@ -174,9 +174,6 @@ runs:
         EOF
         )"
 
-        gh pr close "$pr_number"
-        gh pr reopen "$pr_number"
-
         gh pr merge \
           --auto --merge --delete-branch \
           "${{ steps.next.outputs.branch }}"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove redundant close/reopen cycle from version-bump-pr action

## Issue Linkage

- Fixes #65

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -
