### PR TITLE
docs: add Rust Library to required checks matrix

### DIFF
--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -6,18 +6,18 @@ The following table shows which CI checks apply to each repository category.
 Checks marked **Required** must be configured as required status checks in the
 [CI gates ruleset](repository-rulesets.md#ci-gates-ruleset).
 
-| Check | Go Library | Python Library | Ruby Library | Java Library | Infrastructure | Documentation |
-| ------- | ----------- | --------------- | ------------- | ------------- | ---------------- | --------------- |
-| `ci: standards-compliance` | Required | Required | Required | Required | Required | Required |
-| `ci: dependency-audit` | Required | Required | Required | Required | — | — |
-| `ci: actionlint` | — | — | — | — | Required | — |
-| `ci: shellcheck` | — | — | — | — | Required | — |
-| `test: unit` | Required | Required | Required | Required | — | — |
-| `test: integration` | Required | Required | Required | Required | — | — |
-| `security: codeql` | Required | Required | Required | Required | — | — |
-| `security: semgrep` | Required | Required | Required | Required | — | — |
-| `security: trivy` | Required | Required | Required | Required | — | — |
-| `release: gates` | Required | Required | Required | Required | — | — |
+| Check | Go Library | Python Library | Ruby Library | Java Library | Rust Library | Infrastructure | Documentation |
+| ------- | ----------- | --------------- | ------------- | ------------- | ------------- | ---------------- | --------------- |
+| `ci: standards-compliance` | Required | Required | Required | Required | Required | Required | Required |
+| `ci: dependency-audit` | Required | Required | Required | Required | Required | — | — |
+| `ci: actionlint` | — | — | — | — | — | Required | — |
+| `ci: shellcheck` | — | — | — | — | — | Required | — |
+| `test: unit` | Required | Required | Required | Required | Required | — | — |
+| `test: integration` | Required | Required | Required | Required | Required | — | — |
+| `security: codeql` | Required | Required | Required | Required | Required | — | — |
+| `security: semgrep` | Required | Required | Required | Required | Required | — | — |
+| `security: trivy` | Required | Required | Required | Required | Required | — | — |
+| `release: gates` | Required | Required | Required | Required | Required | — | — |
 
 ### Matrix-expanded check names
 
@@ -30,6 +30,7 @@ CI gates ruleset.
 | mq-rest-admin-go | `test: unit (1.25)`, `test: unit (1.26)` | `test: integration (1.25)`, `test: integration (1.26)` |
 | mq-rest-admin-python | `test: unit (3.12)`, `test: unit (3.13)`, `test: unit (3.14)` | `test: integration (3.12)`, `test: integration (3.13)`, `test: integration (3.14)` |
 | mq-rest-admin-ruby | `test: unit (3.2)`, `test: unit (3.3)`, `test: unit (3.4)` | `test: integration (3.2)`, `test: integration (3.3)`, `test: integration (3.4)` |
+| mq-rest-admin-rust | `test: unit (1.92)`, `test: unit (1.93)` | `test: integration (1.92)`, `test: integration (1.93)` |
 
 ## Job name prefix convention
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add Rust Library to CI required checks matrix

## Issue Linkage

- Fixes #141

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Part of mq-rest-admin-common#10 (Rust port prerequisites). Adds Rust Library column to required checks matrix (all checks Required) and mq-rest-admin-rust to matrix-expanded check names. Verified ci-security.yml already supports language: rust (CodeQL) and p/rust (Semgrep) via parameterized inputs — no workflow changes needed.