### PR TITLE
Design spec and implementation plan for CI workflow reset

### DIFF
--- a/docs/plans/2026-05-05-ci-workflow-reset.md
+++ b/docs/plans/2026-05-05-ci-workflow-reset.md
@@ -1,0 +1,1062 @@
+# CI Workflow Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace stub CI reusable workflows with real implementations
+driven by a centralized `st-validate` command that reads from the
+command registry in standard-tooling.
+
+**Architecture:** Three sequential phases — (1) build `st-validate` CLI
+and fix the command registry in standard-tooling, (2) implement reusable
+CI workflows in standard-actions, (3) roll out thin callers across the
+fleet. Each phase produces a releasable artifact before the next begins.
+
+**Tech Stack:** Python 3.12+ (standard-tooling CLI), GitHub Actions YAML
+(reusable workflows), TOML (configuration)
+
+**Spec:** `docs/specs/2026-05-05-ci-workflow-reset-design.md`
+
+**Coordination:** Phase 1 is combined with the publish-and-docs
+rationalization spec (#318). Both specs' standard-tooling work ships in
+a single release.
+
+---
+
+## Phase 1: standard-tooling foundations
+
+> **Repo:** `standard-tooling`
+> **Branch:** create from `develop`
+> **Prereq:** none
+
+Phase 1 may be split across multiple PRs. Tasks 1-2 form a natural PR
+(registry fixes + install commands). Tasks 3-5 form a second PR
+(`st-validate` command). Task 6 is a third PR (wiring consumers).
+
+### Task 1: Fix command registry and add install commands
+
+**Files:**
+- Modify: `src/standard_tooling/lib/validate_commands.py`
+- Modify: `tests/standard_tooling/test_validate_commands.py`
+
+Update the registry to match the spec: Python lint/typecheck target
+`src/ tests/`, test coverage scoped to `src`, pip-audit plain
+invocation. Add `CheckKind.INSTALL` and install commands per language.
+
+- [ ] **Step 1: Write failing tests for updated Python commands**
+
+Add/update in `tests/standard_tooling/test_validate_commands.py`:
+
+```python
+# -- Install commands ---------------------------------------------------------
+
+
+def test_python_install_commands() -> None:
+    cmds = language_commands("python", CheckKind.INSTALL)
+    assert cmds == ["uv sync --frozen --group dev"]
+
+
+def test_go_install_commands() -> None:
+    cmds = language_commands("go", CheckKind.INSTALL)
+    assert cmds == ["go mod download"]
+
+
+def test_ruby_install_commands() -> None:
+    cmds = language_commands("ruby", CheckKind.INSTALL)
+    assert cmds == ["bundle install --jobs 4"]
+
+
+def test_rust_install_commands() -> None:
+    cmds = language_commands("rust", CheckKind.INSTALL)
+    assert cmds == ["cargo fetch"]
+
+
+def test_java_install_commands() -> None:
+    cmds = language_commands("java", CheckKind.INSTALL)
+    assert cmds == ["./mvnw dependency:resolve -B"]
+
+
+def test_shell_install_commands() -> None:
+    cmds = language_commands("shell", CheckKind.INSTALL)
+    assert cmds == []
+```
+
+Update existing Python tests to match new commands:
+
+```python
+def test_python_lint_commands() -> None:
+    cmds = language_commands("python", CheckKind.LINT)
+    assert cmds == ["ruff check src/ tests/", "ruff format --check src/ tests/"]
+
+
+def test_python_typecheck_commands() -> None:
+    cmds = language_commands("python", CheckKind.TYPECHECK)
+    assert "mypy src/ tests/" in cmds
+    assert "ty check src tests" in cmds
+
+
+def test_python_test_commands() -> None:
+    cmds = language_commands("python", CheckKind.TEST)
+    assert any("pytest" in c for c in cmds)
+    assert any("--cov=src" in c for c in cmds)
+
+
+def test_python_audit_commands() -> None:
+    cmds = language_commands("python", CheckKind.AUDIT)
+    assert any("uv sync --check" in c for c in cmds)
+    assert any("uv lock --check" in c for c in cmds)
+    assert "pip-audit" in cmds
+    assert any("pip-licenses" in c for c in cmds)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_validate_commands.py -v`
+Expected: FAIL — `CheckKind.INSTALL` does not exist, Python commands
+differ from expected values.
+
+- [ ] **Step 3: Update registry with fixed commands and install entries**
+
+In `src/standard_tooling/lib/validate_commands.py`:
+
+Add `INSTALL = "install"` to the `CheckKind` enum.
+
+Update the `_REGISTRY` dict:
+
+```python
+_REGISTRY: dict[str, dict[CheckKind, list[str]]] = {
+    "python": {
+        CheckKind.INSTALL: ["uv sync --frozen --group dev"],
+        CheckKind.LINT: ["ruff check src/ tests/", "ruff format --check src/ tests/"],
+        CheckKind.TYPECHECK: ["mypy src/ tests/", "ty check src tests"],
+        CheckKind.TEST: ["pytest --cov=src --cov-branch --cov-fail-under=100"],
+        CheckKind.AUDIT: [
+            "uv sync --check --frozen --group dev",
+            "uv lock --check",
+            "pip-audit",
+            "pip-licenses --allow-only=<standard-allowlist>",
+        ],
+    },
+    "go": {
+        CheckKind.INSTALL: ["go mod download"],
+        CheckKind.LINT: ["golangci-lint run ./...", "gocyclo -over 15 ."],
+        CheckKind.TYPECHECK: ["go vet ./..."],
+        CheckKind.TEST: [
+            "go test -race -count=1 -coverprofile=coverage.out ./...",
+            "go-test-coverage --config .testcoverage.yml",
+        ],
+        CheckKind.AUDIT: ["govulncheck ./...", "go-licenses check ./..."],
+    },
+    "java": {
+        CheckKind.INSTALL: ["./mvnw dependency:resolve -B"],
+        CheckKind.LINT: ["./mvnw spotless:check checkstyle:check -B"],
+        CheckKind.TYPECHECK: ["./mvnw compile -B"],
+        CheckKind.TEST: ["./mvnw verify -B"],
+        CheckKind.AUDIT: [
+            "./mvnw dependency:tree -B -q",
+            "./mvnw org.codehaus.mojo:license-maven-plugin:add-third-party -B",
+        ],
+    },
+    "ruby": {
+        CheckKind.INSTALL: ["bundle install --jobs 4"],
+        CheckKind.LINT: ["bundle exec rubocop"],
+        CheckKind.TYPECHECK: ["bundle exec steep check"],
+        CheckKind.TEST: ["bundle exec rake"],
+        CheckKind.AUDIT: ["bundle exec bundle-audit check --update"],
+    },
+    "rust": {
+        CheckKind.INSTALL: ["cargo fetch"],
+        CheckKind.LINT: ["cargo fmt --all -- --check", "cargo clippy -- -D warnings"],
+        CheckKind.TYPECHECK: ["cargo check"],
+        CheckKind.TEST: ["cargo llvm-cov --fail-under-lines 100"],
+        CheckKind.AUDIT: ["cargo deny check"],
+    },
+}
+```
+
+Note: `<standard-allowlist>` for pip-licenses needs the actual allowlist
+value resolved during implementation. Check existing consumer repos for
+the canonical allowlist string.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_validate_commands.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```
+st-commit --type feat --scope validate --message "fix Python commands and add install entries to command registry" --agent claude
+```
+
+### Task 2: Build `st-validate` command
+
+**Files:**
+- Create: `src/standard_tooling/bin/st_validate.py`
+- Create: `tests/standard_tooling/test_st_validate.py`
+- Modify: `pyproject.toml` (add entry point)
+
+The unified validation command. Reads language from config, dispatches
+to common checks or registry commands based on `--check` argument.
+
+- [ ] **Step 1: Write failing tests for st-validate**
+
+Create `tests/standard_tooling/test_st_validate.py`:
+
+```python
+"""Tests for standard_tooling.bin.st_validate."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from standard_tooling.bin.st_validate import main
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _container_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ST_IN_DEV_CONTAINER", "1")
+
+
+def _write_config(tmp_path: Path, language: str) -> None:
+    (tmp_path / "standard-tooling.toml").write_text(
+        f'[project]\nrepository-type = "library"\nversioning-scheme = "semver"\n'
+        f'branching-model = "library-release"\nrelease-model = "tagged-release"\n'
+        f'primary-language = "{language}"\n\n[dependencies]\nstandard-tooling = "v1.4"\n'
+    )
+
+
+# -- Container guard ----------------------------------------------------------
+
+
+def test_rejects_host_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ST_IN_DEV_CONTAINER", raising=False)
+    with patch("standard_tooling.bin.st_validate._in_dev_container", return_value=False):
+        assert main([]) == 1
+
+
+# -- --check common -----------------------------------------------------------
+
+
+def test_check_common_runs_common_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0) as mock,
+    ):
+        result = main(["--check", "common"])
+    assert result == 0
+    mock.assert_called_once()
+
+
+# -- --check lint (language-specific) -----------------------------------------
+
+
+def test_check_lint_runs_install_then_lint(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    calls: list[str] = []
+
+    def mock_run_commands(cmds: list[str], label: str) -> int:
+        calls.extend(cmds)
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_run_commands),
+    ):
+        result = main(["--check", "lint"])
+    assert result == 0
+    assert "uv sync --frozen --group dev" in calls
+    assert "ruff check src/ tests/" in calls
+
+
+def test_check_lint_no_commands_for_shell(tmp_path: Path) -> None:
+    _write_config(tmp_path, "shell")
+    with patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path):
+        result = main(["--check", "lint"])
+    assert result == 0
+
+
+# -- No --check (run all) ----------------------------------------------------
+
+
+def test_run_all_calls_common_then_language_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+    order: list[str] = []
+
+    def mock_common(repo_root: Path) -> int:
+        order.append("common")
+        return 0
+
+    def mock_commands(cmds: list[str], label: str) -> int:
+        order.append(label)
+        return 0
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", side_effect=mock_common),
+        patch("standard_tooling.bin.st_validate._run_commands", side_effect=mock_commands),
+        patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 0
+    assert order[0] == "common"
+    assert "install" in order
+    assert "lint" in order
+    assert "typecheck" in order
+    assert "test" in order
+    assert "audit" in order
+
+
+def test_run_all_stops_on_failure(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    def mock_common(repo_root: Path) -> int:
+        return 1
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", side_effect=mock_common),
+    ):
+        result = main([])
+    assert result == 1
+
+
+def test_run_all_includes_custom_validator(tmp_path: Path) -> None:
+    _write_config(tmp_path, "python")
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._run_commands", return_value=0),
+        patch(
+            "standard_tooling.bin.st_validate._find_custom_validator",
+            return_value="/path/to/custom",
+        ),
+        patch(
+            "standard_tooling.bin.st_validate._run_custom_validator",
+            return_value=0,
+        ) as mock_custom,
+    ):
+        result = main([])
+    assert result == 0
+    mock_custom.assert_called_once()
+
+
+def test_run_all_language_none_skips_language_checks(tmp_path: Path) -> None:
+    _write_config(tmp_path, "none")
+
+    with (
+        patch("standard_tooling.bin.st_validate.git.repo_root", return_value=tmp_path),
+        patch("standard_tooling.bin.st_validate._run_common_checks", return_value=0),
+        patch("standard_tooling.bin.st_validate._find_custom_validator", return_value=None),
+    ):
+        result = main([])
+    assert result == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_st_validate.py -v`
+Expected: FAIL — module `standard_tooling.bin.st_validate` does not
+exist.
+
+- [ ] **Step 3: Implement `st-validate` command**
+
+Create `src/standard_tooling/bin/st_validate.py`:
+
+```python
+"""Unified validation command.
+
+Reads primary_language from standard-tooling.toml, then either runs a
+specific check type (--check) or all checks in sequence:
+  common → install → lint → typecheck → test → audit → custom
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from standard_tooling.lib import config, git
+from standard_tooling.lib.validate_commands import CheckKind, language_commands
+
+_CHECK_KINDS = {
+    "common": None,
+    "lint": CheckKind.LINT,
+    "typecheck": CheckKind.TYPECHECK,
+    "test": CheckKind.TEST,
+    "audit": CheckKind.AUDIT,
+}
+
+_LANGUAGE_CHECK_ORDER = [
+    CheckKind.LINT,
+    CheckKind.TYPECHECK,
+    CheckKind.TEST,
+    CheckKind.AUDIT,
+]
+
+
+def _in_dev_container() -> bool:
+    return Path("/.dockerenv").exists() or bool(os.environ.get("ST_IN_DEV_CONTAINER"))
+
+
+def _run_commands(cmds: list[str], label: str) -> int:
+    for cmd in cmds:
+        print(f"Running ({label}): {cmd}")
+        result = subprocess.run(  # noqa: S603
+            cmd, shell=True, check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+def _run_common_checks(repo_root: Path) -> int:
+    # Import here to avoid circular dependency and keep common checks
+    # self-contained in their existing module.
+    from standard_tooling.bin.validate_local_common_container import main as common_main
+    return common_main()
+
+
+def _find_custom_validator(repo_root: Path) -> str | None:
+    scripts_bin = repo_root / "scripts" / "bin"
+    entry_point = shutil.which("st-validate-local-custom")
+    if entry_point is not None:
+        return entry_point
+    local = scripts_bin / "validate-local-custom"
+    if local.is_file() and os.access(local, os.X_OK):
+        return str(local)
+    return None
+
+
+def _run_custom_validator(path: str) -> int:
+    print(f"Running: {path}")
+    result = subprocess.run((path,), check=False)  # noqa: S603
+    return result.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="st-validate",
+        description="Run validation checks from the command registry.",
+    )
+    parser.add_argument(
+        "--check",
+        choices=list(_CHECK_KINDS.keys()),
+        default=None,
+        help="Run only this check type. Omit to run all.",
+    )
+    args = parser.parse_args(argv)
+
+    if not _in_dev_container():
+        print(
+            "ERROR: st-validate must run inside a dev container.\n"
+            "       Run: st-docker-run -- st-validate",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo_root = git.repo_root()
+
+    try:
+        st_config = config.read_config(repo_root)
+        language = st_config.project.primary_language
+    except FileNotFoundError:
+        language = ""
+    except config.ConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.check is not None:
+        return _run_single_check(args.check, language, repo_root)
+    return _run_all_checks(language, repo_root)
+
+
+def _run_single_check(check: str, language: str, repo_root: Path) -> int:
+    if check == "common":
+        return _run_common_checks(repo_root)
+
+    kind = _CHECK_KINDS[check]
+    cmds = language_commands(language, kind)
+    if not cmds:
+        print(f"No {check} commands for language '{language}'")
+        return 0
+
+    install_cmds = language_commands(language, CheckKind.INSTALL)
+    if install_cmds:
+        rc = _run_commands(install_cmds, "install")
+        if rc != 0:
+            return rc
+
+    return _run_commands(cmds, check)
+
+
+def _run_all_checks(language: str, repo_root: Path) -> int:
+    print("=" * 40)
+    print("st-validate")
+    print(f"primary_language: {language or '<not set>'}")
+    print("=" * 40)
+    print()
+
+    rc = _run_common_checks(repo_root)
+    if rc != 0:
+        return rc
+
+    if language and language != "none":
+        install_cmds = language_commands(language, CheckKind.INSTALL)
+        if install_cmds:
+            print()
+            rc = _run_commands(install_cmds, "install")
+            if rc != 0:
+                return rc
+
+        for kind in _LANGUAGE_CHECK_ORDER:
+            cmds = language_commands(language, kind)
+            if cmds:
+                print()
+                rc = _run_commands(cmds, kind.value)
+                if rc != 0:
+                    return rc
+
+    custom = _find_custom_validator(repo_root)
+    if custom is not None:
+        print()
+        rc = _run_custom_validator(custom)
+        if rc != 0:
+            return rc
+
+    print()
+    print("=" * 40)
+    print("st-validate: all checks passed")
+    print("=" * 40)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Add entry point to pyproject.toml**
+
+Add to `[project.scripts]`:
+
+```
+st-validate = "standard_tooling.bin.st_validate:main"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_st_validate.py -v`
+Expected: all PASS
+
+Run full suite to verify no regressions:
+`cd /Users/pmoore/dev/github/standard-tooling && uv run pytest -v`
+
+- [ ] **Step 6: Commit**
+
+```
+st-commit --type feat --scope validate --message "add st-validate command with registry-driven check dispatch" --agent claude
+```
+
+### Task 3: Add hadolint and actionlint to common checks
+
+**Files:**
+- Modify: `src/standard_tooling/bin/validate_local_common_container.py`
+- Modify: `tests/standard_tooling/test_validate_local_common_container.py`
+
+The pushback review identified that ci-quality.yml currently runs
+hadolint and actionlint in the common job, but
+`validate_local_common_container.py` does not. Add them to close
+the parity gap.
+
+- [ ] **Step 1: Write failing tests for hadolint and actionlint**
+
+Add to `tests/standard_tooling/test_validate_local_common_container.py`
+tests that verify hadolint runs when `Dockerfile*` files exist and
+actionlint runs when `.github/workflows/` exists.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Add hadolint and actionlint to common container checks**
+
+In `src/standard_tooling/bin/validate_local_common_container.py`, add
+after the yamllint block:
+
+```python
+    dockerfile_files = _find_dockerfiles(repo_root)
+    if dockerfile_files:
+        print(f"Running: hadolint ({len(dockerfile_files)} files)")
+        result = subprocess.run(
+            ["hadolint", *dockerfile_files],
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+
+    workflows_dir = repo_root / ".github" / "workflows"
+    if workflows_dir.is_dir():
+        print("Running: actionlint")
+        result = subprocess.run(
+            ["actionlint"],
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+```
+
+Add the file-discovery helper:
+
+```python
+def _find_dockerfiles(repo_root: Path) -> list[str]:
+    found: list[str] = []
+    for path in repo_root.iterdir():
+        if path.is_file() and path.name.startswith("Dockerfile"):
+            found.append(str(path))
+    return sorted(found)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```
+st-commit --type feat --scope validate --message "add hadolint and actionlint to common validation checks" --agent claude
+```
+
+### Task 4: Wire docker_cache.py to use registry install commands
+
+**Files:**
+- Modify: `src/standard_tooling/lib/docker_cache.py`
+- Modify: `tests/standard_tooling/test_docker_cache.py`
+
+Replace the `_WARMUP_COMMANDS` dict with a lookup against the command
+registry.
+
+- [ ] **Step 1: Write a test that verifies registry-driven warmup**
+
+Add a test to `tests/standard_tooling/test_docker_cache.py` that
+asserts the warmup command for Python comes from the registry (i.e.,
+`uv sync --frozen --group dev`) rather than the old hardcoded value
+(`uv sync --group dev`).
+
+- [ ] **Step 2: Replace `_WARMUP_COMMANDS` with registry lookup**
+
+In `src/standard_tooling/lib/docker_cache.py`, remove the
+`_WARMUP_COMMANDS` dict and replace its usage with:
+
+```python
+from standard_tooling.lib.validate_commands import CheckKind, language_commands
+
+def _warmup_command(lang: str) -> str:
+    cmds = language_commands(lang, CheckKind.INSTALL)
+    return " && ".join(cmds) if cmds else ""
+```
+
+Update `_build_cached_image` to call `_warmup_command(lang)` instead
+of `_WARMUP_COMMANDS.get(lang)`.
+
+- [ ] **Step 3: Run tests to verify no regressions**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_docker_cache.py -v`
+
+- [ ] **Step 4: Commit**
+
+```
+st-commit --type refactor --scope docker --message "replace _WARMUP_COMMANDS with registry-driven install lookup" --agent claude
+```
+
+### Task 5: Update st-finalize-repo to call st-validate
+
+**Files:**
+- Modify: `src/standard_tooling/bin/finalize_repo.py`
+- Modify: `tests/standard_tooling/test_finalize_repo.py`
+
+Update the post-finalization validation call to use `st-validate`
+instead of `st-validate-local`.
+
+- [ ] **Step 1: Update the command in finalize_repo.py**
+
+In `src/standard_tooling/bin/finalize_repo.py`, change lines 242-244:
+
+From:
+```python
+            cmd: tuple[str, ...] = ("st-docker-run", "--", "uv", "run", "st-validate-local")
+        else:
+            cmd = ("st-docker-run", "--", "st-validate-local")
+```
+
+To:
+```python
+            cmd: tuple[str, ...] = ("st-docker-run", "--", "uv", "run", "st-validate")
+        else:
+            cmd = ("st-docker-run", "--", "st-validate")
+```
+
+Also update the dry-run message on line 250.
+
+- [ ] **Step 2: Update tests**
+
+Update `tests/standard_tooling/test_finalize_repo.py` to assert the
+new command strings.
+
+- [ ] **Step 3: Run tests to verify**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standard_tooling/test_finalize_repo.py -v`
+
+- [ ] **Step 4: Commit**
+
+```
+st-commit --type refactor --scope finalize --message "call st-validate instead of st-validate-local in post-finalization" --agent claude
+```
+
+### Task 6: Full validation and release
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest -v --cov --cov-branch --cov-fail-under=100`
+
+- [ ] **Step 2: Run local validation**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && st-docker-run -- uv run st-validate-local`
+
+- [ ] **Step 3: Coordinate with #318 standard-tooling work**
+
+Ensure the #318 tasks (st-version, [publish] config) are also complete
+on the same branch or merged before this release.
+
+- [ ] **Step 4: Release standard-tooling**
+
+Tag and release the combined standard-tooling version containing
+`st-validate`, registry fixes, and #318 work.
+
+---
+
+## Phase 2: standard-actions workflows
+
+> **Repo:** `standard-actions`
+> **Branch:** `feature/337-ci-workflow-reset` (worktree:
+> `.worktrees/issue-337-ci-workflow-reset/`)
+> **Prereq:** Phase 1 complete (standard-tooling released with
+> `st-validate`)
+
+### Task 7: Implement ci-quality.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-quality.yml`
+
+Replace the stub lint and typecheck jobs with real implementations.
+Keep the common job but replace inline tool invocations with
+`st-validate --check common`.
+
+- [ ] **Step 1: Rewrite ci-quality.yml**
+
+```yaml
+name: CI Quality
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        type: string
+        required: true
+      versions:
+        type: string
+        required: true
+
+jobs:
+  common:
+    name: common
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run common quality checks
+        run: st-validate --check common
+
+  lint:
+    name: lint / ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run lint
+        run: st-validate --check lint
+
+  typecheck:
+    name: typecheck / ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run typecheck
+        run: st-validate --check typecheck
+```
+
+- [ ] **Step 2: Validate actionlint passes**
+
+Run: `actionlint .github/workflows/ci-quality.yml`
+
+- [ ] **Step 3: Commit**
+
+```
+st-commit --type feat --scope ci --message "implement ci-quality.yml with st-validate dispatch" --agent claude
+```
+
+### Task 8: Implement ci-test.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-test.yml`
+
+Replace stub unit job. Remove integration-tests input (per pushback
+review: integration tests are repo-local).
+
+- [ ] **Step 1: Rewrite ci-test.yml**
+
+```yaml
+name: CI Test
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        type: string
+        required: true
+      versions:
+        type: string
+        required: true
+
+jobs:
+  unit:
+    name: unit / ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run unit tests
+        run: st-validate --check test
+```
+
+- [ ] **Step 2: Validate actionlint passes**
+
+- [ ] **Step 3: Commit**
+
+```
+st-commit --type feat --scope ci --message "implement ci-test.yml with st-validate dispatch" --agent claude
+```
+
+### Task 9: Implement ci-audit.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-audit.yml`
+
+Replace stub dependencies job.
+
+- [ ] **Step 1: Rewrite ci-audit.yml**
+
+```yaml
+name: CI Audit
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        type: string
+        required: true
+      versions:
+        type: string
+        required: true
+
+jobs:
+  dependencies:
+    name: dependencies / ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run dependency audit
+        run: st-validate --check audit
+```
+
+- [ ] **Step 2: Validate actionlint passes**
+
+- [ ] **Step 3: Commit**
+
+```
+st-commit --type feat --scope ci --message "implement ci-audit.yml with st-validate dispatch" --agent claude
+```
+
+### Task 10: Implement ci-release.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-release.yml`
+
+Replace stub version-bump job with the version-divergence action
+using `st-version show`.
+
+- [ ] **Step 1: Rewrite ci-release.yml**
+
+```yaml
+name: CI Release
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        type: string
+        required: true
+      run-release:
+        type: boolean
+        default: true
+
+jobs:
+  version-bump:
+    name: version-bump
+    if: ${{ inputs.run-release }}
+    runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify version bump
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        with:
+          head-version-command: st-version show
+          main-version-command: st-version show
+```
+
+Note: The exact integration with the version-divergence action for the
+main branch comparison depends on the #318 `st-version` implementation.
+The action may need a worktree or ref-based version extraction. Adjust
+during implementation.
+
+- [ ] **Step 2: Validate actionlint passes**
+
+- [ ] **Step 3: Commit**
+
+```
+st-commit --type feat --scope ci --message "implement ci-release.yml with st-version version-bump gate" --agent claude
+```
+
+### Task 11: Update ci.yml self-referencing orchestrator
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+Ensure the orchestrator correctly calls all reusable workflows for
+standard-actions (a shell repo).
+
+- [ ] **Step 1: Review and update ci.yml if needed**
+
+The current ci.yml already calls ci-quality, ci-security, and
+ci-release. Verify inputs match the updated workflow signatures
+(e.g., `versions` is required for ci-quality). No ci-test or ci-audit
+calls needed for a shell repo.
+
+- [ ] **Step 2: Commit if changes were needed**
+
+```
+st-commit --type ci --message "update ci.yml orchestrator for updated workflow signatures" --agent claude
+```
+
+### Task 12: Validate and release
+
+- [ ] **Step 1: Run local validation**
+
+Run: `st-docker-run -- st-validate-local`
+
+- [ ] **Step 2: Push branch and create PR**
+
+Push `feature/337-ci-workflow-reset` and create PR targeting `develop`.
+The self-referencing CI will test the updated workflows against the
+standard-actions repo itself.
+
+- [ ] **Step 3: Verify CI passes**
+
+All checks should pass:
+- `quality / common` — runs st-validate --check common (shellcheck,
+  markdownlint, yamllint, actionlint, repo-profile)
+- `quality / lint / latest` — runs st-validate --check lint (exits 0,
+  no lint commands for shell)
+- `quality / typecheck / latest` — runs st-validate --check typecheck
+  (exits 0, no typecheck commands for shell)
+- `security / *` — unchanged, already working
+- `release / version-bump` — runs version-divergence check
+
+- [ ] **Step 4: Merge and tag v1.6**
+
+---
+
+## Phase 3: consumer re-sweep
+
+> **Repos:** mq-rest-admin-python, ai-research-methodology, then all
+> remaining managed repos
+> **Prereq:** Phase 2 complete (standard-actions v1.6 released)
+
+### Task 13: Update mq-rest-admin-python
+
+- [ ] **Step 1: Replace bespoke CI with thin wrappers**
+
+Rewrite `.github/workflows/ci.yml` to use reusable workflows from
+`standard-actions@v1.6`. Remove all bespoke lint, typecheck, test,
+audit jobs.
+
+- [ ] **Step 2: Remove scripts/dev/ validation scripts**
+
+Remove `scripts/dev/lint.sh`, `typecheck.sh`, `test.sh`, `audit.sh`.
+Keep `scripts/dev/test-integration.sh` if it exists (integration tests
+are repo-local). Keep any `validate_*` scripts that are tracked by
+centralization issues (#526-#532).
+
+- [ ] **Step 3: Verify CI passes**
+
+- [ ] **Step 4: Commit and merge**
+
+### Task 14: Update ai-research-methodology
+
+Same pattern as Task 13.
+
+### Task 15: Update remaining repos
+
+Repeat for each remaining managed repo: standard-tooling,
+mq-rest-admin-go, mq-rest-admin-java, mq-rest-admin-ruby,
+mq-rest-admin-rust, standard-tooling-docker, standard-tooling-plugin.

--- a/docs/plans/2026-05-05-ci-workflow-reset.md
+++ b/docs/plans/2026-05-05-ci-workflow-reset.md
@@ -31,9 +31,11 @@ a single release.
 > **Branch:** create from `develop`
 > **Prereq:** none
 
-Phase 1 may be split across multiple PRs. Tasks 1-2 form a natural PR
-(registry fixes + install commands). Tasks 3-5 form a second PR
-(`st-validate` command). Task 6 is a third PR (wiring consumers).
+Phase 1 is combined with the publish-and-docs rationalization (#318).
+Both specs' standard-tooling work ships in a single release. Tasks 1-3
+are from this spec (registry + `st-validate`). Tasks 4-5 wire existing
+code to use the new registry. Task 6 covers the `st-version` dependency
+from #318. Task 7 is the combined release.
 
 ### Task 1: Fix command registry and add install commands
 
@@ -724,7 +726,35 @@ Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest tests/standa
 st-commit --type refactor --scope finalize --message "call st-validate instead of st-validate-local in post-finalization" --agent claude
 ```
 
-### Task 6: Full validation and release
+### Task 6: Build `st-version` library and CLI (from #318)
+
+ci-release.yml (Task 10) depends on `st-version show` to extract
+version strings for the version-divergence comparison. This task
+implements `st-version` as defined in the publish-and-docs
+rationalization plan.
+
+**Full task details:** See
+`docs/plans/2026-05-05-publish-and-docs-rationalization.md`, Tasks 2-3.
+Those tasks define the complete `st-version` library (per-language
+version discovery, show, show --major-minor, bump) and the CLI entry
+point. Do not duplicate the steps here — execute Tasks 2-3 from that
+plan.
+
+**Files (from #318 plan):**
+- Create: `src/standard_tooling/lib/version.py`
+- Create: `src/standard_tooling/bin/version.py`
+- Create: `tests/standard_tooling/test_version.py`
+- Create: `tests/standard_tooling/test_version_cli.py`
+- Modify: `pyproject.toml` (add `st-version` entry point)
+
+- [ ] **Step 1: Execute #318 Task 2 (st-version library)**
+- [ ] **Step 2: Execute #318 Task 3 (st-version bump + CLI)**
+- [ ] **Step 3: Verify st-version show works**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run st-version show`
+Expected: outputs the current version from `VERSION` or `pyproject.toml`
+
+### Task 7: Full validation and release
 
 - [ ] **Step 1: Run full test suite**
 
@@ -734,15 +764,19 @@ Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run pytest -v --cov --c
 
 Run: `cd /Users/pmoore/dev/github/standard-tooling && st-docker-run -- uv run st-validate-local`
 
-- [ ] **Step 3: Coordinate with #318 standard-tooling work**
+- [ ] **Step 3: Verify all Phase 1 deliverables**
 
-Ensure the #318 tasks (st-version, [publish] config) are also complete
-on the same branch or merged before this release.
+Confirm these are all present and tested:
+- `st-validate` command (Tasks 1-3)
+- Registry with install commands and fixed Python entries (Task 1)
+- docker_cache.py using registry (Task 4)
+- finalize-repo using st-validate (Task 5)
+- `st-version` command (Task 6)
 
 - [ ] **Step 4: Release standard-tooling**
 
 Tag and release the combined standard-tooling version containing
-`st-validate`, registry fixes, and #318 work.
+`st-validate`, registry fixes, and `st-version`.
 
 ---
 
@@ -752,9 +786,9 @@ Tag and release the combined standard-tooling version containing
 > **Branch:** `feature/337-ci-workflow-reset` (worktree:
 > `.worktrees/issue-337-ci-workflow-reset/`)
 > **Prereq:** Phase 1 complete (standard-tooling released with
-> `st-validate`)
+> `st-validate` and `st-version`)
 
-### Task 7: Implement ci-quality.yml
+### Task 8: Implement ci-quality.yml
 
 **Files:**
 - Modify: `.github/workflows/ci-quality.yml`
@@ -829,7 +863,7 @@ Run: `actionlint .github/workflows/ci-quality.yml`
 st-commit --type feat --scope ci --message "implement ci-quality.yml with st-validate dispatch" --agent claude
 ```
 
-### Task 8: Implement ci-test.yml
+### Task 9: Implement ci-test.yml
 
 **Files:**
 - Modify: `.github/workflows/ci-test.yml`
@@ -876,7 +910,7 @@ jobs:
 st-commit --type feat --scope ci --message "implement ci-test.yml with st-validate dispatch" --agent claude
 ```
 
-### Task 9: Implement ci-audit.yml
+### Task 10: Implement ci-audit.yml
 
 **Files:**
 - Modify: `.github/workflows/ci-audit.yml`
@@ -922,7 +956,7 @@ jobs:
 st-commit --type feat --scope ci --message "implement ci-audit.yml with st-validate dispatch" --agent claude
 ```
 
-### Task 10: Implement ci-release.yml
+### Task 11: Implement ci-release.yml
 
 **Files:**
 - Modify: `.github/workflows/ci-release.yml`
@@ -964,9 +998,9 @@ jobs:
           main-version-command: st-version show
 ```
 
-Note: The exact integration with the version-divergence action for the
-main branch comparison depends on the #318 `st-version` implementation.
-The action may need a worktree or ref-based version extraction. Adjust
+Note: `st-version show` is built in Task 6 (Phase 1). The exact
+integration with the version-divergence action for the main branch
+comparison may need a worktree or ref-based version extraction. Adjust
 during implementation.
 
 - [ ] **Step 2: Validate actionlint passes**
@@ -977,7 +1011,7 @@ during implementation.
 st-commit --type feat --scope ci --message "implement ci-release.yml with st-version version-bump gate" --agent claude
 ```
 
-### Task 11: Update ci.yml self-referencing orchestrator
+### Task 12: Update ci.yml self-referencing orchestrator
 
 **Files:**
 - Modify: `.github/workflows/ci.yml`
@@ -998,7 +1032,7 @@ calls needed for a shell repo.
 st-commit --type ci --message "update ci.yml orchestrator for updated workflow signatures" --agent claude
 ```
 
-### Task 12: Validate and release
+### Task 13: Validate and release
 
 - [ ] **Step 1: Run local validation**
 
@@ -1032,7 +1066,7 @@ All checks should pass:
 > remaining managed repos
 > **Prereq:** Phase 2 complete (standard-actions v1.6 released)
 
-### Task 13: Update mq-rest-admin-python
+### Task 14: Update mq-rest-admin-python
 
 - [ ] **Step 1: Replace bespoke CI with thin wrappers**
 
@@ -1051,11 +1085,11 @@ centralization issues (#526-#532).
 
 - [ ] **Step 4: Commit and merge**
 
-### Task 14: Update ai-research-methodology
+### Task 15: Update ai-research-methodology
 
-Same pattern as Task 13.
+Same pattern as Task 14.
 
-### Task 15: Update remaining repos
+### Task 16: Update remaining repos
 
 Repeat for each remaining managed repo: standard-tooling,
 mq-rest-admin-go, mq-rest-admin-java, mq-rest-admin-ruby,

--- a/docs/plans/2026-05-05-ci-workflow-reset.md
+++ b/docs/plans/2026-05-05-ci-workflow-reset.md
@@ -728,17 +728,23 @@ st-commit --type refactor --scope finalize --message "call st-validate instead o
 
 ### Task 6: Build `st-version` library and CLI (from #318)
 
-ci-release.yml (Task 10) depends on `st-version show` to extract
+ci-release.yml (Task 11) depends on `st-version show` to extract
 version strings for the version-divergence comparison. This task
 implements `st-version` as defined in the publish-and-docs
 rationalization plan.
+
+ci-release.yml also requires `st-version show --ref <ref>` to read the
+version from a git ref (e.g., `origin/main`) without checking out that
+branch. The `--ref` argument reads the version file via
+`git show <ref>:<path>` instead of the filesystem. This must be included
+in the `st-version` implementation (see #318 plan Tasks 2-3).
 
 **Full task details:** See
 `docs/plans/2026-05-05-publish-and-docs-rationalization.md`, Tasks 2-3.
 Those tasks define the complete `st-version` library (per-language
 version discovery, show, show --major-minor, bump) and the CLI entry
 point. Do not duplicate the steps here — execute Tasks 2-3 from that
-plan.
+plan, ensuring `--ref` support is included.
 
 **Files (from #318 plan):**
 - Create: `src/standard_tooling/lib/version.py`
@@ -753,6 +759,11 @@ plan.
 
 Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run st-version show`
 Expected: outputs the current version from `VERSION` or `pyproject.toml`
+
+- [ ] **Step 4: Verify st-version show --ref works**
+
+Run: `cd /Users/pmoore/dev/github/standard-tooling && uv run st-version show --ref HEAD`
+Expected: outputs the same version (reading via `git show` instead of filesystem)
 
 ### Task 7: Full validation and release
 
@@ -827,7 +838,7 @@ jobs:
   lint:
     name: lint / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -841,7 +852,7 @@ jobs:
   typecheck:
     name: typecheck / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -890,7 +901,7 @@ jobs:
   unit:
     name: unit / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -936,7 +947,7 @@ jobs:
   dependencies:
     name: dependencies / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -995,13 +1006,13 @@ jobs:
         uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
         with:
           head-version-command: st-version show
-          main-version-command: st-version show
+          main-version-command: st-version show --ref origin/main
 ```
 
-Note: `st-version show` is built in Task 6 (Phase 1). The exact
-integration with the version-divergence action for the main branch
-comparison may need a worktree or ref-based version extraction. Adjust
-during implementation.
+`st-version show` reads the version file from the filesystem (PR
+branch). `st-version show --ref origin/main` reads the version file
+via `git show origin/main:<path>`, avoiding any worktree or checkout
+manipulation. The `--ref` argument is built in Task 6 (Phase 1).
 
 - [ ] **Step 2: Validate actionlint passes**
 
@@ -1036,7 +1047,7 @@ st-commit --type ci --message "update ci.yml orchestrator for updated workflow s
 
 - [ ] **Step 1: Run local validation**
 
-Run: `st-docker-run -- st-validate-local`
+Run: `st-docker-run -- st-validate`
 
 - [ ] **Step 2: Push branch and create PR**
 

--- a/docs/specs/2026-05-05-ci-workflow-reset-design.md
+++ b/docs/specs/2026-05-05-ci-workflow-reset-design.md
@@ -48,6 +48,7 @@ and CI workflows.
 ## Scope
 
 **In scope:**
+
 - `st-validate` command in standard-tooling (replaces `st-validate-local`
   chain)
 - Command registry fixes (`validate_commands.py`)
@@ -58,6 +59,7 @@ and CI workflows.
   standard-tooling release (`st-version` dependency)
 
 **Out of scope (tracked separately):**
+
 - Rename `st-validate-local` → `st-validate` at the CLI level (entry
   point alias — cosmetic, do after the functional work)
 - Consumer repo re-sweep (blocked by this work)
@@ -75,7 +77,7 @@ and CI workflows.
 
 ### Interface
 
-```
+```text
 st-validate                      # run all checks: common → language-specific → custom
 st-validate --check common       # common checks only
 st-validate --check lint         # language-specific lint only
@@ -170,24 +172,28 @@ the registry, eliminating the duplication.
 ### Check command fixes
 
 **Python lint:**
-```
+
+```text
 ruff check src/ tests/
 ruff format --check src/ tests/
 ```
 
 **Python typecheck:**
-```
+
+```text
 mypy src/ tests/
 ty check src tests
 ```
 
 **Python test:**
-```
+
+```text
 pytest --cov=src --cov-branch --cov-fail-under=100
 ```
 
 **Python audit:**
-```
+
+```text
 uv sync --check --frozen --group dev
 uv lock --check
 pip-audit
@@ -195,6 +201,7 @@ pip-licenses --allow-only=<standard-allowlist>
 ```
 
 Changes from current registry:
+
 - lint and typecheck now target `src/` and `tests/` (not just `src/`)
 - test coverage scoped to `src` directory (not package-name-specific)
 - `pip-audit` is a plain invocation (no `-r requirements.txt` args,
@@ -444,30 +451,31 @@ release.
 
 **From #318:**
 
-5. Build `st-version` library and CLI (`show`, `show --major-minor`,
-   `bump` with per-language version discovery and lockfile maintenance).
-6. Extend config schema with `[publish]` section.
-7. Extend `st-github-config` for publish validation.
+1. Build `st-version` library and CLI (`show`, `show --major-minor`,
+   `show --ref`, `bump` with per-language version discovery and
+   lockfile maintenance).
+2. Extend config schema with `[publish]` section.
+3. Extend `st-github-config` for publish validation.
 
 **Combined:**
 
-8. Tests, validation, release as a single standard-tooling version.
+1. Tests, validation, release as a single standard-tooling version.
 
 ### Phase 2: standard-actions
 
-6. Implement ci-quality.yml (common + lint + typecheck jobs).
-7. Implement ci-test.yml (unit job; integration deferred).
-8. Implement ci-audit.yml (dependencies job).
-9. Implement ci-release.yml (version-bump job using existing action).
-10. Validate self-referencing CI passes.
-11. Release as standard-actions v1.6.
+1. Implement ci-quality.yml (common + lint + typecheck jobs).
+2. Implement ci-test.yml (unit job; integration deferred).
+3. Implement ci-audit.yml (dependencies job).
+4. Implement ci-release.yml (version-bump job using existing action).
+5. Validate self-referencing CI passes.
+6. Release as standard-actions v1.6.
 
 ### Phase 3: consumer re-sweep
 
-12. Update each consumer repo: replace bespoke CI with thin wrappers,
-    remove `scripts/dev/` scripts, pin to standard-actions v1.6.
-13. Start with mq-rest-admin-python (where the problems were found),
-    then ai-research-methodology, then remaining repos.
+1. Update each consumer repo: replace bespoke CI with thin wrappers,
+   remove `scripts/dev/` scripts, pin to standard-actions v1.6.
+2. Start with mq-rest-admin-python (where the problems were found),
+   then ai-research-methodology, then remaining repos.
 
 ---
 

--- a/docs/specs/2026-05-05-ci-workflow-reset-design.md
+++ b/docs/specs/2026-05-05-ci-workflow-reset-design.md
@@ -1,0 +1,441 @@
+# CI reusable workflow reset — unified validation architecture
+
+**Issue:** [#337](https://github.com/wphillipmoore/standard-actions/issues/337)
+**Date:** 2026-05-05
+**Status:** Design
+
+## Context
+
+Three of five CI reusable workflows in standard-actions v1.5 are stubs
+that echo a placeholder and exit 0. A fourth (ci-quality.yml) has real
+tool invocations but suppresses 4 of 5 failures with `|| true`, and its
+language-specific lint and typecheck jobs are also stubs. Only
+ci-security.yml is fully implemented.
+
+Consumer repos that upgraded to v1.5 worked around the stubs by writing
+fully bespoke CI jobs — duplicating the logic that should live in the
+reusable workflows. This is the exact opposite of the intended
+architecture.
+
+The root cause is that the validation command registry
+(`validate_commands.py` in standard-tooling) defines canonical commands
+per language but nothing executes from it. The execution path goes
+through bespoke `scripts/dev/{lint,typecheck,test,audit}.sh` scripts in
+each consumer repo. Those scripts duplicate what the registry already
+knows, and have drifted across repos.
+
+This design unifies execution around a single `st-validate` command
+that reads from the registry and is called by both local validation
+and CI workflows.
+
+## Design goals
+
+1. One command — `st-validate` — serves both local pre-commit and CI.
+2. All check commands are centrally defined in standard-tooling's
+   command registry. No bespoke `scripts/dev/` scripts.
+3. CI reusable workflows in standard-actions are thin: checkout,
+   container, `st-validate --check <type>`.
+4. Check names produced by CI match what `st-github-config` generates
+   for branch protection rulesets.
+5. Approach A sequencing: standard-tooling first (new `st-validate`
+   command + registry fixes), then standard-actions (workflow
+   implementations), then consumer repo re-sweep.
+
+## Scope
+
+**In scope:**
+- `st-validate` command in standard-tooling (replaces `st-validate-local`
+  chain)
+- Command registry fixes (`validate_commands.py`)
+- Install command registry (dependency setup per language)
+- All five CI reusable workflow implementations in standard-actions
+- Self-referencing CI validation in standard-actions
+
+**Out of scope (tracked separately):**
+- Rename `st-validate-local` → `st-validate` at the CLI level (entry
+  point alias — cosmetic, do after the functional work)
+- Consumer repo re-sweep (blocked by this work)
+- Custom validation script centralization (#526, #527, #528, #531, #532,
+  #543)
+- Migration of registry from Python code to TOML data file (future v2.0)
+- Integration test framework (repo-specific by nature)
+- `standards-and-conventions` repo retirement
+
+---
+
+## Part 1: `st-validate` command (standard-tooling)
+
+### Interface
+
+```
+st-validate                      # run all checks: common → language-specific → custom
+st-validate --check common       # common checks only
+st-validate --check lint         # language-specific lint only
+st-validate --check typecheck    # language-specific typecheck only
+st-validate --check test         # language-specific test only
+st-validate --check audit        # language-specific audit only
+```
+
+### Behavior
+
+1. Must run inside a dev container (same `/.dockerenv` /
+   `ST_IN_DEV_CONTAINER` guard as today).
+2. Reads `primary_language` from `standard-tooling.toml`.
+3. If `--check` is specified:
+   - If `common`: run built-in common checks (repo-profile,
+     markdownlint, shellcheck, yamllint) with file-discovery logic.
+   - If `lint`, `typecheck`, `test`, or `audit`: look up install
+     commands for the language from the registry, run them, then
+     look up check commands, run them in sequence. Fail on first
+     failure.
+4. If no `--check` (run-all mode):
+   - Run common checks.
+   - If `primary_language` is set and not `none`: run install, then
+     run lint → typecheck → test → audit from the registry.
+   - If `scripts/bin/validate-local-custom` exists: run it.
+5. Exit 0 only if all checks pass.
+
+### What it replaces
+
+| Current | Replaced by |
+|---|---|
+| `st-validate-local` (orchestrator) | `st-validate` (no `--check`) |
+| `st-validate-local-common` (common checks) | `st-validate --check common` |
+| `st-validate-local-python` | `st-validate --check <type>` |
+| `st-validate-local-go` | `st-validate --check <type>` |
+| `st-validate-local-java` | `st-validate --check <type>` |
+| `st-validate-local-rust` | `st-validate --check <type>` |
+| `scripts/dev/lint.sh` (per repo) | Registry lookup |
+| `scripts/dev/typecheck.sh` (per repo) | Registry lookup |
+| `scripts/dev/test.sh` (per repo) | Registry lookup |
+| `scripts/dev/audit.sh` (per repo) | Registry lookup |
+
+### What stays unchanged
+
+- `st-docker-run` — host-side launcher, picks container image, calls
+  `st-validate` inside it.
+- `scripts/bin/validate-local-custom` — repo-specific escape hatch,
+  runs in no-`--check` mode only.
+- `st-finalize-repo` — calls `st-docker-run -- st-validate` (updated
+  command name, same flow).
+
+### Common checks (built-in logic)
+
+The `common` check type is not a simple command-string lookup. It
+contains file-discovery logic:
+
+1. **repo-profile** — always runs (`st-repo-profile` function call).
+2. **markdownlint** — runs if `*.md` files exist under `docs/site/`
+   or `README.md` exists. Uses bundled canonical config from
+   `standard_tooling.configs`. Respects `[markdownlint].ignore`
+   from `standard-tooling.toml`.
+3. **shellcheck** — runs if `*.sh` files or `scripts/bin/` entries
+   exist under `scripts/`.
+4. **yamllint** — runs if `*.yml` / `*.yaml` files exist under
+   `.github/` or repo root.
+
+This logic is currently in `validate_local_common_container.py` and
+moves into `st-validate` as the `common` check handler.
+
+---
+
+## Part 2: Command registry updates (standard-tooling)
+
+### Install commands (new)
+
+Added to `validate_commands.py` as a new concept — dependency setup
+commands that run before any check.
+
+| Language | Install commands |
+|---|---|
+| Python | `uv sync --frozen --group dev` |
+| Go | `go mod download` |
+| Ruby | `bundle install --jobs 4` |
+| Rust | `cargo fetch` |
+| Java | `./mvnw dependency:resolve -B` |
+
+`docker_cache.py`'s `_WARMUP_COMMANDS` dict is replaced by a call to
+the registry, eliminating the duplication.
+
+### Check command fixes
+
+**Python lint:**
+```
+ruff check src/ tests/
+ruff format --check src/ tests/
+```
+
+**Python typecheck:**
+```
+mypy src/ tests/
+ty check src tests
+```
+
+**Python test:**
+```
+pytest --cov=src --cov-branch --cov-fail-under=100
+```
+
+**Python audit:**
+```
+uv sync --check --frozen --group dev
+uv lock --check
+pip-audit
+pip-licenses --allow-only=<standard-allowlist>
+```
+
+Changes from current registry:
+- lint and typecheck now target `src/` and `tests/` (not just `src/`)
+- test coverage scoped to `src` directory (not package-name-specific)
+- `pip-audit` is a plain invocation (no `-r requirements.txt` args,
+  per #543)
+
+Go, Java, Ruby, and Rust registries are already correct and unchanged.
+
+---
+
+## Part 3: CI reusable workflows (standard-actions)
+
+### Job structure pattern
+
+Every language-specific CI job follows an identical structure:
+
+```yaml
+steps:
+  - name: Checkout code
+    uses: actions/checkout@v6
+
+  - name: Run <check-type>
+    run: st-validate --check <type>
+```
+
+The workflow YAML contains no language-specific logic. `st-validate`
+reads the language from `standard-tooling.toml`, looks up install and
+check commands from the registry, and runs them.
+
+### Container image selection
+
+Each version-matrixed job uses the language-specific dev container:
+
+```yaml
+container: ghcr.io/wphillipmoore/dev-<language>:${{ matrix.version }}
+```
+
+For `shell` and `none` languages, or for language-independent jobs
+(common, version-bump): `ghcr.io/wphillipmoore/dev-base:latest`.
+
+Container images have `st-validate` pre-installed (standard-tooling
+is installed in the dev container images built by
+standard-tooling-docker).
+
+### ci-quality.yml
+
+**Inputs:** `language` (string, required), `versions` (JSON array,
+required)
+
+**Jobs:**
+
+| Job | Matrix | Container | Command | Check name |
+|---|---|---|---|---|
+| `common` | none | `dev-base:latest` | `st-validate --check common` | `quality / common` |
+| `lint / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check lint` | `quality / lint / <ver>` |
+| `typecheck / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check typecheck` | `quality / typecheck / <ver>` |
+
+`lint` and `typecheck` jobs use a conditional `if:` to skip entirely
+when the language has no registry entry for that check type (e.g.,
+`shell` has no lint or typecheck commands). Skipped jobs must not
+produce a GitHub check at all — `st-github-config` does not generate
+required status checks for unsupported check types, so a phantom
+check would create a ruleset mismatch.
+
+### ci-test.yml
+
+**Inputs:** `language` (string, required), `versions` (JSON array,
+required), `integration-tests` (boolean, default: false)
+
+**Jobs:**
+
+| Job | Matrix | Container | Command | Check name |
+|---|---|---|---|---|
+| `unit / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check test` | `test / unit / <ver>` |
+| `integration / <ver>` | versions | `dev-<lang>:<ver>` | repo-specific | `test / integration / <ver>` |
+
+The `integration` job is conditional on `inputs.integration-tests`.
+Integration tests are repo-specific by nature — the job runs a
+repo-defined script or command, not the registry. The exact
+interface for specifying integration test commands is deferred;
+the simplest option is `scripts/dev/test-integration.sh` as a
+convention.
+
+### ci-audit.yml
+
+**Inputs:** `language` (string, required), `versions` (JSON array,
+required)
+
+**Jobs:**
+
+| Job | Matrix | Container | Command | Check name |
+|---|---|---|---|---|
+| `dependencies / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check audit` | `audit / dependencies / <ver>` |
+
+### ci-release.yml
+
+**Inputs:** `language` (string, required), `run-release` (boolean,
+default: true)
+
+**Jobs:**
+
+| Job | Matrix | Container | Command | Check name |
+|---|---|---|---|---|
+| `version-bump` | none | `dev-base:latest` | `version-divergence` action | `release / version-bump` |
+
+Uses the existing `actions/release-gates/version-divergence` composite
+action. No version matrix. Skipped when `run-release` is false.
+
+### ci-security.yml
+
+**No changes.** Already fully implemented.
+
+### ci.yml (self-referencing orchestrator)
+
+Standard-actions is a `shell` language repo. Its orchestrator calls:
+
+```yaml
+jobs:
+  quality:
+    uses: ./.github/workflows/ci-quality.yml
+    with:
+      language: shell
+      versions: '["latest"]'
+
+  security:
+    uses: ./.github/workflows/ci-security.yml
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: shell
+      run-codeql: false
+
+  release:
+    uses: ./.github/workflows/ci-release.yml
+    with:
+      language: shell
+```
+
+Since `shell` has no lint, typecheck, test, or audit entries in the
+registry, only `quality / common`, security jobs, and
+`release / version-bump` run. This is correct.
+
+Does not call `ci-test.yml` or `ci-audit.yml` (no tests or auditable
+dependencies for a shell/YAML repo).
+
+---
+
+## Part 4: Consumer repo pattern (post-reset)
+
+After both standard-tooling and standard-actions changes land,
+consumer repos become thin callers. Example for a Python repo:
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  quality:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.6
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+
+  test:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.6
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+
+  audit:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.6
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.6
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      language: python
+
+  release:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.6
+    with:
+      language: python
+```
+
+All bespoke CI jobs are removed. All `scripts/dev/` scripts are
+removed. The repo's CI is fully driven by the reusable workflows.
+
+---
+
+## Part 5: Implementation sequence (Approach A)
+
+### Phase 1: standard-tooling
+
+1. Fix `validate_commands.py` registry (lint/typecheck/test/audit
+   corrections, add install commands).
+2. Build `st-validate` command (new module, reads config, dispatches
+   to registry and common checks).
+3. Wire `docker_cache.py` to read install commands from registry
+   instead of `_WARMUP_COMMANDS`.
+4. Update `st-finalize-repo` to call `st-validate` instead of
+   `st-validate-local`.
+5. Tests, validation, release as standard-tooling v1.5.
+
+### Phase 2: standard-actions
+
+6. Implement ci-quality.yml (common + lint + typecheck jobs).
+7. Implement ci-test.yml (unit job; integration deferred).
+8. Implement ci-audit.yml (dependencies job).
+9. Implement ci-release.yml (version-bump job using existing action).
+10. Validate self-referencing CI passes.
+11. Release as standard-actions v1.6.
+
+### Phase 3: consumer re-sweep
+
+12. Update each consumer repo: replace bespoke CI with thin wrappers,
+    remove `scripts/dev/` scripts, pin to standard-actions v1.6.
+13. Start with mq-rest-admin-python (where the problems were found),
+    then ai-research-methodology, then remaining repos.
+
+---
+
+## Deprecation plan
+
+After consumer re-sweep is complete:
+
+- `st-validate-local`, `st-validate-local-common`,
+  `st-validate-local-python`, etc. — deprecated, emit a warning
+  pointing to `st-validate`. Remove in standard-tooling v2.0.
+- `scripts/dev/{lint,typecheck,test,audit}.sh` — no longer needed.
+  `st-validate-local-<lang>` (if still called) ignores them in
+  favor of the registry.
+- `_WARMUP_COMMANDS` in `docker_cache.py` — replaced by registry
+  lookup.
+- `validate_local_*.sh` in `standards-and-conventions` — retired
+  with the repo.
+
+## Future considerations (out of scope)
+
+- Migrate command registry from Python code to a TOML data file for
+  easier management and potential per-repo overrides.
+- Integration test interface standardization.
+- `st-validate` version matrix support for local development (run
+  checks across multiple versions locally via Docker).

--- a/docs/specs/2026-05-05-ci-workflow-reset-design.md
+++ b/docs/specs/2026-05-05-ci-workflow-reset-design.md
@@ -228,11 +228,13 @@ check commands from the registry, and runs them.
 Each version-matrixed job uses the language-specific dev container:
 
 ```yaml
-container: ghcr.io/wphillipmoore/dev-<language>:${{ matrix.version }}
+container: ghcr.io/wphillipmoore/dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}:${{ matrix.version }}
 ```
 
-For `shell` and `none` languages, or for language-independent jobs
-(common, version-bump): `ghcr.io/wphillipmoore/dev-base:latest`.
+For `shell` and `none` languages the expression resolves to
+`dev-base`; for all other languages it resolves to
+`dev-<language>`. Language-independent jobs (common, version-bump)
+hardcode `ghcr.io/wphillipmoore/dev-base:latest`.
 
 Container images have `st-validate` pre-installed (standard-tooling
 is installed in the dev container images built by
@@ -311,8 +313,10 @@ Uses the existing `actions/release-gates/version-divergence` composite
 action with `st-version show` as the version commands. The action's
 generic interface (accepting shell commands for version extraction) is
 preserved. The workflow passes `st-version show` as the
-`head-version-command` and uses a temporary worktree to run
-`st-version show` against the main branch for `main-version-command`.
+`head-version-command` and `st-version show --ref origin/main` as the
+`main-version-command`. The `--ref` argument reads the version file
+via `git show <ref>:<path>` instead of the filesystem, avoiding any
+worktree or checkout manipulation.
 `st-version` is defined in the publish-and-docs rationalization spec
 (#318) and is included in the shared standard-tooling release.
 

--- a/docs/specs/2026-05-05-ci-workflow-reset-design.md
+++ b/docs/specs/2026-05-05-ci-workflow-reset-design.md
@@ -8,9 +8,10 @@
 
 Three of five CI reusable workflows in standard-actions v1.5 are stubs
 that echo a placeholder and exit 0. A fourth (ci-quality.yml) has real
-tool invocations but suppresses 4 of 5 failures with `|| true`, and its
-language-specific lint and typecheck jobs are also stubs. Only
-ci-security.yml is fully implemented.
+tool invocations for its common job (enforcement of all five common
+checks was completed in PR #336), but its language-specific lint and
+typecheck jobs are still stubs. Only ci-security.yml is fully
+implemented.
 
 Consumer repos that upgraded to v1.5 worked around the stubs by writing
 fully bespoke CI jobs — duplicating the logic that should live in the
@@ -40,6 +41,9 @@ and CI workflows.
 5. Approach A sequencing: standard-tooling first (new `st-validate`
    command + registry fixes), then standard-actions (workflow
    implementations), then consumer repo re-sweep.
+6. Coordinated with the publish-and-docs rationalization spec (#318):
+   both specs share a single standard-tooling release that includes
+   `st-validate` (this spec) and `st-version` (#318).
 
 ## Scope
 
@@ -50,6 +54,8 @@ and CI workflows.
 - Install command registry (dependency setup per language)
 - All five CI reusable workflow implementations in standard-actions
 - Self-referencing CI validation in standard-actions
+- Coordination with publish-and-docs rationalization (#318) for shared
+  standard-tooling release (`st-version` dependency)
 
 **Out of scope (tracked separately):**
 - Rename `st-validate-local` → `st-validate` at the CLI level (entry
@@ -58,7 +64,9 @@ and CI workflows.
 - Custom validation script centralization (#526, #527, #528, #531, #532,
   #543)
 - Migration of registry from Python code to TOML data file (future v2.0)
-- Integration test framework (repo-specific by nature)
+- Integration test implementation (repo-specific; the reusable workflow
+  defines the naming convention and `st-github-config` enforces the
+  check gate, but implementation is repo-owned)
 - `standards-and-conventions` repo retirement
 
 ---
@@ -133,6 +141,8 @@ contains file-discovery logic:
    exist under `scripts/`.
 4. **yamllint** — runs if `*.yml` / `*.yaml` files exist under
    `.github/` or repo root.
+5. **hadolint** — runs if `Dockerfile*` files exist.
+6. **actionlint** — runs if `.github/workflows/` directory exists.
 
 This logic is currently in `validate_local_common_container.py` and
 moves into `st-validate` as the `common` check handler.
@@ -241,31 +251,39 @@ required)
 | `lint / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check lint` | `quality / lint / <ver>` |
 | `typecheck / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check typecheck` | `quality / typecheck / <ver>` |
 
-`lint` and `typecheck` jobs use a conditional `if:` to skip entirely
-when the language has no registry entry for that check type (e.g.,
-`shell` has no lint or typecheck commands). Skipped jobs must not
-produce a GitHub check at all — `st-github-config` does not generate
-required status checks for unsupported check types, so a phantom
-check would create a ruleset mismatch.
+`lint` and `typecheck` jobs always run, regardless of whether the
+language has registry entries for that check type. When there are no
+commands, `st-validate` exits 0 with a message like "no lint commands
+for language 'shell'". This avoids conditional complexity in the
+workflow YAML and produces harmless phantom checks that
+`st-github-config` simply does not require. The no-op jobs also serve
+as natural placeholders that get filled in as tooling matures for each
+language.
 
 ### ci-test.yml
 
 **Inputs:** `language` (string, required), `versions` (JSON array,
-required), `integration-tests` (boolean, default: false)
+required)
 
 **Jobs:**
 
 | Job | Matrix | Container | Command | Check name |
 |---|---|---|---|---|
 | `unit / <ver>` | versions | `dev-<lang>:<ver>` | `st-validate --check test` | `test / unit / <ver>` |
-| `integration / <ver>` | versions | `dev-<lang>:<ver>` | repo-specific | `test / integration / <ver>` |
 
-The `integration` job is conditional on `inputs.integration-tests`.
-Integration tests are repo-specific by nature — the job runs a
-repo-defined script or command, not the registry. The exact
-interface for specifying integration test commands is deferred;
-the simplest option is `scripts/dev/test-integration.sh` as a
-convention.
+Integration tests are not included in the reusable workflow.
+Investigation of all five mq-rest-admin language repos showed that
+integration test patterns are uniform within a product family (same
+setup action, same env vars, same matrix structure) but the service
+provisioning and port allocation are product-specific and cannot be
+generalized into a reusable workflow.
+
+Integration test support works through the naming convention:
+`st-github-config` generates required status checks
+(`test / integration / <ver>`) when a repo declares integration
+tests. The implementation is repo-local — repos define their own
+integration job in their ci.yml with whatever setup they need, as
+long as the check name matches the convention.
 
 ### ci-audit.yml
 
@@ -290,7 +308,15 @@ default: true)
 | `version-bump` | none | `dev-base:latest` | `version-divergence` action | `release / version-bump` |
 
 Uses the existing `actions/release-gates/version-divergence` composite
-action. No version matrix. Skipped when `run-release` is false.
+action with `st-version show` as the version commands. The action's
+generic interface (accepting shell commands for version extraction) is
+preserved. The workflow passes `st-version show` as the
+`head-version-command` and uses a temporary worktree to run
+`st-version show` against the main branch for `main-version-command`.
+`st-version` is defined in the publish-and-docs rationalization spec
+(#318) and is included in the shared standard-tooling release.
+
+No version matrix. Skipped when `run-release` is false.
 
 ### ci-security.yml
 
@@ -329,6 +355,14 @@ registry, only `quality / common`, security jobs, and
 
 Does not call `ci-test.yml` or `ci-audit.yml` (no tests or auditable
 dependencies for a shell/YAML repo).
+
+### Dependency: `st-version` (from #318)
+
+The ci-release.yml workflow depends on `st-version show` from the
+publish-and-docs rationalization spec (#318). Both specs share a
+single standard-tooling release: `st-validate` + registry updates
+(this spec) and `st-version` + `[publish]` config (#318) ship
+together before either spec's standard-actions phase can proceed.
 
 ---
 
@@ -387,17 +421,33 @@ removed. The repo's CI is fully driven by the reusable workflows.
 
 ## Part 5: Implementation sequence (Approach A)
 
-### Phase 1: standard-tooling
+### Phase 1: standard-tooling (combined with #318)
+
+This phase is coordinated with the publish-and-docs rationalization
+spec (#318). Both specs' standard-tooling work ships in a single
+release.
+
+**From this spec:**
 
 1. Fix `validate_commands.py` registry (lint/typecheck/test/audit
    corrections, add install commands).
 2. Build `st-validate` command (new module, reads config, dispatches
-   to registry and common checks).
+   to registry and common checks including hadolint and actionlint).
 3. Wire `docker_cache.py` to read install commands from registry
    instead of `_WARMUP_COMMANDS`.
 4. Update `st-finalize-repo` to call `st-validate` instead of
    `st-validate-local`.
-5. Tests, validation, release as standard-tooling v1.5.
+
+**From #318:**
+
+5. Build `st-version` library and CLI (`show`, `show --major-minor`,
+   `bump` with per-language version discovery and lockfile maintenance).
+6. Extend config schema with `[publish]` section.
+7. Extend `st-github-config` for publish validation.
+
+**Combined:**
+
+8. Tests, validation, release as a single standard-tooling version.
 
 ### Phase 2: standard-actions
 

--- a/paad/alignment-reviews/2026-05-05-ci-workflow-reset-alignment.md
+++ b/paad/alignment-reviews/2026-05-05-ci-workflow-reset-alignment.md
@@ -1,0 +1,92 @@
+# Alignment Review: CI workflow reset (#337)
+
+**Date:** 2026-05-05
+**Commit:** 353d9b9
+
+## Documents Reviewed
+
+- **Intent:** GitHub issue #337 (CI reusable workflows are stubs)
+- **Design:** `docs/specs/2026-05-05-ci-workflow-reset-design.md`
+- **Action:** `docs/plans/2026-05-05-ci-workflow-reset.md`
+- **Supplementary:** `paad/pushback-reviews/2026-05-05-ci-workflow-reset-pushback.md`
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. PR #336 (removing `|| true`
+suppressions) is already reflected in the spec and plan. PR #334
+(publish-and-docs rationalization) is correctly cross-referenced as a
+coordination dependency.
+
+## Issues Reviewed
+
+### [1] `integration-tests` input removal is a breaking change
+
+- **Category:** Missing coverage
+- **Severity:** Minor
+- **Documents:** Plan Task 9 vs current ci-test.yml on `develop`
+- **Issue:** Plan Task 9 removes the `integration-tests` input and
+  `integration` job from ci-test.yml. Any consumer repo passing
+  `integration-tests: true` would get a workflow call error after
+  upgrading to v1.6.
+- **Resolution:** Non-issue. Scale of one, fleet frozen, consumer repos
+  will be brought up to speed during the Phase 3 re-sweep. No changes
+  needed.
+
+### [2] `main-version-command` runs in the PR branch working tree
+
+- **Category:** Design gap
+- **Severity:** Important
+- **Documents:** Plan Task 11, Design spec Part 3 (ci-release.yml),
+  version-divergence action
+- **Issue:** The version-divergence action fetches `origin/main` but
+  never checks it out. Both `head-version-command` and
+  `main-version-command` execute in the PR branch's working tree,
+  so passing `st-version show` for both would return the same version.
+  The design spec mentioned a temporary worktree but neither the plan
+  nor the action implemented it.
+- **Resolution:** Add `--ref` argument to `st-version show`. The
+  `--ref` argument reads the version file via `git show <ref>:<path>`
+  instead of the filesystem, avoiding worktree or checkout
+  manipulation. ci-release.yml passes `st-version show` for head and
+  `st-version show --ref origin/main` for main. The `--ref`
+  requirement flows into the #318 plan's `st-version` tasks (Task 6
+  in this plan, Tasks 2-3 in the #318 plan). Applied to both spec
+  and plan.
+
+### [3] `dev-shell` container image does not exist
+
+- **Category:** Design gap
+- **Severity:** Important
+- **Documents:** Plan Tasks 8-10 YAML, Design spec Part 3 (container
+  image selection)
+- **Issue:** Language-versioned workflow jobs use
+  `dev-<language>:<version>` as the container. For `language: shell`,
+  this resolves to `dev-shell:latest`, which does not exist. The design
+  spec said shell/none should use `dev-base` but the YAML template
+  applied `dev-<language>` unconditionally.
+- **Resolution:** Use an inline expression to map `shell` and `none`
+  to `dev-base`:
+  `dev-${{ (inputs.language == 'shell' || inputs.language == 'none') && 'base' || inputs.language }}`.
+  Applied to ci-quality.yml (Task 8), ci-test.yml (Task 9), and
+  ci-audit.yml (Task 10) in both spec and plan.
+
+### [4] Task 13 uses old `st-validate-local` command name
+
+- **Category:** Minor inconsistency
+- **Severity:** Minor
+- **Documents:** Plan Task 13 Step 1
+- **Issue:** Task 13 Step 1 said `st-docker-run -- st-validate-local`
+  but by this point in the plan, `st-validate` is the canonical
+  command.
+- **Resolution:** Updated to `st-docker-run -- st-validate`.
+
+## Unresolved Issues
+
+None.
+
+## Alignment Summary
+
+- **Requirements:** 7 total, 7 covered, 0 gaps
+- **Tasks:** 16 total, 16 in scope, 0 orphaned
+- **Design items:** All aligned after applying resolutions
+- **Status:** Aligned — ready for implementation

--- a/paad/pushback-reviews/2026-05-05-ci-workflow-reset-pushback.md
+++ b/paad/pushback-reviews/2026-05-05-ci-workflow-reset-pushback.md
@@ -1,0 +1,127 @@
+# Pushback Review: CI reusable workflow reset — unified validation architecture
+
+**Date:** 2026-05-05
+**Spec:** `docs/specs/2026-05-05-ci-workflow-reset-design.md`
+**Commit:** f59fe734edcba326ffe74cb2780e34fde994edb8
+
+## Source Control Conflicts
+
+PR #336 (merged 2026-05-01) removed `|| true` suppression from yamllint,
+markdownlint, hadolint, and actionlint in ci-quality.yml. The spec's
+context section describes ci-quality.yml as "suppressing 4 of 5 failures
+with `|| true`" — that's now stale. The current state already enforces
+all 5 common checks. This doesn't invalidate the design (the workflows
+are still bespoke inline scripts, not `st-validate`), but the urgency
+framing is slightly outdated. The spec context section was updated to
+reflect this.
+
+## Issues Reviewed
+
+### [1] Feasibility — `if:` conditional to skip lint/typecheck for unsupported languages
+
+- **Category:** Feasibility
+- **Severity:** Serious
+- **Issue:** The spec says lint and typecheck jobs use `if:` to skip when
+  the language has no registry entry. But there's no mechanism for the
+  workflow to query the registry at YAML evaluation time — `if:`
+  conditions evaluate before any step runs.
+- **Resolution:** Always run the jobs. `st-validate` exits 0 with a
+  message like "no lint commands for language 'shell'" when the registry
+  has nothing. No conditional `if:`, no probe step. Phantom checks are
+  harmless; `st-github-config` controls what's required. The no-op jobs
+  also serve as natural placeholders that get filled in as tooling
+  matures for each language.
+
+### [2] Ambiguity — Integration test interface is unresolved
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** The spec includes an `integration` job in ci-test.yml with
+  the note "the exact interface for specifying integration test commands
+  is deferred." Investigation of all five mq-rest-admin repos showed
+  integration tests follow a uniform pattern (same setup action, same env
+  vars, same matrix structure) but the service provisioning and port
+  allocation are product-specific, not generic.
+- **Resolution:** Remove the `integration` job and `integration-tests`
+  input from ci-test.yml. The reusable workflow handles `unit` only.
+  Integration test support means `st-github-config` generates the
+  required check name (`test / integration / <ver>`) when a repo
+  declares integration tests. Implementation is repo-local, constrained
+  only by the check naming convention.
+
+### [3] Omission — No rollback plan if `st-validate` has a bug
+
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** The spec replaces 10+ existing commands and all
+  `scripts/dev/` scripts with a single `st-validate` command. A bug
+  would break every repo's CI and local validation simultaneously.
+- **Resolution:** No explicit rollback plan needed. Scale of one — the
+  developer is the only consumer. The fleet is on hold during this
+  transition. Version pinning provides an implicit rollback path. Fix
+  forward; the self-referencing CI in standard-actions validates
+  workflows before release.
+
+### [4] Ambiguity — Common checks file-discovery scope differs from current CI
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** The spec's common checks describe narrower scopes
+  (markdownlint for `docs/site/` + `README.md` only) than ci-quality.yml
+  uses today (`**/*.md`). Also, ci-quality.yml currently runs hadolint
+  and actionlint, which aren't listed in the spec's common checks.
+- **Resolution:** The spec's narrow markdownlint scope is correct — it
+  matches the existing validated implementation in `st-validate-local-common`
+  (standard-tooling). The broader scope in ci-quality.yml is the bespoke
+  inline code being replaced. Add hadolint and actionlint to the common
+  checks list: hadolint runs if `Dockerfile*` files exist, actionlint
+  runs if `.github/workflows/` directory exists.
+
+### [5] Ambiguity — ci-release.yml version-bump job references the existing version-divergence action but doesn't describe how inputs are provided
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** The `version-divergence` action requires `head-version-command`
+  and `main-version-command` inputs — repo-specific shell commands. The
+  spec doesn't describe how these are provided.
+- **Resolution:** Use `st-version show` (from the publish-and-docs
+  rationalization spec, issue #318) as the version commands. This
+  replaces caller-provided per-language version commands. The
+  version-divergence action's interface stays unchanged; the workflow
+  passes `st-version show` as the head-version-command and uses a
+  temporary worktree for the main-version-command.
+
+### [6] Omission — No coordination with the publish-and-docs rationalization spec (#318)
+
+- **Category:** Omission
+- **Severity:** Serious
+- **Issue:** Both the CI workflow reset spec and the publish-and-docs
+  rationalization spec (#318) require standard-tooling work in Phase 1.
+  The CI reset needs `st-validate`, and the publish/docs work needs
+  `st-version`. Both need a standard-tooling release before their
+  standard-actions phases can proceed. The specs are written as
+  independent timelines with no cross-references.
+- **Resolution:** Coordinate the two specs into a single standard-tooling
+  release. Phase 1 becomes a combined effort: `st-validate` + registry
+  updates (from this spec), `st-version` + `[publish]` config (from
+  #318). This avoids two sequential standard-tooling releases and
+  ensures both standard-actions phases can proceed without blocking
+  each other.
+
+### [7] Omission — version-divergence action modification not described
+
+- **Category:** Omission
+- **Severity:** Minor
+- **Issue:** The spec says ci-release.yml "uses the existing
+  `actions/release-gates/version-divergence` composite action" but the
+  action requires command inputs that the spec doesn't describe.
+- **Resolution:** Keep the version-divergence action's generic interface.
+  The ci-release.yml workflow passes `st-version show` as inputs. The
+  spec documents this explicitly.
+
+## Summary
+
+- **Issues found:** 7
+- **Issues resolved:** 7
+- **Unresolved:** 0
+- **Spec status:** Ready for implementation after applying resolutions


### PR DESCRIPTION
# Pull Request

## Summary

- Add design spec, implementation plan, pushback review, and alignment review for replacing stub CI reusable workflows with st-validate-driven implementations

## Issue Linkage

- Ref #337

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- # Pull Request

## Summary

- Add design spec and implementation plan for replacing stub CI reusable workflows with real implementations driven by a centralized `st-validate` command
- Apply pushback review resolutions (7 issues) and alignment review fixes (4 issues) to both spec and plan
- Three-phase approach: build `st-validate` + registry fixes in standard-tooling, implement CI workflows in standard-actions, then re-sweep consumer repos

## Issue Linkage

- Ref #337
- Work is not complete until the issue is closed.

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- This PR contains only documentation (spec, plan, and review reports). No code or workflow changes yet.
- Phase 1 is coordinated with the publish-and-docs rationalization spec (#318) for a combined standard-tooling release.
- Key alignment decisions: `st-version show --ref` for ref-based version reading, `shell`/`none` languages map to `dev-base` container via inline expression, integration tests removed from reusable workflow (repo-local only).