### PR TITLE
feat: make docs-deploy container-aware

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -40,19 +40,29 @@ runs:
         ref: ${{ inputs.checkout-common-ref }}
         path: .mq-rest-admin-common
 
+    - name: Detect pre-installed tools
+      id: detect
+      shell: bash
+      run: |
+        if command -v mike >/dev/null 2>&1; then
+          echo "mike-installed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "mike-installed=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Set up Python 3.12
-      if: inputs.mike-command == 'mike'
+      if: inputs.mike-command == 'mike' && steps.detect.outputs.mike-installed == 'false'
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
     - name: Install MkDocs and mike
-      if: inputs.mike-command == 'mike'
+      if: inputs.mike-command == 'mike' && steps.detect.outputs.mike-installed == 'false'
       shell: bash
       run: pip install mkdocs-material mike
 
     - name: Install pyyaml for nav patching
-      if: inputs.mike-command != 'mike'
+      if: inputs.mike-command != 'mike' && steps.detect.outputs.mike-installed == 'false'
       shell: bash
       run: pip install pyyaml
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add a detect step that checks if mike is already on PATH
- Gate Python setup, mkdocs/mike install, and pyyaml install on mike not being pre-installed
- Backward compatible: repos not yet using the container still get the pip install

## Issue Linkage

- Fixes #175

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Merge after standard-tooling-docker#27 publishes the image
