### PR TITLE
fix(trivy): use setup-trivy with cache disabled instead of manual binary download

### DIFF
--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -46,21 +46,10 @@ runs:
   using: composite
   steps:
     - name: Install Trivy
-      shell: bash
-      run: |
-        TRIVY_VERSION="v0.62.1"
-        ARCH="$(uname -m)"
-        case "$ARCH" in
-          x86_64)  ARCH="64bit" ;;
-          aarch64) ARCH="ARM64" ;;
-          arm64)   ARCH="ARM64" ;;
-          *)       echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-        esac
-        OS="$(uname -s)"
-        URL="https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VERSION#v}_${OS}-${ARCH}.tar.gz"
-        echo "Downloading Trivy ${TRIVY_VERSION} from ${URL}"
-        curl -sfL "$URL" | tar xzf - -C /usr/local/bin trivy
-        trivy --version
+      uses: aquasecurity/setup-trivy@v0.2.0
+      with:
+        version: v0.69.1
+        cache: "false"
 
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'


### PR DESCRIPTION
# Pull Request

## Summary

- Use setup-trivy with cache disabled to avoid broken cache miss fallback

## Issue Linkage

- Fixes #151

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -