### PR TITLE
refactor(standards-compliance): slim to PR-only checks, remove repo-profile and markdown validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ st-docker-run -- st-validate-local   # Canonical validation (runs in dev-base co
 
 All actions live under `actions/` as composite GitHub Actions:
 
-- `actions/standards-compliance` — Validates repo profile, markdown, PR linkage, and rejects auto-close keywords (delegates to standard-tooling validators via PATH)
+- `actions/standards-compliance` — PR-specific compliance checks: issue linkage and auto-close keyword rejection
 - `actions/python/setup` — Python environment setup with uv and caching
 - `actions/security/codeql` — CodeQL static analysis
 - `actions/security/semgrep` — Semgrep SAST scanning
@@ -133,9 +133,9 @@ This repository's CI workflow uses **local paths** (`./actions/...`) rather than
 
 ### Standard-Tooling Integration
 
-Shared validators (`st-repo-profile`, `st-markdown-standards`,
-`st-pr-issue-linkage`) are provided by `standard-tooling`. CI uses the
-`ghcr.io/wphillipmoore/dev-base:latest` container image which has all
+Shared validators (`st-repo-profile`, `st-pr-issue-linkage`) and local
+validation (`st-validate-local`) are provided by `standard-tooling`. CI uses
+the `ghcr.io/wphillipmoore/dev-base:latest` container image which has all
 validators pre-installed. Locally, `st-docker-run` uses the same image so
 validation results match CI exactly.
 

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -1,39 +1,13 @@
 name: Standards compliance
 description: >-
-  Validates repository standards: markdown formatting, PR issue
-  linkage, and repository profile. Assumes standard-tooling is on
-  PATH — the ci-security workflow installs it before calling this
-  action (uv sync for Python repos, pip install from st-config.toml
-  for non-Python repos). The verification step below catches setups
-  where the install did not run.
+  PR-specific compliance checks: issue linkage and auto-close keyword
+  rejection. Repository profile, markdown, and other structural
+  validations are handled by st-validate-local-common (run separately
+  in the CI workflow).
 
 runs:
   using: composite
   steps:
-    - name: Verify standard-tooling is installed
-      shell: bash
-      run: |
-        if ! command -v st-repo-profile >/dev/null 2>&1; then
-          {
-            echo "::error::st-repo-profile not found on PATH."
-            echo "The ci-security workflow should install standard-tooling"
-            echo "before this action runs. For Python repos it runs"
-            echo "'uv sync --group dev'; for non-Python repos it reads"
-            echo "st-config.toml and pip-installs the pinned version."
-            echo "See wphillipmoore/standard-tooling"
-            echo "docs/specs/host-level-tool.md."
-          }
-          exit 1
-        fi
-
-    - name: Validate repository profile
-      shell: bash
-      run: st-repo-profile
-
-    - name: Validate markdown standards
-      shell: bash
-      run: st-markdown-standards
-
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'
       shell: bash

--- a/docs/site/docs/actions/index.md
+++ b/docs/site/docs/actions/index.md
@@ -8,9 +8,8 @@ supporting scripts.
 
 ### CI & Validation
 
-- **[standards-compliance](standards-compliance.md)** — Validates repository
-  standards: markdown, PR linkage, auto-close keyword rejection, and repository
-  profile.
+- **[standards-compliance](standards-compliance.md)** — PR-specific compliance
+  checks: issue linkage and auto-close keyword rejection.
 
 ### Documentation
 

--- a/docs/site/docs/actions/standards-compliance.md
+++ b/docs/site/docs/actions/standards-compliance.md
@@ -1,7 +1,8 @@
 # standards-compliance
 
-Validates repository standards: markdown formatting, PR issue linkage,
-auto-close keyword rejection, and repository profile.
+PR-specific compliance checks: issue linkage and auto-close keyword rejection.
+Repository profile, markdown, and other structural validations are handled by
+`st-validate-local-common` (run separately in the CI workflow).
 
 ## Usage
 
@@ -19,22 +20,14 @@ None. The action has no configurable inputs.
 
 ## Behavior
 
-The action delegates to standard-tooling CLI validators that must be on PATH.
-This is satisfied either by the dev container image (non-Python consumers) or
-by the consumer's own `uv sync --group dev` (Python consumers).
-
-1. **Verify standard-tooling is installed** — Checks that `st-repo-profile` is
-   available on PATH. Fails with a diagnostic message if not found.
-2. **Validate repository profile** — Runs `st-repo-profile` to check required
-   repository metadata.
-3. **Validate markdown standards** — Runs `st-markdown-standards` to lint
-   markdown files.
-4. **Validate PR issue linkage** — On pull requests, runs `st-pr-issue-linkage`
+1. **Validate PR issue linkage** — On pull requests, runs `st-pr-issue-linkage`
    to verify the PR body references a GitHub issue.
-5. **Reject auto-close linkage keywords** — On pull requests, inspects the PR
+2. **Reject auto-close linkage keywords** — On pull requests, inspects the PR
    body for `Fixes`, `Closes`, or `Resolves` keywords targeting an issue
    reference. These keywords are rejected because auto-closing bypasses the
    `st-finalize-repo` workflow. Use `Ref #N` instead.
+
+Both steps only run on `pull_request` events.
 
 ## Examples
 
@@ -49,8 +42,5 @@ by the consumer's own `uv sync --group dev` (Python consumers).
 
 ## GitHub configuration
 
-- **Repository profile** — The repo must contain the files checked by
-  `st-repo-profile` (typically `README.md`, `LICENSE`, `VERSION`, and standard
-  documentation files).
 - **Branch protection** — Recommended: require this check to pass on `develop`
   and `main` branches.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -12,7 +12,7 @@ across all managed repositories.
 
 | Category | Actions | Purpose |
 | ---------- | --------- | --------- |
-| CI & Validation | [standards-compliance](actions/standards-compliance.md) | PR validation and standards enforcement |
+| CI & Validation | [standards-compliance](actions/standards-compliance.md) | PR issue linkage and auto-close keyword rejection |
 | Documentation | [docs-deploy](actions/docs-deploy.md) | MkDocs Material + mike versioned deployment |
 | Python | [python/setup](actions/python-setup.md) | Python environment with uv and caching |
 | Security | [security/codeql](actions/security-codeql.md), [security/semgrep](actions/security-semgrep.md), [security/trivy](actions/security-trivy.md) | SAST and vulnerability scanning |


### PR DESCRIPTION
# Pull Request

## Summary

- Slim standards-compliance to PR-only checks, removing repo-profile and markdown validation that are now handled by st-validate-local-common

## Issue Linkage

- Ref #260

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -