### PR TITLE
fix(ci): install standard-tooling in standards-compliance job (#255)

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -43,6 +43,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        shell: bash
+        run: |
+          if command -v st-repo-profile >/dev/null 2>&1; then
+            echo "standard-tooling already on PATH"
+            exit 0
+          fi
+          if [ "${{ inputs.language }}" = "python" ]; then
+            uv sync --group dev --frozen
+            echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          else
+            TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
+            if [ -z "$TAG" ]; then
+              echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+              exit 1
+            fi
+            pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+          fi
+
       - name: Validate standards
         uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        shell: bash
+        run: |
+          if command -v st-repo-profile >/dev/null 2>&1; then
+            echo "standard-tooling already on PATH"
+            exit 0
+          fi
+          TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
+          if [ -z "$TAG" ]; then
+            echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+            exit 1
+          fi
+          pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+
       - name: Validate standards
         uses: ./actions/standards-compliance
 

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -2,12 +2,10 @@ name: Standards compliance
 description: >-
   Validates repository standards: markdown formatting, PR issue
   linkage, and repository profile. Assumes standard-tooling is on
-  PATH — either via the dev container image's pre-baked install
-  (non-Python consumers) or via the consumer's own
-  `uv sync --group dev` (Python consumers, per the host-level-tool
-  spec at wphillipmoore/standard-tooling docs/specs/host-level-tool.md).
-  The verification step below catches setups where neither path is in
-  effect.
+  PATH — the ci-security workflow installs it before calling this
+  action (uv sync for Python repos, pip install from st-config.toml
+  for non-Python repos). The verification step below catches setups
+  where the install did not run.
 
 runs:
   using: composite
@@ -18,10 +16,10 @@ runs:
         if ! command -v st-repo-profile >/dev/null 2>&1; then
           {
             echo "::error::st-repo-profile not found on PATH."
-            echo "Either run inside a dev container image with"
-            echo "standard-tooling pre-baked (non-Python consumers),"
-            echo "or run after 'uv sync --group dev' so the project's"
-            echo ".venv/bin is on PATH (Python consumers)."
+            echo "The ci-security workflow should install standard-tooling"
+            echo "before this action runs. For Python repos it runs"
+            echo "'uv sync --group dev'; for non-Python repos it reads"
+            echo "st-config.toml and pip-installs the pinned version."
             echo "See wphillipmoore/standard-tooling"
             echo "docs/specs/host-level-tool.md."
           }


### PR DESCRIPTION
# Pull Request

## Summary

- install standard-tooling in ci-security standards-compliance job

## Issue Linkage

- Ref #255

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## Summary

- Add install step to standards-compliance job in ci-security.yml
- Python repos: `uv sync --group dev --frozen` (uses lockfile-pinned version)
- Non-Python repos: pip install from `st-config.toml` tag
- Update action description and error message to reflect new install model

## Issue Linkage

- Ref #255

## Testing

- actionlint passes on modified workflow
- CI will self-test: this repo's own standards-compliance job uses the updated workflow

## Notes

- The dev-base container image no longer ships standard-tooling pre-baked
  (standard-tooling-docker#95). This fix restores the install at CI time
  using the correct version source for each language ecosystem.