### PR TITLE
ci: remove standard-tooling setup hacks from standards-compliance

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -38,6 +38,7 @@ jobs:
     name: "ci: standards-compliance"
     if: ${{ inputs.run-standards != 'false' }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   standards-compliance:
     name: "ci: standards-compliance"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -17,13 +17,13 @@ runs:
 
     - name: Validate repository profile
       shell: bash
-      run: repo-profile
+      run: st-repo-profile
 
     - name: Validate markdown standards
       shell: bash
-      run: markdown-standards
+      run: st-markdown-standards
 
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'
       shell: bash
-      run: pr-issue-linkage
+      run: st-pr-issue-linkage

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -2,37 +2,18 @@ name: Standards compliance
 description: >-
   Validates repository standards: markdown formatting,
   PR issue linkage, and repository profile.
-
-inputs:
-  standard-tooling-ref:
-    description: >-
-      Git ref (branch or tag) of standard-tooling to check out.
-      Use a tag (e.g. v1.2) for stable consumption.
-    required: false
-    default: "develop"
+  Requires the dev-docs container image (standard-tooling pre-installed).
 
 runs:
   using: composite
   steps:
-    - name: Checkout standard-tooling
-      uses: actions/checkout@v6
-      with:
-        repository: wphillipmoore/standard-tooling
-        ref: ${{ inputs.standard-tooling-ref }}
-        path: .standard-tooling
-
-    - name: Add standard-tooling to PATH
+    - name: Verify standard-tooling is installed
       shell: bash
-      run: echo "${{ github.workspace }}/.standard-tooling/scripts/bin" >> "$GITHUB_PATH"
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: "20"
-
-    - name: Install markdownlint-cli
-      shell: bash
-      run: npm install --global markdownlint-cli@0.41.0
+      run: |
+        if ! command -v st-repo-profile >/dev/null 2>&1; then
+          echo "::error::st-repo-profile not found. This action requires the dev-docs container image."
+          exit 1
+        fi
 
     - name: Validate repository profile
       shell: bash


### PR DESCRIPTION
## Summary

Fixes #214

- Remove checkout, PATH, Node.js, and markdownlint setup steps from standards-compliance action — all pre-installed in dev-docs container
- Add hard requirement check for st-repo-profile with clear error message
- Add container: ghcr.io/wphillipmoore/dev-docs:latest to standards-compliance jobs in ci-security.yml and ci.yml
- Remove standard-tooling-ref input (no longer needed)

Depends on wphillipmoore/standard-tooling-docker#32 (adds markdownlint to dev-docs image)

## Test plan

- [ ] standard-actions CI passes (self-test of updated action in container)
- [ ] After merge, downstream repos next CI run uses container-based standards-compliance automatically via ci-security.yml

Generated with [Claude Code](https://claude.com/claude-code)