### PR TITLE
fix(trivy): install Trivy binary directly to avoid setup-trivy cache fallback failure

### DIFF
--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -45,10 +45,28 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Trivy
+      shell: bash
+      run: |
+        TRIVY_VERSION="v0.62.1"
+        ARCH="$(uname -m)"
+        case "$ARCH" in
+          x86_64)  ARCH="64bit" ;;
+          aarch64) ARCH="ARM64" ;;
+          arm64)   ARCH="ARM64" ;;
+          *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+        esac
+        OS="$(uname -s)"
+        URL="https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VERSION#v}_${OS}-${ARCH}.tar.gz"
+        echo "Downloading Trivy ${TRIVY_VERSION} from ${URL}"
+        curl -sfL "$URL" | tar xzf - -C /usr/local/bin trivy
+        trivy --version
+
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'
       uses: aquasecurity/trivy-action@0.34.0
       with:
+        skip-setup-trivy: true
         scan-type: fs
         scan-ref: ${{ inputs.scan-ref }}
         severity: ${{ inputs.severity }}
@@ -70,6 +88,7 @@ runs:
       if: inputs.scan-type == 'image'
       uses: aquasecurity/trivy-action@0.34.0
       with:
+        skip-setup-trivy: true
         scan-type: image
         image-ref: ${{ inputs.scan-ref }}
         severity: ${{ inputs.severity }}
@@ -91,6 +110,7 @@ runs:
       if: inputs.scan-type == 'sbom'
       uses: aquasecurity/trivy-action@0.34.0
       with:
+        skip-setup-trivy: true
         scan-type: fs
         scan-ref: ${{ inputs.scan-ref }}
         format: cyclonedx


### PR DESCRIPTION
# Pull Request

## Summary

- Install Trivy binary directly instead of relying on setup-trivy cache fallback

## Issue Linkage

- Fixes #151

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -