### PR TITLE
chore(docs): reposition Releases in MkDocs nav

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -54,6 +54,9 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Releases:
+      - Release Notes: releases/index.md
+      - Changelog: changelog.md
   - Getting Started: getting-started.md
   - Repository Configuration: configuration.md
   - Action Reference:
@@ -85,6 +88,3 @@ nav:
       - Environment and Tooling: development/environment-and-tooling.md
       - Validation: development/validation.md
       - Contributing: development/contributing.md
-  - Releases:
-      - Release Notes: releases/index.md
-      - Changelog: changelog.md


### PR DESCRIPTION
## Summary

- Move Releases section from bottom of MkDocs nav to position 2 (after Home, before Getting Started) for greater prominence

Fixes #106

## Test plan

- [x] Verify `mkdocs.yml` nav ordering is correct
- [ ] Confirm docs site renders with Releases in the expected position

> [!NOTE]
> Docs-only change — no code or test changes required.

Generated with [Claude Code](https://claude.ai/code)
