### PR TITLE
chore: strip config sections from repository-standards.md

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -2,24 +2,8 @@
 
 ## Table of Contents
 
-- [Repository profile](#repository-profile)
-- [AI co-authors](#ai-co-authors)
 - [Local references](#local-references)
 - [Local deviations](#local-deviations)
-
-## Repository profile
-
-- repository_type: library
-- versioning_scheme: library
-- branching_model: library-release
-- release_model: artifact-publishing
-- supported_release_lines: 1.x
-- primary_language: shell
-
-## AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
 
 ## Local references
 


### PR DESCRIPTION
# Pull Request

## Summary

- Strip Repository profile and AI co-authors sections from repository-standards.md — values now in standard-tooling.toml

## Issue Linkage

- Ref #273

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -