### PR TITLE
chore: remove legacy st-config.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
             echo "standard-tooling already on PATH"
             exit 0
           fi
-          TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
-          if [ -z "$TAG" ]; then
-            echo "::error::st-config.toml not found or missing [standard-tooling] tag"
+          if [ -f standard-tooling.toml ]; then
+            TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+          fi
+          if [ -z "${TAG:-}" ]; then
+            echo "::error::standard-tooling.toml not found or missing [dependencies] standard-tooling tag"
             exit 1
           fi
           pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"

--- a/st-config.toml
+++ b/st-config.toml
@@ -1,2 +1,0 @@
-[standard-tooling]
-tag = "v1.4"


### PR DESCRIPTION
## Summary

- Remove `st-config.toml` — superseded by `standard-tooling.toml` which is already present in this repo.

Ref wphillipmoore/standard-tooling#363
