### PR TITLE
chore: read version tag from standard-tooling.toml with st-config.toml fallback

### DIFF
--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -16,9 +16,13 @@ runs:
           echo "st-pr-issue-linkage already on PATH"
           exit 0
         fi
-        TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
-        if [ -z "$TAG" ]; then
-          echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+        if [ -f standard-tooling.toml ]; then
+          TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+        elif [ -f st-config.toml ]; then
+          TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
+        fi
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::standard-tooling.toml (or st-config.toml) not found or missing version tag"
           exit 1
         fi
         pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate the standards-compliance action to read the standard-tooling version tag from standard-tooling.toml ([dependencies] section) first, falling back to st-config.toml for backward compatibility during the fleet-wide migration (standard-tooling#363).

## Issue Linkage

- Ref #275

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -