### PR TITLE
fix(ci-quality): install dev dependencies in lint and typecheck jobs

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
-      - name: Install dev dependencies
+      - name: Install dependencies
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen
 

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -32,5 +32,9 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
+      - name: Install dev dependencies
+        if: inputs.language == 'python'
+        run: uv sync --group dev --frozen
+
       - name: Run dependency audit
         run: st-validate --check audit

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
+      - name: Install dev dependencies
+        if: inputs.language == 'python'
+        run: uv sync --group dev --frozen
+
       - name: Run lint
         run: st-validate --check lint
 
@@ -62,6 +66,10 @@ jobs:
 
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
+
+      - name: Install dev dependencies
+        if: inputs.language == 'python'
+        run: uv sync --group dev --frozen
 
       - name: Run typecheck
         run: st-validate --check typecheck

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
-      - name: Install dev dependencies
+      - name: Install dependencies
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen
 
@@ -67,7 +67,7 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
-      - name: Install dev dependencies
+      - name: Install dependencies
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,5 +32,9 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
+      - name: Install dev dependencies
+        if: inputs.language == 'python'
+        run: uv sync --group dev --frozen
+
       - name: Run unit tests
         run: st-validate --check test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
-      - name: Install dev dependencies
+      - name: Install dependencies
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add conditional uv sync --group dev --frozen step for Python repos in lint and typecheck jobs so dev tools like ruff and mypy are on PATH when st-validate invokes them

## Issue Linkage

- Ref #349

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- No change to the common job — it uses dev-base and does not need repo-specific dev tools. The new step is skipped for non-Python languages.