### PR TITLE
docs: add ci: type-check to required checks matrix

### DIFF
--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -12,6 +12,7 @@ Checks marked **Required** must be configured as required status checks in the
 | `ci: dependency-audit` | Required | Required | Required | Required | Required | — | — |
 | `ci: actionlint` | — | — | — | — | — | Required | — |
 | `ci: shellcheck` | — | — | — | — | — | Required | — |
+| `ci: type-check` | — | Required | Required | — | — | — | — |
 | `test: unit` | Required | Required | Required | Required | Required | — | — |
 | `test: integration` | Required | Required | Required | Required | Required | — | — |
 | `security: codeql` | Required | Required | Required | Required | Required | — | — |


### PR DESCRIPTION
# Pull Request

## Summary

- Add ci: type-check to required checks matrix for Python and Ruby

## Issue Linkage

- Ref #110

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -