### PR TITLE
feat(security/trivy): print findings table to stdout in addition to SARIF

### DIFF
--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -53,23 +53,56 @@ runs:
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'
       shell: bash
+      env:
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+        SCAN_REF: ${{ inputs.scan-ref }}
+        SCANNERS: ${{ inputs.scanners }}
+        SEVERITY: ${{ inputs.severity }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
         TRIVYIGNORE_ARGS=""
-        if [ -n "${{ inputs.trivyignores }}" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile ${{ inputs.trivyignores }}"
+        if [ -n "$TRIVYIGNORES" ]; then
+          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
         fi
+        # Single docker session: scan once to JSON, then convert to both
+        # table (stdout, never gates) and SARIF (file, gates per input).
+        # `trivy convert` operates on the cached JSON — no re-scan, no
+        # extra DB download, no extra vuln matching.
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/workspace" \
           -w /workspace \
-          "${{ inputs.trivy-image }}" \
-          fs \
-          --scanners "${{ inputs.scanners }}" \
-          --severity "${{ inputs.severity }}" \
-          --exit-code "${{ inputs.exit-code }}" \
-          --format sarif \
-          --output "/workspace/${{ inputs.output-file }}" \
-          $TRIVYIGNORE_ARGS \
-          "${{ inputs.scan-ref }}"
+          -e SCANNERS \
+          -e SEVERITY \
+          -e EXIT_CODE \
+          -e OUTPUT_FILE \
+          -e SCAN_REF \
+          -e TRIVYIGNORE_ARGS \
+          --entrypoint sh \
+          "$TRIVY_IMAGE" \
+          -c '
+            set -e
+            trivy fs \
+              --scanners "$SCANNERS" \
+              --severity "$SEVERITY" \
+              --exit-code 0 \
+              --format json \
+              --output /tmp/trivy-raw.json \
+              $TRIVYIGNORE_ARGS \
+              "$SCAN_REF"
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format table \
+              --exit-code 0 \
+              /tmp/trivy-raw.json
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format sarif \
+              --exit-code "$EXIT_CODE" \
+              --output "/workspace/$OUTPUT_FILE" \
+              /tmp/trivy-raw.json
+          '
 
     - name: Upload SARIF (filesystem scan)
       if: inputs.scan-type == 'fs' && always()
@@ -81,24 +114,57 @@ runs:
     - name: Run Trivy image scan
       if: inputs.scan-type == 'image'
       shell: bash
+      env:
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+        SCAN_REF: ${{ inputs.scan-ref }}
+        SCANNERS: ${{ inputs.scanners }}
+        SEVERITY: ${{ inputs.severity }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
         TRIVYIGNORE_ARGS=""
-        if [ -n "${{ inputs.trivyignores }}" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile ${{ inputs.trivyignores }}"
+        if [ -n "$TRIVYIGNORES" ]; then
+          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
         fi
+        # Single docker session: scan once to JSON, then convert to both
+        # table (stdout, never gates) and SARIF (file, gates per input).
+        # `trivy convert` operates on the cached JSON — no re-scan, no
+        # extra DB download, no extra vuln matching.
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/workspace" \
           -v /var/run/docker.sock:/var/run/docker.sock \
           -w /workspace \
-          "${{ inputs.trivy-image }}" \
-          image \
-          --scanners "${{ inputs.scanners }}" \
-          --severity "${{ inputs.severity }}" \
-          --exit-code "${{ inputs.exit-code }}" \
-          --format sarif \
-          --output "/workspace/${{ inputs.output-file }}" \
-          $TRIVYIGNORE_ARGS \
-          "${{ inputs.scan-ref }}"
+          -e SCANNERS \
+          -e SEVERITY \
+          -e EXIT_CODE \
+          -e OUTPUT_FILE \
+          -e SCAN_REF \
+          -e TRIVYIGNORE_ARGS \
+          --entrypoint sh \
+          "$TRIVY_IMAGE" \
+          -c '
+            set -e
+            trivy image \
+              --scanners "$SCANNERS" \
+              --severity "$SEVERITY" \
+              --exit-code 0 \
+              --format json \
+              --output /tmp/trivy-raw.json \
+              $TRIVYIGNORE_ARGS \
+              "$SCAN_REF"
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format table \
+              --exit-code 0 \
+              /tmp/trivy-raw.json
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format sarif \
+              --exit-code "$EXIT_CODE" \
+              --output "/workspace/$OUTPUT_FILE" \
+              /tmp/trivy-raw.json
+          '
 
     - name: Upload SARIF (image scan)
       if: inputs.scan-type == 'image' && always()


### PR DESCRIPTION
# Pull Request

## Summary

- Print Trivy findings table to stdout alongside SARIF

## Issue Linkage

- Closes #210

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Two-pass invocation: first pass renders --format table to stdout with --exit-code 0 (informative only); second pass renders SARIF for Code Scanning upload with the configured --exit-code (gates as before). Applies to fs and image scan modes; SBOM mode unaffected. Cost: one extra Trivy DB download per scan; cheap relative to the triage time saved when a gate fails. Trivy version unchanged at 0.69.2. Existing callers (standard-tooling-docker docker-publish.yml × 2 jobs, plus any standard-actions-internal callers) are transparent — same inputs, just more output.