### PR TITLE
Implement reusable CI workflows with st-validate dispatch

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
+
       - name: Run dependency audit
         run: st-validate --check audit

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -9,11 +9,19 @@ on:
       versions:
         type: string
         required: true
+      container-suffix:
+        type: string
+        required: false
+        description: >-
+          Container image name suffix (e.g. python, go, base). Defaults
+          to the language input. Callers whose language is "shell" or
+          "none" should pass "base".
 
 jobs:
   dependencies:
     name: dependencies / ${{ matrix.version }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -22,4 +30,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run dependency audit
-        run: echo "Dependency audit for ${{ inputs.language }} ${{ matrix.version }}"
+        run: st-validate --check audit

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
+
       - name: Run common quality checks
         run: st-validate --check common
 
@@ -40,6 +43,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
+
       - name: Run lint
         run: st-validate --check lint
 
@@ -53,6 +59,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
 
       - name: Run typecheck
         run: st-validate --check typecheck

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -9,6 +9,13 @@ on:
       versions:
         type: string
         required: true
+      container-suffix:
+        type: string
+        required: false
+        description: >-
+          Container image name suffix (e.g. python, go, base). Defaults
+          to the language input. Callers whose language is "shell" or
+          "none" should pass "base".
 
 jobs:
   common:
@@ -20,38 +27,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run common quality checks
-        shell: bash
-        run: |
-          has_files() { find . -name "$1" -not -path './.git/*' | head -1 | grep -q .; }
-
-          if has_files "*.md"; then
-            echo "Running markdownlint..."
-            markdownlint '**/*.md' --ignore node_modules
-          fi
-
-          if has_files "*.sh" || [ -d scripts/bin ]; then
-            echo "Running shellcheck..."
-            find . -name "*.sh" -o -path "*/scripts/bin/*" -print0 | xargs -0 -r shellcheck
-          fi
-
-          if has_files "*.yml" || has_files "*.yaml"; then
-            echo "Running yamllint..."
-            yamllint .
-          fi
-
-          if has_files "Dockerfile*"; then
-            echo "Running hadolint..."
-            find . -name "Dockerfile*" -print0 | xargs -0 -r hadolint
-          fi
-
-          if [ -d .github/workflows ]; then
-            echo "Running actionlint..."
-            actionlint
-          fi
+        run: st-validate --check common
 
   lint:
     name: lint / ${{ matrix.version }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -60,11 +41,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run lint
-        run: echo "Lint for ${{ inputs.language }} ${{ matrix.version }}"
+        run: st-validate --check lint
 
   typecheck:
     name: typecheck / ${{ matrix.version }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -73,4 +55,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run typecheck
-        run: echo "Typecheck for ${{ inputs.language }} ${{ matrix.version }}"
+        run: st-validate --check typecheck

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
+
       - name: Verify version bump
         uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -15,6 +15,7 @@ jobs:
     name: version-bump
     if: ${{ inputs.run-release }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -22,4 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Verify version bump
-        run: echo "Verify version incremented relative to main"
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        with:
+          head-version-command: st-version show
+          main-version-command: st-version show --ref origin/main

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -37,27 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install standard-tooling
-        shell: bash
-        run: |
-          if command -v st-repo-profile >/dev/null 2>&1; then
-            echo "standard-tooling already on PATH"
-            exit 0
-          fi
-          if [ "${{ inputs.language }}" = "python" ]; then
-            uv sync --group dev --frozen
-            export PATH="$PWD/.venv/bin:$PATH"
-            echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          fi
-          if ! command -v st-repo-profile >/dev/null 2>&1; then
-            if [ -f standard-tooling.toml ]; then
-              TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
-            fi
-            if [ -z "${TAG:-}" ]; then
-              echo "::error::standard-tooling.toml not found or missing version tag"
-              exit 1
-            fi
-            pip install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
-          fi
+        uses: ./actions/setup/standard-tooling
 
       - name: Validate standards
         uses: wphillipmoore/standard-actions/actions/standards-compliance@develop

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install standard-tooling
+        uses: ./actions/setup/standard-tooling
+
       - name: Run unit tests
         run: st-validate --check test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,14 +9,19 @@ on:
       versions:
         type: string
         required: true
-      integration-tests:
-        type: boolean
-        default: false
+      container-suffix:
+        type: string
+        required: false
+        description: >-
+          Container image name suffix (e.g. python, go, base). Defaults
+          to the language input. Callers whose language is "shell" or
+          "none" should pass "base".
 
 jobs:
   unit:
     name: unit / ${{ matrix.version }}
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -25,18 +30,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run unit tests
-        run: echo "Unit tests for ${{ inputs.language }} ${{ matrix.version }}"
-
-  integration:
-    if: ${{ inputs.integration-tests }}
-    name: integration / ${{ matrix.version }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ${{ fromJSON(inputs.versions) }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run integration tests
-        run: echo "Integration tests for ${{ inputs.language }} ${{ matrix.version }}"
+        run: st-validate --check test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       language: shell
       versions: '["latest"]'
+      container-suffix: base
 
   security:
     uses: ./.github/workflows/ci-security.yml

--- a/actions/release-gates/version-divergence/action.yml
+++ b/actions/release-gates/version-divergence/action.yml
@@ -27,6 +27,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Mark workspace safe for git
+      shell: bash
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Fetch main branch
       shell: bash
       run: git fetch origin main --depth=1

--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -14,10 +14,6 @@ runs:
     - name: Install standard-tooling
       shell: bash
       run: |
-        if command -v st-validate >/dev/null 2>&1; then
-          echo "standard-tooling already on PATH"
-          exit 0
-        fi
         TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
         if [ -z "${TAG:-}" ]; then
           echo "::error::standard-tooling.toml not found or missing version tag"

--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -1,0 +1,22 @@
+name: Install standard-tooling
+description: >-
+  Reads the pinned standard-tooling version from standard-tooling.toml
+  and installs it via uv tool install. Skips installation if the tools
+  are already on PATH.
+
+runs:
+  using: composite
+  steps:
+    - name: Install standard-tooling
+      shell: bash
+      run: |
+        if command -v st-validate >/dev/null 2>&1; then
+          echo "standard-tooling already on PATH"
+          exit 0
+        fi
+        TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::standard-tooling.toml not found or missing version tag"
+          exit 1
+        fi
+        uv tool install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"

--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -7,6 +7,10 @@ description: >-
 runs:
   using: composite
   steps:
+    - name: Mark workspace safe for git
+      shell: bash
+      run: git config --global --add safe.directory "${GITHUB_WORKSPACE:-$(pwd)}"
+
     - name: Install standard-tooling
       shell: bash
       run: |

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -10,14 +10,7 @@ runs:
   steps:
     - name: Install standard-tooling
       if: github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
-        if [ -z "${TAG:-}" ]; then
-          echo "::error::standard-tooling.toml not found or missing version tag"
-          exit 1
-        fi
-        uv tool install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+      uses: ./actions/setup/standard-tooling
 
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Pull Request

## Summary

- Phase 2: replace stub CI workflows with st-validate and st-version driven implementations

## Issue Linkage

- Ref #337

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Phase 2 of the CI workflow reset plan. Replaces stub reusable
workflows with real implementations driven by st-validate and st-version
from standard-tooling v1.4.

Changes:
- ci-quality.yml: common job runs st-validate --check common; lint and
  typecheck jobs run st-validate --check lint/typecheck in language-specific
  containers
- ci-test.yml: unit job runs st-validate --check test; removed
  integration-tests input (integration tests are repo-local)
- ci-audit.yml: dependencies job runs st-validate --check audit
- ci-release.yml: version-bump job uses the version-divergence composite
  action with st-version show
- All language-specific workflows accept a container-suffix input to
  cleanly derive the container image name, replacing an inline ternary
  expression
- ci.yml orchestrator passes container-suffix: base for this shell repo