### PR TITLE
fix(docs-deploy): install pyyaml when mike-command is not mike

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -51,6 +51,11 @@ runs:
       shell: bash
       run: pip install mkdocs-material mike
 
+    - name: Install pyyaml for nav patching
+      if: inputs.mike-command != 'mike'
+      shell: bash
+      run: pip install pyyaml
+
     - name: Configure git identity
       shell: bash
       run: |


### PR DESCRIPTION
# Pull Request

## Summary

- Install pyyaml explicitly when mike-command != mike so patch-nav.py can import yaml

## Issue Linkage

- Fixes #127

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -