### PR TITLE
chore: align with st-github-config enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,8 @@ jobs:
     with:
       language: shell
       run-codeql: false
+
+  release:
+    uses: ./.github/workflows/ci-release.yml
+    with:
+      language: shell

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -1,13 +1,17 @@
 [project]
 repository-type = "library"
-versioning-scheme = "library"
+versioning-scheme = "semver"
 branching-model = "library-release"
-release-model = "artifact-publishing"
+release-model = "tagged-release"
 primary-language = "shell"
 
 [project.co-authors]
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
+
+[ci]
+versions = ["latest"]
+integration-tests = false
 
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Updates config and CI for compliance with the new st-github-config derivation engine

## Issue Linkage

- Ref wphillipmoore/standard-tooling#173

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- After merge, run st-github-config apply --repo wphillipmoore/standard-actions --yes to enforce actions permissions and update CI gates ruleset