### PR TITLE
fix(publish): use env vars + quoted heredoc in version-bump-pr Update step

### DIFF
--- a/actions/publish/version-bump-pr/action.yml
+++ b/actions/publish/version-bump-pr/action.yml
@@ -122,22 +122,35 @@ runs:
     - name: Update version file
       if: steps.check.outputs.needed == 'true'
       shell: bash
+      # Pass values via env vars and a single-quoted heredoc delimiter
+      # (<<'PYEOF') so bash does no interpolation on the body.  This
+      # avoids the class of bugs where double-quotes in the regex or
+      # replacement (common with `"version"` JSON keys, etc.) prematurely
+      # closed an outer bash string and broke the python invocation.
+      env:
+        VERSION_FILE: ${{ inputs.version-file }}
+        VERSION_REGEX: ${{ inputs.version-regex }}
+        VERSION_REPLACEMENT: ${{ inputs.version-replacement }}
+        NEXT_VERSION: ${{ steps.next.outputs.version }}
+        REGEX_MULTILINE: ${{ inputs.version-regex-multiline }}
       run: |
-        python3 -c "
+        python3 <<'PYEOF'
         from pathlib import Path
+        import os
         import re
-        p = Path('${{ inputs.version-file }}')
+
+        p = Path(os.environ['VERSION_FILE'])
         content = p.read_text()
-        flags = re.MULTILINE if '${{ inputs.version-regex-multiline }}' == 'true' else 0
+        flags = re.MULTILINE if os.environ['REGEX_MULTILINE'] == 'true' else 0
         content = re.sub(
-            r'${{ inputs.version-regex }}',
-            r'${{ inputs.version-replacement }}'.replace('{version}', '${{ steps.next.outputs.version }}'),
+            os.environ['VERSION_REGEX'],
+            os.environ['VERSION_REPLACEMENT'].replace('{version}', os.environ['NEXT_VERSION']),
             content,
             count=1,
             flags=flags,
         )
         p.write_text(content)
-        "
+        PYEOF
 
     - name: Run post-bump command
       if: steps.check.outputs.needed == 'true' && inputs.post-bump-command != ''


### PR DESCRIPTION
# Pull Request

## Summary

- use env vars + quoted heredoc in version-bump-pr composite to survive double-quote values

## Issue Linkage

- Fixes #197

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## What

Rewrite the `version-bump-pr` composite's "Update version file"
step to use environment variables and a single-quoted heredoc
(`<<'PYEOF'`). No interface change.

## Why

GitHub expression interpolation puts raw input values into the
bash `python3 -c "..."` string. When the regex or replacement
contains double quotes (common for any `"version"` JSON key or
`VERSION = "x.y.z"` Ruby constant), bash's outer string closes
prematurely and subsequent parens look like subshell metachars.
Hit live on the v1.4.1 plugin publish as a syntax error at
runtime.

Single-quoted heredoc means bash performs zero interpolation on
the body. Values arrive via `os.environ['NAME']` and don't
interact with bash quoting at all.

## Scope

One step in one file:
`actions/publish/version-bump-pr/action.yml`. In-file comment
captures the rationale. Patch bump (`1.2.0` → `1.2.1` once
released); `v1.2` rolling tag will pick up the fix on release.

Fixes #197.