### PR TITLE
fix(standards-compliance): self-install standard-tooling when not on PATH

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -53,7 +53,8 @@ jobs:
           if [ "${{ inputs.language }}" = "python" ]; then
             uv sync --group dev --frozen
             echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          else
+          fi
+          if ! command -v st-repo-profile >/dev/null 2>&1; then
             TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
             if [ -z "$TAG" ]; then
               echo "::error::st-config.toml not found or missing [standard-tooling] tag"

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -8,6 +8,21 @@ description: >-
 runs:
   using: composite
   steps:
+    - name: Ensure standard-tooling is available
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        if command -v st-pr-issue-linkage >/dev/null 2>&1; then
+          echo "st-pr-issue-linkage already on PATH"
+          exit 0
+        fi
+        TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
+        if [ -z "$TAG" ]; then
+          echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+          exit 1
+        fi
+        pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'
       shell: bash

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,0 +1,13 @@
+[project]
+repository-type = "library"
+versioning-scheme = "library"
+branching-model = "library-release"
+release-model = "artifact-publishing"
+primary-language = "shell"
+
+[project.co-authors]
+claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
+codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+
+[dependencies]
+standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- The standards-compliance composite action calls st-pr-issue-linkage directly, assuming the command is on PATH. This fails in repos where standard-tooling is not pre-installed in the container or via uv sync.

Changes:
- Add a self-install step to the standards-compliance action that installs standard-tooling from st-config.toml when st-pr-issue-linkage is not on PATH
- Fix ci-security.yml install step to fall back to pip install when uv sync (for Python repos) doesn't provide standard-tooling
- Add standard-tooling.toml for TOML-based project config (enables st-commit and other tooling)

## Issue Linkage

- Ref #267

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -