### PR TITLE
fix(publish): use App token throughout publish.yml so freeze-refs commit can be pushed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,22 @@ jobs:
     name: "publish: release"
     runs-on: ubuntu-latest
     steps:
+      # Generate the App token first so checkout can use it. The freeze-
+      # internal-refs step below modifies .github/workflows/*.yml, and
+      # GITHUB_TOKEN is forbidden from pushing workflow-file changes.
+      # The App (APP_ID/APP_PRIVATE_KEY) has workflows:write granted.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract version
         id: version
@@ -80,14 +92,6 @@ jobs:
             ## standard-actions v${{ steps.version.outputs.version }}
 
             Shared GitHub Actions for all managed repositories.
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'


### PR DESCRIPTION
# Pull Request

## Summary

- Use App token throughout publish.yml so freeze-refs commit can be pushed

## Issue Linkage

- Closes #217

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- publish.yml's freeze-internal-refs step (#211/#212) modifies workflow files. GITHUB_TOKEN is forbidden from pushing workflow-file changes (platform-level rule, not overridable via the permissions block). Switches to the existing GitHub App token, which has workflows:write granted, for the whole job: app-token generated first, passed to actions/checkout, reused by the existing version-bump-pr step. Removed the now-duplicate later token-generation step. The standard-actions v1.3.0 release is currently half-completed — main has VERSION=1.3.0 but no tag because the freeze-refs step in #212 succeeded but the subsequent tag push was rejected. Once this lands and reaches main, publish.yml will retry, the freeze step rewrites again (idempotent), tag push now succeeds with the App token. See tracking issue #215 for the half-released state.