### PR TITLE
fix(publish/version-bump-pr): use Issues API instead of Search API for tracking-issue lookup

### DIFF
--- a/actions/publish/version-bump-pr/action.yml
+++ b/actions/publish/version-bump-pr/action.yml
@@ -180,10 +180,16 @@ runs:
           echo "Using explicit tracking-issue input: #${issue}"
         else
           echo "Searching for issue titled \"release: ${{ inputs.current-version }}\"..."
+          # Use the Issues API (real-time) with a client-side title filter,
+          # not the Search API (--search), which has indexing latency. The
+          # tracking issue is typically created seconds before this step
+          # runs, so it may not be in the search index yet.
           issue=$(gh issue list \
             --state all \
-            --search "release: ${{ inputs.current-version }} in:title" \
-            --json number --jq '.[0].number // empty') || true
+            --limit 200 \
+            --json number,title \
+            --jq ".[] | select(.title == \"release: ${{ inputs.current-version }}\") | .number" \
+            | head -1) || true
           if [ -n "$issue" ]; then
             echo "Found tracking issue: #${issue}"
           else


### PR DESCRIPTION
# Pull Request

## Summary

- Fix version-bump-pr tracking-issue lookup race

## Issue Linkage

- Closes #225

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- RCA in issue #225. Same shape of bug surfaced on every prior release: v1.3.0's bump PR (#220) silently shipped with bogus Ref #0 because an earlier action template defaulted to that on missing input. v1.3.1's bump PR (#224) failed CI outright after the template was tightened. This fix closes the race.