### PR TITLE
chore: migrate ci-security.yml install step to standard-tooling.toml

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -52,12 +52,17 @@ jobs:
           fi
           if [ "${{ inputs.language }}" = "python" ]; then
             uv sync --group dev --frozen
+            export PATH="$PWD/.venv/bin:$PATH"
             echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
           fi
           if ! command -v st-repo-profile >/dev/null 2>&1; then
-            TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
-            if [ -z "$TAG" ]; then
-              echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+            if [ -f standard-tooling.toml ]; then
+              TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+            elif [ -f st-config.toml ]; then
+              TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
+            fi
+            if [ -z "${TAG:-}" ]; then
+              echo "::error::standard-tooling.toml (or st-config.toml) not found or missing version tag"
               exit 1
             fi
             pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate ci-security.yml install step: read version tag from standard-tooling.toml (with st-config.toml fallback), and fix Python PATH export so st-repo-profile is found within the same step.

## Issue Linkage

- Ref #280

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -