### PR TITLE
chore(docs): align local validation with container-based st-docker-run workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,20 +98,21 @@ git config core.hooksPath .githooks  # Enable the pre-commit gate
 ```
 
 Standard-tooling CLI tools (`st-commit`, `st-validate-local`, etc.) are
-pre-installed in the dev container images. No local setup required.
+pre-installed in the dev container images. No local setup required beyond
+the host-level tool (`st-docker-run`, `st-commit`, etc.):
 
-Additional tools required:
+```bash
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
+```
 
-- **markdownlint**: `npm install --global markdownlint-cli`
-- **mkdocs-material**: `pip install mkdocs-material`
-- **mike**: `pip install mike`
-- **actionlint**: `brew install actionlint`
-- **shellcheck**: `brew install shellcheck`
+All validation tools (yamllint, shellcheck, actionlint, markdownlint, etc.)
+run inside the `ghcr.io/wphillipmoore/dev-base:latest` container — no manual
+host installs needed.
 
 ### Validation
 
 ```bash
-st-validate-local    # Canonical validation (dispatches to common + custom checks)
+st-docker-run -- st-validate-local   # Canonical validation (runs in dev-base container)
 ```
 
 ## Architecture
@@ -132,15 +133,11 @@ This repository's CI workflow uses **local paths** (`./actions/...`) rather than
 
 ### Standard-Tooling Integration
 
-Shared validators (`st-repo-profile`, `st-markdown-standards`, `st-pr-issue-linkage`) are provided by `standard-tooling`. CI uses the dev container image's pre-baked install (non-Python consumers like this one). Locally, install the host tool per the [host-level-tool spec](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/host-level-tool.md):
-
-```bash
-uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
-# or, for the alternative pip-based path:
-pip install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
-```
-
-The `standards-compliance` action no longer clones `standard-tooling` onto the runner — it assumes `st-*` is on `PATH` either via the dev container pre-bake (non-Python) or `uv sync --group dev` (Python).
+Shared validators (`st-repo-profile`, `st-markdown-standards`,
+`st-pr-issue-linkage`) are provided by `standard-tooling`. CI uses the
+`ghcr.io/wphillipmoore/dev-base:latest` container image which has all
+validators pre-installed. Locally, `st-docker-run` uses the same image so
+validation results match CI exactly.
 
 ### Repo-Specific Scripts
 

--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -4,15 +4,9 @@
 > [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/environment-and-tooling/).
 > It is retained for backward compatibility.
 
-## Table of Contents
+## Host prerequisites
 
-- [Purpose](#purpose)
-- [External tooling dependencies](#external-tooling-dependencies)
-
-## Purpose
-
-Define the minimal external tooling required for development and validation.
-
-## External tooling dependencies
+Install the standard-tooling host tool and ensure Docker is running. All
+other tools run inside the dev-base container via `st-docker-run`.
 
 See [tooling-dependencies.md](tooling-dependencies.md).

--- a/docs/development/tooling-dependencies.md
+++ b/docs/development/tooling-dependencies.md
@@ -4,17 +4,8 @@
 > [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/environment-and-tooling/).
 > It is retained for backward compatibility.
 
-## Table of Contents
-
-- [Purpose](#purpose)
-- [Required tools](#required-tools)
-
-## Purpose
-
-List external tools required for validation and daily workflow.
-
 ## Required tools
 
-- `actionlint`
-- `shellcheck`
-- `markdownlint`
+All validation tools (actionlint, shellcheck, markdownlint, yamllint) are
+pre-installed in the `ghcr.io/wphillipmoore/dev-base:latest` container image
+and run via `st-docker-run`. No manual host installs needed.

--- a/docs/development/validation.md
+++ b/docs/development/validation.md
@@ -4,23 +4,11 @@
 > [MkDocs documentation site](https://wphillipmoore.github.io/standard-actions/development/validation/).
 > It is retained for backward compatibility.
 
-## Table of Contents
+## Canonical command
 
-- [Purpose](#purpose)
-- [Canonical commands](#canonical-commands)
-- [Tooling dependencies](#tooling-dependencies)
+```bash
+st-docker-run -- st-validate-local
+```
 
-## Purpose
-
-Define the required local validation commands for this repository.
-
-## Canonical commands
-
-- Full validation: `scripts/dev/validate_local.sh`
-- Docs-only validation: `scripts/dev/validate_docs.sh`
-
-## Tooling dependencies
-
-- `actionlint`
-- `shellcheck`
-- `markdownlint`
+All validation tools run inside the dev-base container image. No manual
+host installs needed beyond the standard-tooling host tool.

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -5,41 +5,33 @@
 Configure the repository to use the shared git hooks:
 
 ```bash
-git config core.hooksPath scripts/git-hooks
+git config core.hooksPath .githooks
 ```
 
 This enables the pre-commit hook that prevents direct commits to protected
 branches (`main`, `develop`).
 
-## External tooling
+## Host prerequisites
 
-The following tools are required for local development and validation:
-
-### Validation tools
-
-| Tool | Install command | Purpose |
-| ------ | ---------------- | --------- |
-| `actionlint` | `brew install actionlint` | GitHub Actions workflow linter |
-| `shellcheck` | `brew install shellcheck` | Shell script static analysis |
-| `markdownlint` | `npm install --global markdownlint-cli` | Markdown formatting linter |
-
-### Documentation tools
-
-| Tool | Install command | Purpose |
-| ------ | ---------------- | --------- |
-| `mkdocs-material` | `pip install mkdocs-material` | MkDocs with Material theme |
-| `mike` | `pip install mike` | Versioned documentation deployment |
-
-### Local documentation preview
-
-To preview the documentation site locally:
+Install the standard-tooling host tool, which provides `st-docker-run`,
+`st-commit`, `st-validate-local`, and other workflow commands:
 
 ```bash
-mkdocs serve -f docs/site/mkdocs.yml
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
 ```
 
-To verify the build with strict mode (catches broken links and warnings):
+Docker must be running for `st-docker-run` to work.
+
+## Validation and development tools
+
+All validation tools (actionlint, shellcheck, markdownlint, yamllint) and
+documentation tools (mkdocs-material, mike) are pre-installed in the
+`ghcr.io/wphillipmoore/dev-base:latest` container image. No manual host
+installs are needed — `st-docker-run` pulls and runs this image
+automatically.
 
 ```bash
-mkdocs build -f docs/site/mkdocs.yml --strict
+st-docker-run -- st-validate-local       # Run all validation checks
+st-docker-run -- mkdocs serve -f docs/site/mkdocs.yml   # Preview docs locally
+st-docker-run -- mkdocs build -f docs/site/mkdocs.yml --strict  # Strict docs build
 ```

--- a/docs/site/docs/development/validation.md
+++ b/docs/site/docs/development/validation.md
@@ -3,44 +3,32 @@
 ## Canonical command
 
 ```bash
-scripts/dev/validate_local.sh
+st-docker-run -- st-validate-local
 ```
 
-This is the single entry point for all local validation. Run it before
-committing to catch issues early.
+This runs all validation inside the `ghcr.io/wphillipmoore/dev-base:latest`
+container, which has every required tool pre-installed. No manual host
+installs needed beyond the standard-tooling host tool.
 
 ## Dispatch architecture
 
-`validate_local.sh` uses a dispatch architecture that separates common
-validation (shared across repositories) from repository-specific checks:
+`st-validate-local` uses a dispatch architecture that separates common
+validation from repository-specific checks:
 
-1. **Common checks** — Sourced from `standard-tooling` via the sync mechanism.
-   These include markdownlint, shellcheck, and other universal validations.
-2. **Custom checks** — Repository-specific validations defined locally, such as
-   actionlint for this repository's workflow files.
+1. **Common checks** (`st-validate-local-common`) — repo-profile validation,
+   markdown standards, shellcheck, and yamllint.
+2. **Custom checks** (`scripts/bin/validate-local-custom`) — repository-specific
+   validations defined locally (actionlint for this repository's workflow files).
 
-The `standard-tooling` package provides the common validation scripts via
-`st-*` CLI commands. The `standards-compliance` action checks script freshness
-in CI to ensure local copies stay in sync with the canonical versions.
+## Tooling
 
-## Docs-only validation
+All validation tools are pre-installed in the dev-base container image:
 
-For changes that only affect documentation:
+| Tool | Purpose |
+| --- | --- |
+| `actionlint` | GitHub Actions workflow linter |
+| `shellcheck` | Shell script static analysis |
+| `markdownlint` | Markdown formatting linter |
+| `yamllint` | YAML formatting linter |
 
-```bash
-scripts/dev/validate_docs.sh
-```
-
-This runs a subset of checks relevant to documentation changes (primarily
-markdownlint).
-
-## Tooling dependencies
-
-Validation requires the following tools to be installed:
-
-- `actionlint` — GitHub Actions workflow linting
-- `shellcheck` — Shell script static analysis
-- `markdownlint` — Markdown formatting
-
-See [Environment and Tooling](environment-and-tooling.md) for installation
-instructions.
+No host-level installs of these tools are required.


### PR DESCRIPTION
# Pull Request

## Summary

- Replace manual host-install prerequisites with st-docker-run container-based validation

## Issue Linkage

- Fixes #236

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -