### PR TITLE
chore(migration): vendor .githooks gate + .yamllint; clean stale CLAUDE.md refs (#208)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# pre-commit gate — admits st-commit-driven commits and legitimate
+# derived-commit workflows; rejects raw `git commit`.
+#
+# Source-of-truth contract: in standard-tooling
+# docs/specs/host-level-tool.md "Git hooks".
+# Companion: `git.run` in standard-tooling sets ST_COMMIT_CONTEXT=1
+# before invoking `git commit`.
+
+# Admit st-commit-driven commits. Print a diagnostic so the admission
+# is visible — this branch is also the documented escape hatch
+# (`ST_COMMIT_CONTEXT=1 git commit ...`) and any silent admit would
+# make manual workarounds invisible in the commit output.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then
+  echo "pre-commit gate: admitted (ST_COMMIT_CONTEXT=1)" >&2
+  exit 0
+fi
+
+# Admit derived-commit workflows that legitimately invoke `git commit`
+# without going through st-commit (amend, rebase, cherry-pick, revert,
+# merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
+case "${GIT_REFLOG_ACTION:-}" in
+amend | cherry-pick | revert | rebase* | merge*)
+  echo "pre-commit gate: admitted (GIT_REFLOG_ACTION=${GIT_REFLOG_ACTION})" >&2
+  exit 0
+  ;;
+esac
+
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,43 @@
+# Canonical yamllint config for this repo.
+#
+# Vendored from standard-tooling for fleet consistency
+# (host-level-tool spec, Phase 6 migration; issue #208 / parent
+# standard-tooling#302). yamllint auto-discovers `.yamllint` in the
+# project root, so any local or CI yamllint run picks this up.
+#
+# Tuned for GitHub Actions workflow files and project YAML (mkdocs,
+# markdownlint, issue templates). Stricter rules would flag
+# pre-existing-and-fine content (e.g., GHA `on:` keys, long lines
+# carrying URLs or python-c expressions in workflow `run:` blocks),
+# turning every edit into a yak-shave. Where rules are relaxed below,
+# rationale is in-line.
+
+extends: default
+
+rules:
+  # GHA workflow files don't lead with `---`. Disabling rather than
+  # fighting the convention.
+  document-start: disable
+
+  # GHA's `on:` key is YAML's truthy-value (it parses as `True`). The
+  # default rule flags it; we exclude it. Other unintentional truthy
+  # values (yes/no/on/off) still flagged.
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: false
+
+  # Per-rule ignore for `.github/workflows/`: workflows carry inline
+  # `python3 -c "..."` expressions as composite-action inputs (an
+  # unavoidable GHA pattern — input values must be single strings,
+  # can't be split across lines). The glob form matches both absolute
+  # and relative path invocations.
+  line-length:
+    max: 120
+    level: error
+    ignore: |
+      **/.github/workflows/**
+      .github/workflows/**
+
+  # Default trailing-spaces / empty-lines / etc. settings are fine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ This is a shared GitHub Actions library providing reusable composite actions for
 ### Environment Setup
 
 ```bash
-git config core.hooksPath ../standard-tooling/scripts/lib/git-hooks  # Enable git hooks
+git config core.hooksPath .githooks  # Enable the pre-commit gate
 ```
 
 Standard-tooling CLI tools (`st-commit`, `st-validate-local`, etc.) are
@@ -132,7 +132,15 @@ This repository's CI workflow uses **local paths** (`./actions/...`) rather than
 
 ### Standard-Tooling Integration
 
-Shared validators (`repo-profile`, `markdown-standards`, `commit-messages`, `pr-issue-linkage`) are provided by `standard-tooling` via PATH. The `standards-compliance` action checks out `standard-tooling` and prepends its `scripts/bin/` to `$GITHUB_PATH`. Locally, the same tools are available by adding `../standard-tooling/scripts/bin` to your PATH.
+Shared validators (`st-repo-profile`, `st-markdown-standards`, `st-pr-issue-linkage`) are provided by `standard-tooling`. CI uses the dev container image's pre-baked install (non-Python consumers like this one). Locally, install the host tool per the [host-level-tool spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/host-level-tool.md):
+
+```bash
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
+# or, for the alternative pip-based path:
+pip install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
+```
+
+The `standards-compliance` action no longer clones `standard-tooling` onto the runner — it assumes `st-*` is on `PATH` either via the dev container pre-bake (non-Python) or `uv sync --group dev` (Python).
 
 ### Repo-Specific Scripts
 


### PR DESCRIPTION
# Pull Request

## Summary

- Phase 6 migration: vendor .githooks gate + .yamllint; clean stale CLAUDE.md refs

## Issue Linkage

- Closes #208

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Three changes: vendor pre-commit gate, add yamllint config, clean two stale CLAUDE.md references (sibling-checkout hooksPath line + outdated standards-compliance description).