### PR TITLE
feat(security/semgrep): add p/ci base ruleset and auto-detect p/dockerfile, p/github-actions

### DIFF
--- a/actions/security/semgrep/action.yml
+++ b/actions/security/semgrep/action.yml
@@ -26,12 +26,20 @@ runs:
         LANGUAGE: ${{ inputs.language }}
         EXTRA_CONFIG: ${{ inputs.extra-config }}
       run: |
-        config="p/security-audit p/secrets"
+        config="p/ci p/security-audit p/secrets"
 
         if curl -sf "https://semgrep.dev/c/p/$LANGUAGE" -o /dev/null 2>/dev/null; then
           config="p/$LANGUAGE $config"
         else
           echo "::notice::Semgrep ruleset p/$LANGUAGE not found in registry — skipping language-specific rules"
+        fi
+
+        if find . -name "Dockerfile*" -not -path './.git/*' | head -1 | grep -q .; then
+          config="$config p/dockerfile"
+        fi
+
+        if find .github/workflows -name "*.yml" -o -name "*.yaml" 2>/dev/null | head -1 | grep -q .; then
+          config="$config p/github-actions"
         fi
 
         if [ -n "$EXTRA_CONFIG" ]; then

--- a/docs/site/docs/actions/security-semgrep.md
+++ b/docs/site/docs/actions/security-semgrep.md
@@ -29,12 +29,22 @@ rulesets.
 1. **Check language ruleset** — Queries the Semgrep registry to verify that
    `p/<language>` exists. If the registry does not have a ruleset for the
    specified language, the language-specific config is silently skipped.
-2. **Run scan** — Executes `semgrep scan` with the following config rulesets:
+2. **Auto-detect rulesets** — Scans the repository for content that benefits
+   from specialized rulesets:
+    - `p/dockerfile` — enabled when `Dockerfile*` files are present
+    - `p/github-actions` — enabled when `.github/workflows/` contains workflow
+      files
+3. **Run scan** — Executes `semgrep scan` with the following config rulesets:
+    - `p/ci` — CI pipeline security rules (injection, secrets in workflows,
+      unsafe patterns)
     - `p/security-audit` — Cross-cutting security audit rules
     - `p/secrets` — Secret detection rules
     - `p/<language>` — Language-specific rules (if available in the registry)
+    - `p/dockerfile` — Dockerfile best practices (if Dockerfiles detected)
+    - `p/github-actions` — GitHub Actions injection patterns (if workflow files
+      detected)
     - Any additional rulesets from `extra-config`
-3. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
+4. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
    using `github/codeql-action/upload-sarif@v4`, categorized as `semgrep`.
    This step runs even if the scan finds issues (`if: always()`).
 

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -63,3 +63,7 @@ jobs:
   `standard-tooling.toml` (with a legacy `st-config.toml` fallback).
 - For Python repositories, the `standards` job runs `uv sync --group dev --frozen`
   to make project-installed tools available on `PATH`.
+- The Semgrep action auto-detects repository content and enables additional
+  rulesets: `p/dockerfile` when Dockerfiles are present, `p/github-actions`
+  when workflow files exist under `.github/workflows/`. No configuration is
+  needed from consuming repos.

