### PR TITLE
feat(publish): freeze internal @develop refs at tag-cut time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,36 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Rewrite internal @develop refs in the working tree, then commit
+      # locally on top of the checked-out HEAD. The tag step below tags
+      # this commit, so the tagged snapshot has internally-consistent
+      # refs (every wphillipmoore/standard-actions/...@develop becomes
+      # ...@<release-tag>). The commit is reachable only via the tag —
+      # it is never pushed to develop or main.
+      - name: Freeze internal @develop refs to release tag
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mapfile -t files < <(find .github/workflows actions \
+            -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+          rewrote=0
+          for f in "${files[@]}"; do
+            if grep -qE 'wphillipmoore/standard-actions/[^@[:space:]]+@develop' "$f"; then
+              sed -i.bak -E "s|(wphillipmoore/standard-actions/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g" "$f"
+              rm -f "$f.bak"
+              rewrote=$((rewrote + 1))
+            fi
+          done
+          echo "Rewrote internal @develop refs in ${rewrote} file(s)"
+          if [ "${rewrote}" -gt 0 ]; then
+            git add .github/workflows actions
+            git commit -m "chore(release): freeze internal refs to ${RELEASE_TAG}"
+          fi
+
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
         uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@develop


### PR DESCRIPTION
# Pull Request

## Summary

- Freeze internal @develop refs at tag-cut time

## Issue Linkage

- Closes #211

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Adds a step to publish.yml (the standard-actions self-publish workflow) that rewrites every wphillipmoore/standard-actions/...@develop ref in the working tree to the new release tag, then commits the rewrite locally before tagging. The rewrite commit is reachable only via the tag — never pushed to develop or main. Day-to-day work on develop continues to use the floating @develop form. Consumers pinning ci-security.yml@vX.Y.Z (or @vX.Y rolling) get a tagged snapshot whose internal action refs all resolve to the same vX.Y.Z. Refs explicitly pinned to a prior version (@v1.1, @v1.2, etc.) are left untouched. Verified the rewrite pattern locally against current standard-actions and against mq-rest-admin-dev-environment publish.yml (which has @v1.1 refs that should not be touched). Issue #211 carries the full design rationale, including why caller-passed-tag arguments do not work (uses: cannot accept expressions in the @ref portion).