### PR TITLE
fix(release-gates): handle missing version on main in version-divergence check

### DIFF
--- a/actions/release-gates/version-divergence/action.yml
+++ b/actions/release-gates/version-divergence/action.yml
@@ -36,7 +36,14 @@ runs:
       shell: bash
       run: |
         head_version=$(${{ inputs.head-version-command }})
-        main_version=$(${{ inputs.main-version-command }})
+
+        if ! main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || [ -z "$main_version" ]; then
+          echo "head-version=$head_version" >> "$GITHUB_OUTPUT"
+          echo "main-version=" >> "$GITHUB_OUTPUT"
+          echo "diverged=true" >> "$GITHUB_OUTPUT"
+          echo "OK: no version found on main (no prior release). Skipping divergence check."
+          exit 0
+        fi
 
         echo "head-version=$head_version" >> "$GITHUB_OUTPUT"
         echo "main-version=$main_version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Pull Request

## Summary

- Handle missing version on main gracefully in version-divergence gate, fixing false failures for repos with no prior release

## Issue Linkage

- Fixes #86

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -