### PR TITLE
docs(ci-gates): document version matrix for unit and integration tests, add Ruby column, explain duplicate security checks

### DIFF
--- a/docs/site/docs/ci-gates/repository-rulesets.md
+++ b/docs/site/docs/ci-gates/repository-rulesets.md
@@ -47,7 +47,7 @@ checks that must pass before a PR can merge.
 The required checks vary by repository category. See the
 [check matrix](required-checks.md#check-matrix) for the full list.
 
-### Library repositories (Go, Python, Java)
+### Library repositories (Go, Python, Ruby, Java)
 
 ```text
 ci: docs-only
@@ -55,16 +55,18 @@ ci: standards-compliance
 ci: dependency-audit
 release: gates
 test: unit (per matrix version)
-test: integration
+test: integration (per matrix version)
 security: codeql
 security: semgrep
 security: trivy
 ```
 
 !!! note "Matrix-expanded check names"
-    The `test: unit` check appears once per matrix version. For example,
-    mq-rest-admin-go requires `test: unit (1.25)` and `test: unit (1.26)`.
-    Each matrix expansion is a separate required check.
+    Both `test: unit` and `test: integration` appear once per matrix version.
+    For example, mq-rest-admin-go requires `test: unit (1.25)`,
+    `test: unit (1.26)`, `test: integration (1.25)`, and
+    `test: integration (1.26)`. Each matrix expansion is a separate required
+    check.
 
 ### Infrastructure repositories
 

--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -6,19 +6,31 @@ The following table shows which CI checks apply to each repository category.
 Checks marked **Required** must be configured as required status checks in the
 [CI gates ruleset](repository-rulesets.md#ci-gates-ruleset).
 
-| Check | Go Library | Python Library | Java Library | Infrastructure | Documentation |
-| ------- | ----------- | --------------- | ------------- | ---------------- | --------------- |
-| `ci: docs-only` | Required | Required | Required | Required | Required |
-| `ci: standards-compliance` | Required | Required | Required | Required | Required |
-| `ci: dependency-audit` | Required | Required | Required | — | — |
-| `ci: actionlint` | — | — | — | Required | — |
-| `ci: shellcheck` | — | — | — | Required | — |
-| `test: unit` | Required | Required | Required | — | — |
-| `test: integration` | Required | Required | Required | — | — |
-| `security: codeql` | Required | Required | Required | — | — |
-| `security: semgrep` | Required | Required | Required | — | — |
-| `security: trivy` | Required | Required | Required | — | — |
-| `release: gates` | Required | Required | Required | — | — |
+| Check | Go Library | Python Library | Ruby Library | Java Library | Infrastructure | Documentation |
+| ------- | ----------- | --------------- | ------------- | ------------- | ---------------- | --------------- |
+| `ci: docs-only` | Required | Required | Required | Required | Required | Required |
+| `ci: standards-compliance` | Required | Required | Required | Required | Required | Required |
+| `ci: dependency-audit` | Required | Required | Required | Required | — | — |
+| `ci: actionlint` | — | — | — | — | Required | — |
+| `ci: shellcheck` | — | — | — | — | Required | — |
+| `test: unit` | Required | Required | Required | Required | — | — |
+| `test: integration` | Required | Required | Required | Required | — | — |
+| `security: codeql` | Required | Required | Required | Required | — | — |
+| `security: semgrep` | Required | Required | Required | Required | — | — |
+| `security: trivy` | Required | Required | Required | Required | — | — |
+| `release: gates` | Required | Required | Required | Required | — | — |
+
+### Matrix-expanded check names
+
+Both `test: unit` and `test: integration` appear once per version in the
+language matrix. Each matrix expansion is a separate required check in the
+CI gates ruleset.
+
+| Repository | `test: unit` checks | `test: integration` checks |
+| ------------ | --------------------- | ---------------------------- |
+| mq-rest-admin-go | `test: unit (1.25)`, `test: unit (1.26)` | `test: integration (1.25)`, `test: integration (1.26)` |
+| mq-rest-admin-python | `test: unit (3.12)`, `test: unit (3.13)`, `test: unit (3.14)` | `test: integration (3.12)`, `test: integration (3.13)`, `test: integration (3.14)` |
+| mq-rest-admin-ruby | `test: unit (3.2)`, `test: unit (3.3)`, `test: unit (3.4)` | `test: integration (3.2)`, `test: integration (3.3)`, `test: integration (3.4)` |
 
 ## Job name prefix convention
 

--- a/docs/site/docs/ci-gates/security-scanning.md
+++ b/docs/site/docs/ci-gates/security-scanning.md
@@ -19,6 +19,22 @@ requires **GitHub Advanced Security (GHAS)**:
 - **Private repositories** — A GHAS license is required. Contact your GitHub
   administrator.
 
+## Check names in the PR status area
+
+Each security scanner produces **two** check runs on a pull request:
+
+| CI workflow job | SARIF analysis check |
+| ----------------- | ---------------------- |
+| `security: codeql` | `CodeQL` |
+| `security: semgrep` | `Semgrep OSS` |
+| `security: trivy` | `Trivy` |
+
+The first column shows our CI workflow jobs — these are the checks gated in the
+[CI gates ruleset](repository-rulesets.md#ci-gates-ruleset). The second column
+shows checks that GitHub creates automatically when SARIF results are uploaded
+via the `security-events: write` permission. The SARIF analysis checks are
+informational and are **not** included in the required status checks.
+
 ## Viewing results
 
 Security scan results appear in the repository's **Security** tab:
@@ -33,7 +49,7 @@ Security scan results appear in the repository's **Security** tab:
 CodeQL performs deep semantic analysis of source code. It understands data flow,
 control flow, and language-specific patterns.
 
-- **Languages supported**: Python, Go, Java, JavaScript/TypeScript, and more.
+- **Languages supported**: Python, Go, Ruby, Java, JavaScript/TypeScript, and more.
 - **Query suite**: `+security-extended` (default) includes the standard security
   queries plus extended checks.
 - **Autobuild**: CodeQL automatically detects the build system and compiles the


### PR DESCRIPTION
# Pull Request

## Summary

- Document version matrix expansion for both unit and integration tests, add Ruby Library column, explain duplicate security check runs

## Issue Linkage

- Ref #85

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/ci-gates/repository-rulesets.md
- docs/site/docs/ci-gates/required-checks.md
- docs/site/docs/ci-gates/security-scanning.md

## Notes

- -