### PR TITLE
fix: rename dev-docs container references to dev-base

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -38,7 +38,7 @@ jobs:
     name: "ci: standards-compliance"
     if: ${{ inputs.run-standards != 'false' }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   standards-compliance:
     name: "ci: standards-compliance"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -2,7 +2,7 @@ name: Standards compliance
 description: >-
   Validates repository standards: markdown formatting,
   PR issue linkage, and repository profile.
-  Requires the dev-docs container image (standard-tooling pre-installed).
+  Requires the dev-base container image (standard-tooling pre-installed).
 
 runs:
   using: composite
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         if ! command -v st-repo-profile >/dev/null 2>&1; then
-          echo "::error::st-repo-profile not found. This action requires the dev-docs container image."
+          echo "::error::st-repo-profile not found. This action requires the dev-base container image."
           exit 1
         fi
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix broken CI by renaming dev-docs to dev-base in reusable workflows and standards-compliance action

## Issue Linkage

- Closes #181

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -