### PR TITLE
refactor: replace pip install with uv tool install and remove guard patterns

### DIFF
--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -16,8 +16,8 @@ inputs:
   mike-command:
     description: >-
       Command to run mike. Set to "uv run mike" for Python repos that
-      manage their own dependencies. When not "mike", the action skips
-      Python setup and MkDocs installation.
+      manage their own dependencies. When set to "uv run mike", the
+      action skips MkDocs/mike installation (the repo provides them).
     required: false
     default: mike
   checkout-common:
@@ -40,31 +40,10 @@ runs:
         ref: ${{ inputs.checkout-common-ref }}
         path: .mq-rest-admin-common
 
-    - name: Detect pre-installed tools
-      id: detect
-      shell: bash
-      run: |
-        if command -v mike >/dev/null 2>&1; then
-          echo "mike-installed=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "mike-installed=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Set up Python 3.12
-      if: inputs.mike-command == 'mike' && steps.detect.outputs.mike-installed == 'false'
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.12"
-
     - name: Install MkDocs and mike
-      if: inputs.mike-command == 'mike' && steps.detect.outputs.mike-installed == 'false'
+      if: inputs.mike-command == 'mike'
       shell: bash
-      run: pip install mkdocs-material mike
-
-    - name: Install pyyaml for nav patching
-      if: inputs.mike-command != 'mike' && steps.detect.outputs.mike-installed == 'false'
-      shell: bash
-      run: pip install pyyaml
+      run: uv tool install mike --with mkdocs-material
 
     - name: Configure git identity
       shell: bash
@@ -165,7 +144,7 @@ runs:
 
         # Inlined for the same reason as the index-generation script
         # above (see issue #204).
-        python3 - "${{ inputs.mkdocs-config }}" "$DOCS_DIR" <<'PY'
+        uv run --with pyyaml python3 - "${{ inputs.mkdocs-config }}" "$DOCS_DIR" <<'PY'
         """Patch mkdocs.yml nav to inject release version entries under Release Notes."""
         import pathlib
         import re

--- a/actions/security/semgrep/action.yml
+++ b/actions/security/semgrep/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Install Semgrep
       shell: bash
-      run: pip install semgrep
+      run: uv tool install semgrep
 
     - name: Run Semgrep scan
       shell: bash

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -8,24 +8,16 @@ description: >-
 runs:
   using: composite
   steps:
-    - name: Ensure standard-tooling is available
+    - name: Install standard-tooling
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        if command -v st-pr-issue-linkage >/dev/null 2>&1; then
-          echo "st-pr-issue-linkage already on PATH"
-          exit 0
-        fi
-        if [ -f standard-tooling.toml ]; then
-          TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
-        elif [ -f st-config.toml ]; then
-          TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
-        fi
+        TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
         if [ -z "${TAG:-}" ]; then
-          echo "::error::standard-tooling.toml (or st-config.toml) not found or missing version tag"
+          echo "::error::standard-tooling.toml not found or missing version tag"
           exit 1
         fi
-        pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+        uv tool install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
 
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Pull Request

## Summary

- Replace pip install with uv tool install and remove guard patterns across composite actions

## Issue Linkage

- Ref #287

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -