### PR TITLE
fix(pipeline): stabilize version-bump-pr back-merge and docs-deploy container cwd

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -68,13 +68,18 @@ runs:
 
     - name: Configure git identity
       shell: bash
+      # --global avoids depending on cwd being inside the repo. Composite
+      # shell steps in container jobs do not reliably land in
+      # $GITHUB_WORKSPACE when setup-python is skipped (pre-installed mike),
+      # so repo-scoped git config would fail with "not in a git directory".
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Determine version
       id: version
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
         if [ "${{ github.ref }}" = "refs/heads/main" ]; then
           VERSION=$(${{ inputs.version-command }})
@@ -87,6 +92,7 @@ runs:
 
     - name: Stage changelog and release notes
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
         DOCS_DIR=$(dirname "${{ inputs.mkdocs-config }}")/docs
 
@@ -110,6 +116,7 @@ runs:
 
     - name: Patch mkdocs nav with release versions
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
         DOCS_DIR=$(dirname "${{ inputs.mkdocs-config }}")/docs
 
@@ -123,6 +130,7 @@ runs:
 
     - name: Deploy docs
       shell: bash
+      working-directory: ${{ github.workspace }}
       run: |
         if [ -n "${{ steps.version.outputs.alias }}" ]; then
           ${{ inputs.mike-command }} deploy -F ${{ inputs.mkdocs-config }} --push --update-aliases ${{ steps.version.outputs.version }} ${{ steps.version.outputs.alias }}

--- a/actions/publish/version-bump-pr/action.yml
+++ b/actions/publish/version-bump-pr/action.yml
@@ -108,9 +108,13 @@ runs:
     - name: Create bump branch and merge main
       if: steps.check.outputs.needed == 'true'
       shell: bash
+      # -X theirs resolves add/add CHANGELOG conflicts on first-release repos
+      # where develop's scaffolding CHANGELOG diverges from main's generated
+      # one. Intent of this back-merge is "develop reflects post-release main",
+      # so taking main's side on conflict is always correct here.
       run: |
         git checkout -b "${{ steps.next.outputs.branch }}" origin/develop
-        git merge origin/main --no-edit
+        git merge origin/main --no-edit -X theirs
 
     - name: Update version file
       if: steps.check.outputs.needed == 'true'


### PR DESCRIPTION
# Pull Request

## Summary

- stabilize version-bump-pr back-merge and docs-deploy container cwd

## Issue Linkage

- Fixes #186
- Fixes #187

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## What

Two pipeline-stability fixes for the release + docs workflows. Both
were caught live during standard-tooling-plugin's first-ever
release (v1.3.0 -> v1.3.1 on 2026-04-23).

### #186 — version-bump-pr: add `-X theirs` to main back-merge

First-release repos always hit an add/add CHANGELOG.md conflict
when the auto-bump step back-merges main into develop. `-X theirs`
is the correct intent (develop should take main's post-release
state).

### #187 — docs-deploy: container-aware cwd

Since #174 made docs-deploy skip `setup-python` when mike is
pre-installed, subsequent composite shell steps ended up with cwd =
Dockerfile `WORKDIR` (`/workspace`) instead of `$GITHUB_WORKSPACE`.
`git config` and relative-path references blew up. Fix uses
`--global` for git identity and `working-directory:
${{ github.workspace }}` on each file-touching step.

## Verification

- Both diffs are <10 lines and purely mechanical.
- In-file comments capture the rationale for each change.
- Fleet impact: next release cycle for any consuming repo will
  exercise both paths.

## Related

- https://github.com/wphillipmoore/standard-actions/issues/186
- https://github.com/wphillipmoore/standard-actions/issues/187
- https://github.com/wphillipmoore/standard-tooling-plugin/pull/68
  — this cycle's manual bump PR, which is the workaround `-X
  theirs` avoids once this lands.

Fixes #186. Fixes #187.
