### PR TITLE
fix(ci): use relative action refs in CI workflows, freeze to tagged refs at publish

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./actions/setup/standard-tooling
 
       - name: Verify version bump
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop
+        uses: ./actions/release-gates/version-divergence
         with:
           head-version-command: st-version show
           main-version-command: st-version show --ref origin/main

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./actions/setup/standard-tooling
 
       - name: Validate standards
-        uses: wphillipmoore/standard-actions/actions/standards-compliance@develop
+        uses: ./actions/standards-compliance
 
   codeql:
     name: codeql
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run CodeQL analysis
-        uses: wphillipmoore/standard-actions/actions/security/codeql@develop
+        uses: ./actions/security/codeql
         with:
           language: ${{ inputs.language }}
 
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scan
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+        uses: ./actions/security/trivy
         with:
           scan-type: fs
 
@@ -84,6 +84,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Semgrep SAST scan
-        uses: wphillipmoore/standard-actions/actions/security/semgrep@develop
+        uses: ./actions/security/semgrep
         with:
           language: ${{ inputs.language }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,13 +52,13 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Rewrite internal @develop refs in the working tree, then commit
-      # locally on top of the checked-out HEAD. The tag step below tags
-      # this commit, so the tagged snapshot has internally-consistent
-      # refs (every wphillipmoore/standard-actions/...@develop becomes
-      # ...@<release-tag>). The commit is reachable only via the tag —
-      # it is never pushed to develop or main.
-      - name: Freeze internal @develop refs to release tag
+      # Rewrite internal action refs so the tagged snapshot is
+      # self-consistent. Two passes:
+      #   1. ./actions/X  → wphillipmoore/standard-actions/actions/X@<tag>
+      #   2. ...@develop  → ...@<tag>
+      # The commit is reachable only via the tag — never pushed to
+      # develop or main.
+      - name: Freeze internal refs to release tag
         if: steps.tag_check.outputs.exists == 'false'
         env:
           RELEASE_TAG: ${{ steps.version.outputs.tag }}
@@ -68,18 +68,36 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           mapfile -t files < <(find .github/workflows actions \
             -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
-          rewrote=0
           for f in "${files[@]}"; do
-            if grep -qE 'wphillipmoore/standard-actions/[^@[:space:]]+@develop' "$f"; then
-              sed -i.bak -E "s|(wphillipmoore/standard-actions/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g" "$f"
-              rm -f "$f.bak"
-              rewrote=$((rewrote + 1))
-            fi
+            sed -i.bak -E "s|\./actions/([^[:space:]]+)|wphillipmoore/standard-actions/actions/\1@${RELEASE_TAG}|g" "$f"
+            sed -i.bak -E "s|(wphillipmoore/standard-actions/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g" "$f"
+            rm -f "$f.bak"
           done
-          echo "Rewrote internal @develop refs in ${rewrote} file(s)"
-          if [ "${rewrote}" -gt 0 ]; then
+          if ! git diff --quiet; then
             git add .github/workflows actions
             git commit -m "chore(release): freeze internal refs to ${RELEASE_TAG}"
+          fi
+
+      - name: Validate no unfrozen internal refs
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find .github/workflows actions \
+            -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+          failed=0
+          for f in "${files[@]}"; do
+            if grep -nE 'uses:\s+\./actions/' "$f"; then
+              echo "::error file=${f}::Unfrozen relative action ref (./actions/)"
+              failed=1
+            fi
+            if grep -nE 'wphillipmoore/standard-actions/[^@[:space:]]+@develop' "$f"; then
+              echo "::error file=${f}::Unfrozen @develop action ref"
+              failed=1
+            fi
+          done
+          if [ "${failed}" -ne 0 ]; then
+            echo "::error::Internal refs were not fully frozen — aborting"
+            exit 1
           fi
 
       - name: Tag and release

--- a/docs/specs/2026-05-06-self-referential-tagged-action-refs-design.md
+++ b/docs/specs/2026-05-06-self-referential-tagged-action-refs-design.md
@@ -1,0 +1,124 @@
+# Self-Referential Tagged Action Refs
+
+**Issue:** [#343](https://github.com/wphillipmoore/standard-actions/issues/343)
+**Date:** 2026-05-06
+**Scope:** Wave 1 — CI gate workflows only (docs and publish are wave 2)
+
+## Problem
+
+Reusable CI workflows in standard-actions reference composite actions
+using either `./actions/...` (relative paths) or
+`wphillipmoore/standard-actions/...@develop` (remote refs pinned to
+develop). Both break for consumer repos:
+
+- `./actions/...` resolves relative to the caller's checkout, not
+  standard-actions — consumers get "Can't find action.yml" errors.
+- `@develop` resolves without errors but points to whatever is on HEAD
+  of develop at runtime, not the tagged release the consumer pinned to.
+
+## Design Principle
+
+Source code uses relative paths (`./actions/...`) so that
+standard-actions' own CI on feature branches tests the actual action
+code in that branch — true self-referencing during development. At
+publish time, the freeze step rewrites these to fully-qualified tagged
+refs so consumers get a consistent, immutable snapshot.
+
+## Changes
+
+### 1. Source code: convert `@develop` refs to `./` in CI workflows
+
+Convert all remaining remote `@develop` references in CI gate workflows
+to relative `./actions/...` paths. Files already using `./` are left
+unchanged.
+
+**`ci-security.yml`** (4 lines change):
+| Line | Before | After |
+|------|--------|-------|
+| 43 | `wphillipmoore/standard-actions/actions/standards-compliance@develop` | `./actions/standards-compliance` |
+| 56 | `wphillipmoore/standard-actions/actions/security/codeql@develop` | `./actions/security/codeql` |
+| 71 | `wphillipmoore/standard-actions/actions/security/trivy@develop` | `./actions/security/trivy` |
+| 87 | `wphillipmoore/standard-actions/actions/security/semgrep@develop` | `./actions/security/semgrep` |
+
+**`ci-release.yml`** (1 line changes):
+| Line | Before | After |
+|------|--------|-------|
+| 29 | `wphillipmoore/standard-actions/actions/release-gates/version-divergence@develop` | `./actions/release-gates/version-divergence` |
+
+**No changes needed:**
+- `ci-quality.yml` — already uses `./actions/setup/standard-tooling`
+- `ci-test.yml` — already uses `./actions/setup/standard-tooling`
+- `ci-audit.yml` — already uses `./actions/setup/standard-tooling`
+- `actions/standards-compliance/action.yml` — already uses
+  `./actions/setup/standard-tooling`
+
+**Out of scope (wave 2):**
+- `publish.yml` — keeps `@develop` refs to its own composite actions
+- `publish-release.yml` — keeps `@develop` refs
+- `docs.yml` — keeps `./actions/docs-deploy` (push-triggered, not
+  reusable)
+
+### 2. Freeze step: handle `./actions/` pattern
+
+Update the `freeze-internal-refs` step in `publish.yml` (lines 61-83)
+to add a second sed pass for the `./actions/` pattern.
+
+**Two sed passes per file, no grep guard** (seds are idempotent no-ops
+on files without matches):
+
+1. **Pass 1 (new):** `./actions/X` →
+   `wphillipmoore/standard-actions/actions/X@<tag>`
+   ```
+   sed -E "s|\./actions/([^[:space:]]+)|wphillipmoore/standard-actions/actions/\1@${RELEASE_TAG}|g"
+   ```
+
+2. **Pass 2 (existing):** `...@develop` → `...@<tag>`
+   ```
+   sed -E "s|(wphillipmoore/standard-actions/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g"
+   ```
+
+Order matters: pass 1 runs first so all `./` refs become remote refs
+before pass 2 handles any remaining `@develop` refs (from publish
+workflows, unchanged until wave 2).
+
+The grep guard that currently decides whether to process each file is
+removed. The seds run unconditionally on every YAML file found — if a
+file has no matches, the sed is a no-op.
+
+After all seds run, `git diff --quiet` determines whether anything
+changed. If so, the modified files are staged and committed. If not,
+the step is a no-op. This replaces the current grep-based rewrote
+counter.
+
+### 3. Validation step
+
+A new workflow step after the freeze commit validates that no unfrozen
+internal refs survived in the working tree. This is a separate step so
+it appears as its own check in the GitHub Actions UI.
+
+Two patterns are checked across all YAML files in `.github/workflows/`
+and `actions/`:
+
+1. No `./actions/` remains (unfrozen relative refs)
+2. No `wphillipmoore/standard-actions/...@develop` remains (unfrozen
+   remote refs)
+
+If either pattern is found, the step fails with a clear error message
+listing the offending files and lines. The publish workflow stops before
+tagging.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci-security.yml` | 4 `uses:` lines: `@develop` → `./` |
+| `.github/workflows/ci-release.yml` | 1 `uses:` line: `@develop` → `./` |
+| `.github/workflows/publish.yml` | Freeze step updated + validation step added |
+
+## What This Enables
+
+After this change, consumer repos pinned to a tag (e.g. `@v1.5.5`) get
+workflows whose internal composite action references all point to the
+same tag — a consistent, immutable snapshot. This unblocks Phase 3 of
+the CI workflow reset rollout and fixes the consumer repo failures
+(e.g. standard-tooling-plugin PR #253).


### PR DESCRIPTION
# Pull Request

## Summary

- Use relative action refs in CI workflows, freeze to tagged refs at publish time

## Issue Linkage

- Ref #343

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Convert all @develop remote refs in CI gate workflows (ci-security.yml,
ci-release.yml) to ./actions/ relative paths so standard-actions tests
its own action code on feature branches during development.

Update the publish.yml freeze step with a two-pass rewrite:
1. ./actions/X → wphillipmoore/standard-actions/actions/X@<tag>
2. ...@develop → ...@<tag>

Add a validation step after the freeze commit to assert no unfrozen
refs (./actions/ or @develop) survive in the tagged snapshot.

Scope: Wave 1 — CI gate workflows only. Docs and publish workflows
retain their current refs and will be addressed in wave 2.