### PR TITLE
feat(publish): add rolling vX.Y minor tags to tag-and-release action

### DIFF
--- a/actions/publish/tag-and-release/action.yml
+++ b/actions/publish/tag-and-release/action.yml
@@ -32,6 +32,11 @@ outputs:
   tag-created:
     description: "'true' if a new tag was created, 'false' if it already existed."
     value: ${{ steps.check.outputs.created }}
+  rolling-tag:
+    description: >-
+      The rolling major.minor tag (e.g. v1.2) that was created or updated.
+      Empty when tag-created is false.
+    value: ${{ steps.rolling.outputs.tag }}
 
 runs:
   using: composite
@@ -91,3 +96,15 @@ runs:
           release_args+=( ${{ inputs.release-artifacts }} )
         fi
         gh release create "${release_args[@]}"
+
+    - name: Create or update rolling minor tag
+      id: rolling
+      if: steps.check.outputs.created == 'true'
+      shell: bash
+      run: |
+        minor="${{ inputs.version }}"
+        minor="${minor%.*}"
+        rolling_tag="${{ inputs.tag-prefix }}${minor}"
+        git tag -f "$rolling_tag" HEAD
+        git push -f origin "$rolling_tag"
+        echo "tag=${rolling_tag}" >> "$GITHUB_OUTPUT"

--- a/docs/site/docs/actions/publish-tag-and-release.md
+++ b/docs/site/docs/actions/publish-tag-and-release.md
@@ -32,6 +32,7 @@ action safe to re-run.
 | ------ | ------------- |
 | `tag` | The full tag name that was (or would be) created (e.g. `v1.2.3`). |
 | `tag-created` | `true` if a new tag was created, `false` if it already existed. |
+| `rolling-tag` | The rolling `major.minor` tag that was created or updated (e.g. `v1.2`). Empty when `tag-created` is `false`. |
 
 ## Permissions
 
@@ -51,6 +52,10 @@ action safe to re-run.
    enables changelog generation between releases.
 6. **Create GitHub Release** — Uses `gh release create` with the provided title,
    notes, and optional artifacts.
+7. **Create or update rolling minor tag** — Extracts the `major.minor` portion
+   of the version (e.g. `1.2` from `1.2.3`), then force-creates and
+   force-pushes a rolling tag (e.g. `v1.2`). This allows consumers to pin
+   `@v1.2` and automatically receive patch releases.
 
 ## Examples
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add rolling vX.Y minor tags to tag-and-release action so consumers can pin a stable minor version and automatically receive patch fixes

## Issue Linkage

- Fixes #144

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -