### PR TITLE
fix(security): preserve severity filter in SARIF output for Trivy scans

### DIFF
--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -55,6 +55,7 @@ runs:
         exit-code: ${{ inputs.exit-code }}
         scanners: ${{ inputs.scanners }}
         trivyignores: ${{ inputs.trivyignores }}
+        limit-severities-for-sarif: "true"
         format: sarif
         output: ${{ inputs.output-file }}
 
@@ -75,6 +76,7 @@ runs:
         exit-code: ${{ inputs.exit-code }}
         scanners: ${{ inputs.scanners }}
         trivyignores: ${{ inputs.trivyignores }}
+        limit-severities-for-sarif: "true"
         format: sarif
         output: ${{ inputs.output-file }}
 


### PR DESCRIPTION
# Pull Request

## Summary

- Preserve severity filter in SARIF output for Trivy scans

## Issue Linkage

- Fixes #122

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -