### PR TITLE
fix(ci): prepend .venv/bin to PATH before st-validate calls

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -1,3 +1,10 @@
+# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
+# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
+# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
+# to PATH so that st-validate itself (standard-tooling self-install case) and
+# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
+# a harmless no-op for non-Python repos where .venv does not exist.
+
 name: CI Audit
 
 on:
@@ -37,4 +44,6 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run dependency audit
-        run: st-validate --check audit
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check audit

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1,3 +1,10 @@
+# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
+# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
+# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
+# to PATH so that st-validate itself (standard-tooling self-install case) and
+# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
+# a harmless no-op for non-Python repos where .venv does not exist.
+
 name: CI Quality
 
 on:
@@ -30,7 +37,9 @@ jobs:
         uses: ./actions/setup/standard-tooling
 
       - name: Run common quality checks
-        run: st-validate --check common
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check common
 
   lint:
     name: lint / ${{ matrix.version }}
@@ -51,7 +60,9 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run lint
-        run: st-validate --check lint
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check lint
 
   typecheck:
     name: typecheck / ${{ matrix.version }}
@@ -72,4 +83,6 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run typecheck
-        run: st-validate --check typecheck
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check typecheck

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,3 +1,10 @@
+# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
+# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
+# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
+# to PATH so that st-validate itself (standard-tooling self-install case) and
+# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
+# a harmless no-op for non-Python repos where .venv does not exist.
+
 name: CI Test
 
 on:
@@ -37,4 +44,6 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run unit tests
-        run: st-validate --check test
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check test


### PR DESCRIPTION
# Pull Request

## Summary

- Prepend .venv/bin to PATH before st-validate calls in CI workflows

## Issue Linkage

- Ref #362

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## Summary

- Prepend `$GITHUB_WORKSPACE/.venv/bin` to `PATH` in every `run:` block
  that invokes `st-validate`, across `ci-quality.yml`, `ci-test.yml`, and
  `ci-audit.yml`.
- Add a top-of-file comment to each modified workflow explaining the
  WORKDIR/PATH mismatch and why the workaround is needed.

## Context

GitHub Actions overrides the container WORKDIR to `/__w/<repo>/<repo>`,
which means the Docker image's `/workspace/.venv/bin` PATH entry never
resolves. This causes two failures:

1. **standard-tooling self-install**: `st-validate` itself lives in
   `.venv/bin` (since `uv tool install` is skipped per #354). The shell
   cannot find it at all (exit 127).
2. **All Python repos**: Dev tools invoked by `st-validate` (`ruff`,
   `mypy`, `pytest`, `pip-audit`) are installed into `.venv/bin` by
   `uv sync --group dev`. Without `.venv/bin` on PATH, those subprocess
   calls fail with `FileNotFoundError`.

The fix is unconditional — for non-Python repos where `.venv` does not
exist, the prepend is a harmless no-op.

`ci-security.yml` is not modified because its standards job uses the
`./actions/standards-compliance` composite action rather than a `run:`
block calling `st-validate`.

## Testing

- yamllint
- actionlint
- markdownlint
- ci: shellcheck