### PR TITLE
ci: add publish workflow for tag, release, and version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: "publish: release"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: version
+        run: |
+          version=$(cat VERSION)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: tag_check
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop
+        with:
+          version: ${{ steps.version.outputs.version }}
+          release-title: standard-actions
+          release-notes: |
+            ## standard-actions v${{ steps.version.outputs.version }}
+
+            Shared GitHub Actions for all managed repositories.
+
+      - name: Generate app token for bump PR
+        if: steps.tag_check.outputs.exists == 'false'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Version bump PR
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@develop
+        with:
+          current-version: ${{ steps.version.outputs.version }}
+          version-file: VERSION
+          version-regex: '^(\d+\.\d+\.)\d+$'
+          version-replacement: '\g<1>{version}'
+          develop-version-command: cat
+          app-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
# Pull Request

## Summary

- Add publish workflow for automated tagging, GitHub Release creation, and version bump PR

## Issue Linkage

- Ref #129

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -