### PR TITLE
docs: comprehensive doc-site review for v1.5.0 reusable-workflow redesign

### DIFF
--- a/docs/site/docs/actions/docs-deploy.md
+++ b/docs/site/docs/actions/docs-deploy.md
@@ -6,7 +6,7 @@ git configuration, version detection, and mike deploy/set-default.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+- uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
   with:
     version-command: cat VERSION | cut -d. -f1,2
     mkdocs-config: docs/site/mkdocs.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+      - uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
         with:
           version-command: cat VERSION | cut -d. -f1,2
 ```
@@ -71,7 +71,7 @@ jobs:
 ### Python repo with uv-managed dependencies
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+- uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
   with:
     version-command: cat VERSION | cut -d. -f1,2
     mike-command: uv run mike

--- a/docs/site/docs/actions/publish-tag-and-release.md
+++ b/docs/site/docs/actions/publish-tag-and-release.md
@@ -7,7 +7,7 @@ action safe to re-run.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.5
   with:
     version: "1.2.3"
     release-title: mqrestadmin
@@ -62,7 +62,7 @@ action safe to re-run.
 ### Standard library release
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.5
   with:
     version: ${{ steps.version.outputs.version }}
     release-title: mqrestadmin
@@ -72,7 +72,7 @@ action safe to re-run.
 ### Release with build artifacts
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.5
   with:
     version: "2.0.0"
     release-title: myapp

--- a/docs/site/docs/actions/publish-version-bump-pr.md
+++ b/docs/site/docs/actions/publish-version-bump-pr.md
@@ -11,7 +11,7 @@ via `st-merge-when-green` from a release skill).
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.5
   with:
     current-version: "1.2.3"
     version-file: VERSION
@@ -81,7 +81,7 @@ via `st-merge-when-green` from a release skill).
 ### Simple VERSION file bump
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.5
   with:
     current-version: ${{ steps.release.outputs.version }}
     version-file: VERSION
@@ -94,7 +94,7 @@ via `st-merge-when-green` from a release skill).
 ### Python project with lock file refresh
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
+- uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.5
   with:
     current-version: "1.0.0"
     version-file: pyproject.toml

--- a/docs/site/docs/actions/python-setup.md
+++ b/docs/site/docs/actions/python-setup.md
@@ -5,7 +5,7 @@ Sets up Python, installs uv, and configures dependency caching.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/python/setup@v1.4
+- uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
   with:
     python-version: "3.14"
     uv-version: "0.10.7"
@@ -40,7 +40,7 @@ Sets up Python, installs uv, and configures dependency caching.
 
 ```yaml
 - uses: actions/checkout@v6
-- uses: wphillipmoore/standard-actions/actions/python/setup@v1.4
+- uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
   with:
     python-version: "3.14"
 - run: uv sync
@@ -50,7 +50,7 @@ Sets up Python, installs uv, and configures dependency caching.
 ### Custom cache prefix for multiple Python versions
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/python/setup@v1.4
+- uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
   with:
     python-version: "3.13"
     cache-prefix: "uv-py313"

--- a/docs/site/docs/actions/release-gates-version-divergence.md
+++ b/docs/site/docs/actions/release-gates-version-divergence.md
@@ -6,7 +6,7 @@ the step if the two versions are identical.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
+- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
   with:
     head-version-command: cat VERSION
     main-version-command: git show origin/main:VERSION
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
+      - uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
         with:
           head-version-command: cat VERSION
           main-version-command: git show origin/main:VERSION
@@ -58,7 +58,7 @@ jobs:
 ### Python project version check
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
+- uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
   with:
     head-version-command: >-
       grep -oP 'version\s*=\s*"\K[^"]+' pyproject.toml

--- a/docs/site/docs/actions/security-codeql.md
+++ b/docs/site/docs/actions/security-codeql.md
@@ -6,7 +6,7 @@ language.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.5
   with:
     language: python
     queries: "+security-extended"
