### PR TITLE
docs: replace stale script references with st-* commands

### DIFF
--- a/docs/site/docs/actions/standards-compliance.md
+++ b/docs/site/docs/actions/standards-compliance.md
@@ -38,8 +38,8 @@ linkage, and repository profile.
 7. **Validate PR issue linkage** — On pull requests, runs `pr-issue-linkage.sh`
    to verify the PR body references a GitHub issue.
 8. **Validate shared tooling** — On PRs targeting `develop`, checks whether
-   synced scripts are up to date by running `scripts/dev/sync-tooling.sh --check`
-   (if present).
+   shared scripts are up to date with the canonical versions in the
+   `standard-tooling` package.
 
 ## Examples
 

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -47,7 +47,7 @@ provides integration testing without a separate test repository.
 Always use the commit script:
 
 ```bash
-scripts/dev/commit.sh \
+st-commit \
   --type feat \
   --scope ci \
   --message "add new validation check" \
@@ -70,7 +70,7 @@ Optional flags:
 Always use the PR script:
 
 ```bash
-scripts/dev/submit-pr.sh \
+st-submit-pr \
   --issue 42 \
   --summary "Add new validation check"
 ```

--- a/docs/site/docs/development/validation.md
+++ b/docs/site/docs/development/validation.md
@@ -19,9 +19,9 @@ validation (shared across repositories) from repository-specific checks:
 2. **Custom checks** — Repository-specific validations defined locally, such as
    actionlint for this repository's workflow files.
 
-The sync mechanism (`scripts/dev/sync-tooling.sh`) keeps the common validation
-scripts in sync with the canonical versions in `standard-tooling`. The
-`standards-compliance` action validates this staleness in CI.
+The `standard-tooling` package provides the common validation scripts via
+`st-*` CLI commands. The `standards-compliance` action checks script freshness
+in CI to ensure local copies stay in sync with the canonical versions.
 
 ## Docs-only validation
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace stale script references with st-* commands

## Issue Linkage

- Ref wphillipmoore/standards-and-conventions#311

## Testing

Docs-only: tests skipped

Changed files:
- docs/site/docs/actions/standards-compliance.md
- docs/site/docs/development/contributing.md
- docs/site/docs/development/validation.md

## Notes

- -