### PR TITLE
fix: pin astral-sh/setup-uv to v8.1.0 in python/setup

### DIFF
--- a/actions/python/setup/action.yml
+++ b/actions/python/setup/action.yml
@@ -20,7 +20,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv ${{ inputs.uv-version }}
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         version: ${{ inputs.uv-version }}
         enable-cache: "true"


### PR DESCRIPTION
# Pull Request

## Summary

- Pin setup-uv to v8.1.0 — the floating v8 major tag does not exist

## Issue Linkage

- Ref #329

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Pin astral-sh/setup-uv from the non-existent floating v8 major tag to v8.1.0. The astral-sh/setup-uv repository only publishes exact version tags (v8.0.0, v8.1.0, etc.) and does not maintain a v8 major tag, causing jobs to fail at setup with "Unable to resolve action".

Discovered via wphillipmoore/mq-rest-admin-python#480.