@@ -48,7 +48,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: wphillipmoore/standard-actions/actions/security/codeql@v1.4
+      - uses: wphillipmoore/standard-actions/actions/security/codeql@v1.5
         with:
           language: python
 ```
@@ -56,7 +56,7 @@ jobs:
 ### Go CodeQL analysis
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.5
   with:
     language: go
 ```

--- a/docs/site/docs/actions/security-semgrep.md
+++ b/docs/site/docs/actions/security-semgrep.md
@@ -6,7 +6,7 @@ rulesets.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.5
   with:
     language: python
     extra-config: "p/owasp-top-ten"
@@ -26,11 +26,13 @@ rulesets.
 
 ## Behavior
 
-1. **Install Semgrep** — Runs `pip install semgrep`.
+1. **Check language ruleset** — Queries the Semgrep registry to verify that
+   `p/<language>` exists. If the registry does not have a ruleset for the
+   specified language, the language-specific config is silently skipped.
 2. **Run scan** — Executes `semgrep scan` with the following config rulesets:
-    - `p/<language>` — Language-specific rules
     - `p/security-audit` — Cross-cutting security audit rules
     - `p/secrets` — Secret detection rules
+    - `p/<language>` — Language-specific rules (if available in the registry)
     - Any additional rulesets from `extra-config`
 3. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
    using `github/codeql-action/upload-sarif@v4`, categorized as `semgrep`.
@@ -50,7 +52,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.4
+      - uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.5
         with:
           language: python
 ```
@@ -58,7 +60,7 @@ jobs:
 ### Go with additional OWASP rules
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.5
   with:
     language: golang
     extra-config: "p/owasp-top-ten"

--- a/docs/site/docs/actions/security-trivy.md
+++ b/docs/site/docs/actions/security-trivy.md
@@ -5,7 +5,7 @@ Runs Trivy vulnerability scanning, SBOM generation, or container image scanning.
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: fs
     scan-ref: "."
@@ -78,7 +78,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+      - uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
         with:
           scan-type: fs
 ```
@@ -86,7 +86,7 @@ jobs:
 ### Container image scan
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: image
     scan-ref: "myapp:latest"
@@ -95,7 +95,7 @@ jobs:
 ### SBOM generation (advisory only)
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: sbom
     output-file: sbom.cdx.json
@@ -104,7 +104,7 @@ jobs:
 ### Custom SARIF category for matrix builds
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: fs
     sarif-category: "trivy-fs-${{ matrix.target }}"

--- a/docs/site/docs/actions/standards-compliance.md
+++ b/docs/site/docs/actions/standards-compliance.md
@@ -7,7 +7,7 @@ Repository profile, markdown, and other structural validations are handled by
 ## Usage
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.4
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.5
 ```
 
 ## Inputs
@@ -37,7 +37,7 @@ Both steps only run on `pull_request` events.
 - uses: actions/checkout@v6
   with:
     fetch-depth: 0
-- uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.4
+- uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.5
 ```
 
 ## GitHub configuration

--- a/docs/site/docs/ci-gates/index.md
+++ b/docs/site/docs/ci-gates/index.md
@@ -20,6 +20,10 @@ organized by category using job name prefixes:
 
 ## Key concepts
 
+- **Reusable workflows** — v1.5.0 introduced
+  [reusable CI workflows](../workflows/index.md) that produce the canonical
+  check names automatically. Consuming repositories call these workflows
+  rather than assembling jobs by hand.
 - **Required status checks** — Configured in GitHub repository rulesets.
   PRs cannot merge until all required checks pass.
 - **Self-referencing CI** — The standard-actions repository tests its own

--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -51,22 +51,36 @@ jobs:
     name: "release: gates"
 ```
 
+## Reusable workflow check-name mapping
+
+Each reusable workflow produces canonical check names. See
+[Reusable Workflows](../workflows/index.md) for full details.
+
+| Workflow | Check names produced |
+| ---------- | ---------------------- |
+| `ci-security.yml` | `CI Security / standards`, `CI Security / codeql`, `CI Security / trivy`, `CI Security / semgrep` |
+| `ci-quality.yml` | `CI Quality / common`, `CI Quality / lint / <version>`, `CI Quality / typecheck / <version>` |
+| `ci-audit.yml` | `CI Audit / dependencies / <version>` |
+| `ci-test.yml` | `CI Test / unit / <version>`, `CI Test / integration / <version>` |
+| `ci-release.yml` | `CI Release / version-bump` |
+
 ## Reusable workflow flags
 
-The `ci-security.yml` reusable workflow accepts two independent flags that
+The `ci-security.yml` reusable workflow accepts independent flags that
 control which inner jobs run:
 
 | Flag | Controls | Default |
 | ---- | -------- | ------- |
-| `run-standards` | `ci: standards-compliance` job | `'true'` |
-| `run-security` | `security: codeql`, `security: semgrep`, `security: trivy` jobs | `'true'` |
+| `run-standards` | `CI Security / standards` job | `true` |
+| `run-security` | `CI Security / codeql`, `CI Security / trivy`, `CI Security / semgrep` jobs | `true` |
+| `run-codeql` | `CI Security / codeql` job (requires `run-security` to also be true) | `true` |
 
 Consuming repos must pass both flags explicitly so that push CI (tier 2) can
 skip standards and security while PR CI (tier 3) runs the full suite:
 
 ```yaml
 security-and-standards:
-  uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
+  uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
   with:
     language: <lang>
     run-standards: ${{ inputs.run-release-gates || 'true' }}

--- a/docs/site/docs/ci-gates/security-scanning.md
+++ b/docs/site/docs/ci-gates/security-scanning.md
@@ -56,7 +56,7 @@ control flow, and language-specific patterns.
   project.
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/codeql@v1.5
   with:
     language: python
 ```
@@ -75,7 +75,7 @@ Default rulesets enabled for every scan:
 Additional rulesets can be added via `extra-config`:
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/semgrep@v1.5
   with:
     language: golang
     extra-config: "p/owasp-top-ten"
@@ -99,7 +99,7 @@ By default, only `CRITICAL` and `HIGH` severity vulnerabilities are reported.
 This can be adjusted:
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: fs
     severity: "CRITICAL,HIGH,MEDIUM"
@@ -111,7 +111,7 @@ By default, Trivy exits with code `1` when vulnerabilities are found, failing
 the CI check. Set `exit-code: "0"` for advisory-only mode:
 
 ```yaml
-- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+- uses: wphillipmoore/standard-actions/actions/security/trivy@v1.5
   with:
     scan-type: fs
     exit-code: "0"

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -6,12 +6,12 @@ Reference actions from this repository using the full path with a rolling minor
 tag pin:
 
 ```yaml
-uses: wphillipmoore/standard-actions/actions/<action-path>@v1.4
+uses: wphillipmoore/standard-actions/actions/<action-path>@v1.5
 ```
 
 !!! note "Tag pinning"
-    Pin to a rolling minor tag (e.g., `@v1.4`) to automatically receive patch
-    releases. Pin to an exact tag (e.g., `@v1.4.1`) for full reproducibility.
+    Pin to a rolling minor tag (e.g., `@v1.5`) to automatically receive patch
+    releases. Pin to an exact tag (e.g., `@v1.5.1`) for full reproducibility.
 
 ## Minimal workflow example
 
@@ -31,8 +31,48 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.4
+      - uses: wphillipmoore/standard-actions/actions/standards-compliance@v1.5
 ```
+
+## Consuming reusable workflows
+
+v1.5.0 introduced reusable CI workflows that produce canonical check names.
+Reference workflows using the full path to the workflow file:
+
+```yaml
+uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+```
+
+### Minimal workflow example using reusable workflows
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  quality:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: python
+```
+
+See [Reusable Workflows](workflows/index.md) for the full list and
+detailed documentation.
 
 ## Permissions
 
@@ -52,4 +92,4 @@ by the same PR that modifies them — no separate integration testing step is
 needed.
 
 Consuming repositories use the full remote reference
-(`wphillipmoore/standard-actions/actions/...@v1.4`).
+(`wphillipmoore/standard-actions/actions/...@v1.5`).

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -5,8 +5,9 @@ across all managed repositories.
 
 ## Status
 
-**Stable (v1.x)** — Actions are consumed by pinning to a rolling minor tag
-(e.g., `@v1.4`), which automatically receives patch releases.
+**Stable (v1.x)** — Actions and reusable workflows are consumed by pinning to
+a rolling minor tag (e.g., `@v1.5`), which automatically receives patch
+releases.
 
 ## Action categories
 
@@ -19,12 +20,30 @@ across all managed repositories.
 | Publishing | [publish/tag-and-release](actions/publish-tag-and-release.md), [publish/version-bump-pr](actions/publish-version-bump-pr.md) | Release tagging and post-release version bumps |
 | Release Gates | [release-gates/version-divergence](actions/release-gates-version-divergence.md) | Pre-merge version validation |
 
+## Reusable workflows
+
+v1.5.0 introduced reusable CI workflows that provide canonical job and check
+names across all managed repositories. See
+[Reusable Workflows](workflows/index.md) for details.
+
+| Workflow | Purpose |
+| ---------- | --------- |
+| [ci-security](workflows/ci-security.md) | Standards compliance and security scanning |
+| [ci-quality](workflows/ci-quality.md) | Common linting, language-specific lint and typecheck |
+| [ci-audit](workflows/ci-audit.md) | Dependency audit |
+| [ci-test](workflows/ci-test.md) | Unit and integration tests |
+| [ci-release](workflows/ci-release.md) | Release gate verification |
+
 ## Design principles
 
 - **Composite actions only** — No custom JavaScript or Docker actions. Every
   action is a composite `action.yml` with shell steps.
-- **Self-referencing CI** — This repository's own CI uses `./actions/...` local
-  paths, so changes to an action are tested by the same PR that modifies them.
+- **Reusable workflows** — CI workflows are provided as reusable
+  `workflow_call` templates that produce canonical check names across all
+  consuming repositories.
+- **Self-referencing CI** — This repository's own CI uses `./actions/...` and
+  `./.github/workflows/...` local paths, so changes are tested by the same PR
+  that modifies them.
 - **Centralized standards** — Workflow patterns and validation rules are defined
   once here and consumed by all repositories.
 

--- a/docs/site/docs/workflows/ci-audit.md
+++ b/docs/site/docs/workflows/ci-audit.md
@@ -1,0 +1,33 @@
+# ci-audit
+
+Dependency audit workflow.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+| ------- | ------ | ---------- | --------- | ------------- |
+| `language` | string | yes | — | Primary language of the repository |
+| `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
+
+## Jobs and check names
+
+| Job | Check name | Description |
+| ----- | ------------ | ------------- |
+| `dependencies / <version>` | `CI Audit / dependencies / <version>` | Dependency audit (matrix-expanded) |
+
+## Usage
+
+```yaml
+jobs:
+  audit:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+```
+
+## Extension points
+
+The `dependencies` job provides a version matrix scaffold for running
+language-specific dependency audit tools (e.g., `pip-audit`, `npm audit`,
+`bundler-audit`).

--- a/docs/site/docs/workflows/ci-quality.md
+++ b/docs/site/docs/workflows/ci-quality.md
@@ -1,0 +1,50 @@
+# ci-quality
+
+Code quality and linting workflow.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+| ------- | ------ | ---------- | --------- | ------------- |
+| `language` | string | yes | — | Primary language of the repository |
+| `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
+
+## Jobs and check names
+
+| Job | Check name | Description |
+| ----- | ------------ | ------------- |
+| `common` | `CI Quality / common` | Runs common linters based on file presence |
+| `lint / <version>` | `CI Quality / lint / <version>` | Language-specific linting (matrix-expanded) |
+| `typecheck / <version>` | `CI Quality / typecheck / <version>` | Language-specific type checking (matrix-expanded) |
+
+## Common checks
+
+The `common` job runs inside the `ghcr.io/wphillipmoore/dev-base:latest`
+container and conditionally executes each linter based on whether matching
+files exist in the repository:
+
+| Tool | Condition |
+| ------ | ----------- |
+| markdownlint | `*.md` files found |
+| shellcheck | `*.sh` files or `scripts/bin/` directory found |
+| yamllint | `*.yml` or `*.yaml` files found |
+| hadolint | `Dockerfile*` files found |
+| actionlint | `.github/workflows/` directory found |
+
+## Usage
+
+```yaml
+jobs:
+  quality:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+```
+
+## Extension points
+
+The `lint` and `typecheck` jobs provide a version matrix scaffold. Consuming
+repositories customize these jobs by forking the workflow or by running
+language-specific tooling in a separate workflow that calls these as a
+baseline.

--- a/docs/site/docs/workflows/ci-release.md
+++ b/docs/site/docs/workflows/ci-release.md
@@ -1,0 +1,37 @@
+# ci-release
+
+Release gate verification workflow.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+| ------- | ------ | ---------- | --------- | ------------- |
+| `language` | string | yes | — | Primary language of the repository |
+| `run-release` | boolean | no | `true` | Run the version-bump verification job |
+
+## Jobs and check names
+
+| Job | Check name | Condition |
+| ----- | ------------ | ----------- |
+| `version-bump` | `CI Release / version-bump` | `run-release` is true |
+
+## Usage
+
+```yaml
+jobs:
+  release:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+    with:
+      language: python
+```
+
+To skip release gates (e.g., for infrastructure repos that don't version):
+
+```yaml
+jobs:
+  release:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+    with:
+      language: shell
+      run-release: false
+```

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -1,0 +1,65 @@
+# ci-security
+
+Standards compliance and security scanning workflow.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+| ------- | ------ | ---------- | --------- | ------------- |
+| `language` | string | yes | — | Language for security scanners (e.g., `python`, `go`, `ruby`) |
+| `run-standards` | boolean | no | `true` | Run the standards-compliance job |
+| `run-security` | boolean | no | `true` | Run security scanner jobs (CodeQL, Semgrep, Trivy) |
+| `run-codeql` | boolean | no | `true` | Run CodeQL analysis (disable for unsupported languages like `shell`) |
+
+## Required permissions
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+```
+
+## Jobs and check names
+
+| Job | Check name | Condition |
+| ----- | ------------ | ----------- |
+| `standards` | `CI Security / standards` | `run-standards` is true |
+| `codeql` | `CI Security / codeql` | `run-security` and `run-codeql` are true |
+| `trivy` | `CI Security / trivy` | `run-security` is true |
+| `semgrep` | `CI Security / semgrep` | `run-security` is true |
+
+## Usage
+
+```yaml
+jobs:
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: python
+```
+
+To skip CodeQL for languages it does not support:
+
+```yaml
+jobs:
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: shell
+      run-codeql: false
+```
+
+## Implementation notes
+
+- The `standards` and `semgrep` jobs run inside the
+  `ghcr.io/wphillipmoore/dev-base:latest` container.
+- The `standards` job installs `standard-tooling` from the version pinned in
+  `standard-tooling.toml` (with a legacy `st-config.toml` fallback).
+- For Python repositories, the `standards` job runs `uv sync --group dev --frozen`
+  to make project-installed tools available on `PATH`.

--- a/docs/site/docs/workflows/ci-test.md
+++ b/docs/site/docs/workflows/ci-test.md
@@ -1,0 +1,49 @@
+# ci-test
+
+Unit and integration test workflow.
+
+## Inputs
+
+| Input | Type | Required | Default | Description |
+| ------- | ------ | ---------- | --------- | ------------- |
+| `language` | string | yes | — | Primary language of the repository |
+| `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
+| `integration-tests` | boolean | no | `false` | Enable integration test jobs |
+
+## Jobs and check names
+
+| Job | Check name | Condition |
+| ----- | ------------ | ----------- |
+| `unit / <version>` | `CI Test / unit / <version>` | Always runs |
+| `integration / <version>` | `CI Test / integration / <version>` | `integration-tests` is true |
+
+## Usage
+
+Unit tests only:
+
+```yaml
+jobs:
+  test:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+```
+
+With integration tests:
+
+```yaml
+jobs:
+  test:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+      integration-tests: true
+```
+
+## Extension points
+
+The `unit` and `integration` jobs provide version matrix scaffolds.
+Consuming repositories customize these by forking the workflow or by
+running language-specific test commands in a separate workflow.

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -1,0 +1,61 @@
+# Reusable Workflows
+
+v1.5.0 introduced reusable CI workflows that provide canonical job and check
+names across all managed repositories. Each workflow bundles one or more
+composite actions with the container, tooling, and permission setup needed
+to run them.
+
+## Why reusable workflows?
+
+Composite actions run as steps within a caller-defined job. Reusable workflows
+run as complete jobs, which means they control the job name that appears in
+GitHub's checks UI. This guarantees consistent, canonical check names across
+repositories — a requirement for pattern-based required status checks in
+rulesets.
+
+## Available workflows
+
+| Workflow | File | Purpose |
+| ---------- | ------ | --------- |
+| [CI Security](ci-security.md) | `ci-security.yml` | Standards compliance and security scanning |
+| [CI Quality](ci-quality.md) | `ci-quality.yml` | Common linting, language-specific lint and typecheck |
+| [CI Audit](ci-audit.md) | `ci-audit.yml` | Dependency audit |
+| [CI Test](ci-test.md) | `ci-test.yml` | Unit and integration tests |
+| [CI Release](ci-release.md) | `ci-release.yml` | Release gate verification |
+
+## Consuming a reusable workflow
+
+Reference workflows using the full path to the workflow file with a rolling
+minor tag pin:
+
+```yaml
+uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+```
+
+!!! note "Tag pinning"
+    The same tag pinning guidance applies as for composite actions. Pin to
+    `@v1.5` for automatic patch releases, or `@v1.5.0` for full
+    reproducibility.
+
+## Permissions
+
+Reusable workflows inherit permissions from the calling workflow. Callers must
+declare the permissions each workflow needs at the job level:
+
+```yaml
+jobs:
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: python
+```
+
+## Reference freezing
+
+The workflow source files reference composite actions via `@develop` during
+development. At release time, the publish workflow freezes all `@develop`
+references to the release tag (e.g., `@v1.5.0`), ensuring that a pinned
+workflow version uses the matching action versions.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -78,6 +78,13 @@ nav:
           - publish/version-bump-pr: actions/publish-version-bump-pr.md
       - Release Gates:
           - release-gates/version-divergence: actions/release-gates-version-divergence.md
+  - Reusable Workflows:
+      - Overview: workflows/index.md
+      - ci-security: workflows/ci-security.md
+      - ci-quality: workflows/ci-quality.md
+      - ci-audit: workflows/ci-audit.md
+      - ci-test: workflows/ci-test.md
+      - ci-release: workflows/ci-release.md
   - CI Gate Requirements:
       - Overview: ci-gates/index.md
       - Required Checks: ci-gates/required-checks.md


### PR DESCRIPTION
# Pull Request

## Summary

- Comprehensive doc-site review for v1.5.0 reusable-workflow redesign

## Issue Linkage

- Ref #314

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## Summary

Comprehensive documentation review for v1.5.0 reusable workflow redesign:
- Added new Reusable Workflows section with overview and five workflow reference pages (ci-security, ci-quality, ci-audit, ci-test, ci-release)
- Updated home page and getting-started with v1.5 consumption model
- Updated CI gates section with workflow-to-check-name mapping and run-codeql flag
- Swept all action reference pages: version tags @v1.4→@v1.5, fixed stale semgrep behavior docs
- Reviewed development and configuration pages (no changes needed)

## Notes

- mkdocs build --strict shows 2 pre-existing warnings (changelog.md and releases/index.md are generated at deploy time, not checked in) — same as develop
- st-validate-local passes clean