--- a/docs/specs/2026-05-04-semgrep-ruleset-expansion.md
+++ b/docs/specs/2026-05-04-semgrep-ruleset-expansion.md
@@ -1,0 +1,101 @@
+# Semgrep Ruleset Expansion
+
+**Issue:** #303
+**Date:** 2026-05-04
+**Status:** Approved
+
+## Goal
+
+Expand the Semgrep composite action's security coverage by adding `p/ci` to the
+base config and auto-detecting repo content to enable `p/dockerfile` and
+`p/github-actions` rulesets without any configuration from consuming repos.
+
+## Background
+
+The Semgrep action (`actions/security/semgrep/action.yml`) runs with a fixed
+base config of `p/security-audit` and `p/secrets`, plus a conditional
+`p/$LANGUAGE` when the language-specific ruleset exists in the registry. Issue
+#303 identified several high-value rulesets that are not being used — most
+notably `p/ci` (147 CI pipeline security rules), `p/dockerfile` (7 Dockerfile
+best-practice rules), and `p/github-actions` (3 Actions injection rules).
+
+The `ci-quality.yml` workflow already auto-detects file types to run the
+appropriate linter (hadolint for Dockerfiles, shellcheck for shell scripts,
+actionlint for workflow files). The Semgrep action should follow the same
+pattern: detect what's in the repo and scan it accordingly.
+
+## Design
+
+### Base config change
+
+Add `p/ci` to the hardcoded base config string. This ruleset covers CI pipeline
+security (injection, secrets in workflows, unsafe patterns) and applies to all
+repos. The base config becomes:
+
+```
+p/ci p/security-audit p/secrets
+```
+
+### Auto-detection
+
+After the existing `p/$LANGUAGE` registry check, the action detects repo content
+and adds matching rulesets:
+
+| File pattern | Ruleset | Rule count |
+|---|---|---|
+| `Dockerfile*` (excluding `.git/`) | `p/dockerfile` | 7 |
+| `.github/workflows/*.yml` or `*.yaml` | `p/github-actions` | 3 |
+
+Detection uses the same `find | head -1 | grep -q .` pattern from ci-quality's
+`has_files` function. No registry check is needed for these — they are
+known-valid rulesets.
+
+Auto-detected rulesets are silently skipped when the file pattern doesn't match.
+No `::notice` is emitted on skip (unlike the `p/$LANGUAGE` case, where skipping
+is unexpected and worth flagging).
+
+### Config construction order
+
+1. `p/ci p/security-audit p/secrets` — base (always)
+2. `p/$LANGUAGE` — if registry check passes
+3. `p/dockerfile` — if Dockerfiles detected
+4. `p/github-actions` — if workflow files detected
+5. `extra-config` values — explicit opt-in, appended last
+
+### What is NOT changing
+
+- **No new inputs on `ci-security.yml`** — auto-detection is invisible to
+  consuming repos. The `extra-config` input already exists on the action for
+  edge cases; it does not need to be plumbed through the workflow.
+- **`p/command-injection`** — excluded from auto-detection for now. The trigger
+  condition is unclear (shell scripts are already partially covered by `p/ci`),
+  and it can be revisited in a follow-up.
+- **`p/owasp-top-ten`** — 544 rules, needs noise evaluation before adding
+  fleet-wide. Out of scope.
+
+### Documentation updates
+
+- `docs/site/docs/actions/security-semgrep.md` — add `p/ci` to the base
+  rulesets list in the Behavior section. Add an "Auto-detected rulesets"
+  subsection documenting what triggers `p/dockerfile` and `p/github-actions`.
+- `docs/site/docs/workflows/ci-security.md` — add a note in implementation
+  notes that Semgrep auto-detects Dockerfile and GitHub Actions content.
+
+### Self-referencing CI validation
+
+This repo passes `language: shell` to ci-security. After this change:
+
+- `p/ci` runs (base config) — new coverage
+- `p/shell` is skipped (existing registry check, no change)
+- `p/github-actions` is auto-detected (this repo has `.github/workflows/`)
+- `p/dockerfile` is not triggered (no Dockerfiles in this repo)
+
+This validates both the positive and negative auto-detection paths in the same
+PR.
+
+## Out of scope
+
+- `p/command-injection` auto-detection (follow-up)
+- `p/owasp-top-ten` evaluation (follow-up)
+- `semgrep-extra-config` pass-through on `ci-security.yml` (not needed until a
+  consuming repo has a use case the auto-detection doesn't cover)


### PR DESCRIPTION
# Pull Request

## Summary

- Expand Semgrep coverage by adding p/ci to the base config and auto-detecting repo content to enable p/dockerfile and p/github-actions rulesets.

## Issue Linkage

- Ref #303

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Adds p/ci (147 CI pipeline security rules) to every Semgrep scan. Auto-detects Dockerfiles and GitHub Actions workflow files to enable p/dockerfile and p/github-actions rulesets, following the same file-presence pattern used by ci-quality. Consuming repos get expanded coverage automatically with no configuration changes.