### PR TITLE
chore(security): upgrade CodeQL Action from v3 to v4

### DIFF
--- a/actions/security/codeql/action.yml
+++ b/actions/security/codeql/action.yml
@@ -16,15 +16,15 @@ runs:
   using: composite
   steps:
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ inputs.language }}
         queries: ${{ inputs.queries }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     - name: Run CodeQL analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{ inputs.language }}"

--- a/actions/security/semgrep/action.yml
+++ b/actions/security/semgrep/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Upload SARIF
       if: always()
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: semgrep-results.sarif
         category: semgrep

--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Upload SARIF (filesystem scan)
       if: inputs.scan-type == 'fs' && always()
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.output-file }}
         category: trivy-fs
@@ -67,7 +67,7 @@ runs:
 
     - name: Upload SARIF (image scan)
       if: inputs.scan-type == 'image' && always()
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.output-file }}
         category: trivy-image

--- a/docs/site/docs/actions/security-codeql.md
+++ b/docs/site/docs/actions/security-codeql.md
@@ -26,11 +26,11 @@ language.
 
 ## Behavior
 
-1. **Initialize CodeQL** — Uses `github/codeql-action/init@v3` to set up the
+1. **Initialize CodeQL** — Uses `github/codeql-action/init@v4` to set up the
    CodeQL database for the specified language and query suite.
-2. **Autobuild** — Uses `github/codeql-action/autobuild@v3` to automatically
+2. **Autobuild** — Uses `github/codeql-action/autobuild@v4` to automatically
    detect and build the project.
-3. **Run analysis** — Uses `github/codeql-action/analyze@v3` to perform the
+3. **Run analysis** — Uses `github/codeql-action/analyze@v4` to perform the
    analysis and upload results. Results are categorized by
    `/language:<language>`.
 

--- a/docs/site/docs/actions/security-semgrep.md
+++ b/docs/site/docs/actions/security-semgrep.md
@@ -33,7 +33,7 @@ rulesets.
     - `p/secrets` — Secret detection rules
     - Any additional rulesets from `extra-config`
 3. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
-   using `github/codeql-action/upload-sarif@v3`, categorized as `semgrep`.
+   using `github/codeql-action/upload-sarif@v4`, categorized as `semgrep`.
    This step runs even if the scan finds issues (`if: always()`).
 
 ## Examples


### PR DESCRIPTION
# Pull Request

## Summary

- Upgrade all CodeQL Action references from v3 to v4

## Issue Linkage

- Fixes #92

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -