### PR TITLE
docs: update tag protection ruleset docs for rolling tag support

### DIFF
--- a/docs/site/docs/ci-gates/repository-rulesets.md
+++ b/docs/site/docs/ci-gates/repository-rulesets.md
@@ -10,7 +10,7 @@ three rulesets:
 | --------- | -------- | --------- |
 | Branch protection | `main`, `develop` | PR requirements, deletion and force-push prevention |
 | CI gates | `main`, `develop` | Required status checks |
-| Tag protection | `v*` tags | Prevent tag deletion, update, and non-fast-forward |
+| Tag protection | `v*.*.*` tags | Protect semver release tags; allow rolling minor tags |
 
 ## Branch protection ruleset
 
@@ -84,15 +84,36 @@ ci: standards-compliance
 
 ## Tag protection ruleset
 
-Applies to all tags matching `v*`. Prevents unauthorized modification of release
-tags.
+Applies to all tags matching `v*.*.*` (full semver tags such as `v1.1.1` or
+`v2.0.0`). Prevents unauthorized modification of release tags while allowing
+the publish workflow to create and update rolling minor tags (e.g., `v1.1`).
 
 | Setting | Value |
 | --------- | ------- |
+| Pattern | `refs/tags/v*.*.*` |
 | Block deletion | Yes |
 | Block non-fast-forward | Yes |
 | Block update | Yes |
-| Bypass actors | None |
+| Bypass actors | Repository admin (`actor_id: 5`, `bypass_mode: always`) |
+
+### Why `v*.*.*` instead of `v*`
+
+The publish workflow's `tag-and-release` action creates a rolling minor tag
+(e.g., `v1.1`) that always points to the latest patch release. Consumers
+reference these rolling tags to receive automatic patch updates. The broader
+`v*` pattern matches both `v1.1.1` (semver) and `v1.1` (rolling), which causes
+the rolling tag force-push to fail with a repository rule violation.
+
+The `v*.*.*` pattern requires three dot-separated components, so it protects
+immutable release tags (`v1.1.1`, `v1.1.2`) while leaving rolling tags (`v1.1`)
+unprotected for the workflow to update.
+
+### Admin bypass
+
+The repository admin bypass exists as a safety valve for cleanup operations
+(e.g., removing a tag created against the wrong branch). Normal publish
+operations do not require admin bypass — the rolling tag update succeeds because
+rolling tags fall outside the `v*.*.*` pattern.
 
 ## Adding a new required check
 

--- a/docs/site/docs/configuration.md
+++ b/docs/site/docs/configuration.md
@@ -113,7 +113,7 @@ Every managed repository uses three rulesets to enforce merge requirements:
 
 - **Branch protection** — PR requirements for `main` and `develop`
 - **CI gates** — Required status checks for `main` and `develop`
-- **Tag protection** — Prevent modification of `v*` release tags
+- **Tag protection** — Protect semver release tags (`v*.*.*`); allow rolling minor tags
 
 For detailed configuration including settings, check names per repository type,
 and API commands, see [Repository Rulesets](ci-gates/repository-rulesets.md).
@@ -176,7 +176,7 @@ Create three rulesets per the standard configuration:
   ([details](ci-gates/repository-rulesets.md#branch-protection-ruleset))
 - [ ] **CI gates** — targeting `main` and `develop` with required checks
   ([details](ci-gates/repository-rulesets.md#ci-gates-ruleset))
-- [ ] **Tag protection** — targeting `v*`
+- [ ] **Tag protection** — targeting `v*.*.*` with admin bypass
   ([details](ci-gates/repository-rulesets.md#tag-protection-ruleset))
 
 !!! warning "Use explicit branch references"


### PR DESCRIPTION
# Pull Request

## Summary

- Update tag protection ruleset docs for v*.*.* pattern and admin bypass

## Issue Linkage

- Fixes #157

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -