### PR TITLE
chore: bootstrap st-config.toml

### DIFF
--- a/st-config.toml
+++ b/st-config.toml
@@ -1,0 +1,2 @@
+[standard-tooling]
+tag = "v1.4"


### PR DESCRIPTION
Ref wphillipmoore/standard-tooling#362

Adds `st-config.toml` declaring the standard-tooling version tag for the
cache-first `st-docker-run` workflow. This file tells `st-docker-run` which
standard-tooling version to install when building per-branch dev container
images, decoupling consuming repos from pre-baked dev container images.

Part of the standard-tooling v1.4 cache-first architecture rollout.
