### PR TITLE
chore(trivy): bump aquasec/trivy from 0.69.2 to 0.70.0

### DIFF
--- a/actions/security/trivy/action.yml
+++ b/actions/security/trivy/action.yml
@@ -45,7 +45,7 @@ inputs:
     description: >-
       Docker image to use for Trivy. Override to pin a specific version.
     required: false
-    default: "aquasec/trivy:0.69.2"
+    default: "aquasec/trivy:0.70.0"
 
 runs:
   using: composite


### PR DESCRIPTION
# Pull Request

## Summary

- Bump Trivy Docker image default from 0.69.2 to 0.70.0

## Issue Linkage

- Fixes #234

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -