### PR TITLE
fix(python/setup): replace pip install uv with astral-sh/setup-uv

### DIFF
--- a/actions/python/setup/action.yml
+++ b/actions/python/setup/action.yml
@@ -1,6 +1,6 @@
 name: Python setup
 description: >-
-  Sets up Python, installs uv, and configures dependency caching.
+  Sets up Python and uv with dependency caching.
 
 inputs:
   python-version:
@@ -10,10 +10,6 @@ inputs:
     description: uv version to install.
     required: false
     default: "0.10.7"
-  cache-prefix:
-    description: Cache key prefix for uv dependency cache.
-    required: false
-    default: "uv"
 
 runs:
   using: composite
@@ -23,14 +19,8 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install uv
-      shell: bash
-      run: python3 -m pip install uv==${{ inputs.uv-version }}
-
-    - name: Cache uv dependencies
-      uses: actions/cache@v5
+    - name: Install uv ${{ inputs.uv-version }}
+      uses: astral-sh/setup-uv@v8
       with:
-        path: ~/.cache/uv
-        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('uv.lock') }}
-        restore-keys: |
-          ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-
+        version: ${{ inputs.uv-version }}
+        enable-cache: "true"

--- a/docs/site/docs/actions/python-setup.md
+++ b/docs/site/docs/actions/python-setup.md
@@ -1,6 +1,6 @@
 # python/setup
 
-Sets up Python, installs uv, and configures dependency caching.
+Sets up Python and uv with dependency caching.
 
 ## Usage
 
@@ -9,7 +9,6 @@ Sets up Python, installs uv, and configures dependency caching.
   with:
     python-version: "3.14"
     uv-version: "0.10.7"
-    cache-prefix: "uv"
 ```
 
 ## Inputs
@@ -18,7 +17,6 @@ Sets up Python, installs uv, and configures dependency caching.
 | ------ | ---------- | --------- | ------------- |
 | `python-version` | **Yes** | — | Python version to install (e.g. `3.14`). |
 | `uv-version` | No | `0.10.7` | uv version to install. |
-| `cache-prefix` | No | `uv` | Cache key prefix for uv dependency cache. |
 
 ## Permissions
 
@@ -28,11 +26,8 @@ Sets up Python, installs uv, and configures dependency caching.
 
 1. **Set up Python** — Uses `actions/setup-python@v6` to install the specified
    Python version.
-2. **Install uv** — Runs `pip install uv==<version>` to install the pinned
-   version of uv.
-3. **Cache dependencies** — Uses `actions/cache@v5` to cache `~/.cache/uv`.
-   The cache key includes the OS, Python version, and a hash of `uv.lock` for
-   precise invalidation.
+2. **Install uv** — Uses `astral-sh/setup-uv@v8` to install the pinned version
+   of uv and configure dependency caching automatically.
 
 ## Examples
 
@@ -45,15 +40,6 @@ Sets up Python, installs uv, and configures dependency caching.
     python-version: "3.14"
 - run: uv sync
 - run: uv run pytest
-```
-
-### Custom cache prefix for multiple Python versions
-
-```yaml
-- uses: wphillipmoore/standard-actions/actions/python/setup@v1.5
-  with:
-    python-version: "3.13"
-    cache-prefix: "uv-py313"
 ```
 
 ## GitHub configuration


### PR DESCRIPTION
# Pull Request

## Summary

- Replace pip install uv with astral-sh/setup-uv@v8 to eliminate PEP 668 fragility and leverage native dependency caching

## Issue Linkage

- Ref #289

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Follow-up to #287. Only active consumer (mq-rest-admin-python integration tests) runs on bare ubuntu-latest, so this action remains needed but now delegates to the official installer. After release, bump pin in mq-rest-admin-python.