### PR TITLE
fix(docs-deploy): add safe.directory '*' for container workspace ownership (#206)

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -72,9 +72,18 @@ runs:
       # shell steps in container jobs do not reliably land in
       # $GITHUB_WORKSPACE when setup-python is skipped (pre-installed mike),
       # so repo-scoped git config would fail with "not in a git directory".
+      #
+      # `safe.directory '*'` exempts the workspace from git's
+      # dubious-ownership check. Inside a container, the workspace is
+      # mounted with a UID that differs from the user git runs as,
+      # which trips the safety check on every `mike deploy`. The
+      # mechanism is intended to protect interactive users; on a CI
+      # runner with a freshly checked-out workspace, suppressing it
+      # is the right call. Issue #206.
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git config --global --add safe.directory '*'
 
     - name: Determine version
       id: version


### PR DESCRIPTION
# Pull Request

## Summary

- Add safe.directory '*' for container workspace ownership

## Issue Linkage

- Closes #206

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Second of two bugs masking docs publication. Once this merges, docs-publish on standard-tooling should reach completion for the first time since March.