### PR TITLE
chore(deps): bump CI action pins: create-github-app-token v3, attest-build-provenance v4

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -280,7 +280,7 @@ jobs:
         if: >-
           steps.tag_check.outputs.exists == 'false' &&
           inputs.attestation-subject-path != ''
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ inputs.attestation-subject-path }}
 
@@ -348,7 +348,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       # The App (APP_ID/APP_PRIVATE_KEY) has workflows:write granted.
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
# Pull Request

## Summary

- Bump create-github-app-token v2 to v3 and attest-build-provenance v3 to v4

## Issue Linkage

- Ref #240

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -