### PR TITLE
fix(setup): skip uv tool install when consumer repo is standard-tooling

### DIFF
--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -1,8 +1,9 @@
 name: Install standard-tooling
 description: >-
   Reads the pinned standard-tooling version from standard-tooling.toml
-  and installs it via uv tool install. Skips installation if the tools
-  are already on PATH.
+  and installs it via uv tool install. When the consumer repo is
+  standard-tooling itself, skips the install so CI validates the PR's
+  code instead of the released version.
 
 runs:
   using: composite
@@ -14,6 +15,11 @@ runs:
     - name: Install standard-tooling
       shell: bash
       run: |
+        if grep -q '^name = "standard-tooling"' pyproject.toml 2>/dev/null; then
+          echo "Consumer repo is standard-tooling itself — skipping uv tool install"
+          exit 0
+        fi
+
         TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
         if [ -z "${TAG:-}" ]; then
           echo "::error::standard-tooling.toml not found or missing version tag"


### PR DESCRIPTION
# Pull Request

## Summary

- Skip uv tool install when the consumer repo is standard-tooling itself

## Issue Linkage

- Ref #354

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- When the standard-tooling repo itself is the consumer of the reusable CI workflows, the setup action installed the released version (from the tag in standard-tooling.toml) instead of the PR's code under test. This meant CI validated stale code, missing new features or bug fixes in the PR.

The fix checks pyproject.toml for the standard-tooling package name before running uv tool install. When detected, the install is skipped so uv sync --group dev --frozen provides the PR's code on PATH instead.