### PR TITLE
Remove dead st-config.toml fallback from ci-security.yml

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -51,11 +51,9 @@ jobs:
           if ! command -v st-repo-profile >/dev/null 2>&1; then
             if [ -f standard-tooling.toml ]; then
               TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
-            elif [ -f st-config.toml ]; then
-              TAG=$(sed -n 's/^[[:space:]]*tag[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' st-config.toml)
             fi
             if [ -z "${TAG:-}" ]; then
-              echo "::error::standard-tooling.toml (or st-config.toml) not found or missing version tag"
+              echo "::error::standard-tooling.toml not found or missing version tag"
               exit 1
             fi
             pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -60,7 +60,7 @@ jobs:
 - The `standards` and `semgrep` jobs run inside the
   `ghcr.io/wphillipmoore/dev-base:latest` container.
 - The `standards` job installs `standard-tooling` from the version pinned in
-  `standard-tooling.toml` (with a legacy `st-config.toml` fallback).
+  `standard-tooling.toml`.
 - For Python repositories, the `standards` job runs `uv sync --group dev --frozen`
   to make project-installed tools available on `PATH`.
 - The Semgrep action auto-detects repository content and enables additional


### PR DESCRIPTION
# Pull Request

## Summary

- Remove dead st-config.toml fallback from ci-security workflow

## Issue Linkage

- Ref #322

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- All repos migrated to standard-tooling.toml (ref #265). The st-config.toml elif branch and error message reference in ci-security.yml are dead code — already removed from standards-compliance in v1.4.7 (ref #287) but missed here. Also updates the ci-security docs to remove the legacy mention.