### PR TITLE
fix: complete PATH fix and add GHAS required checks

### DIFF
--- a/actions/release-gates/version-divergence/action.yml
+++ b/actions/release-gates/version-divergence/action.yml
@@ -39,6 +39,7 @@ runs:
       id: compare
       shell: bash
       run: |
+        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
         head_version=$(${{ inputs.head-version-command }})
 
         if ! main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || [ -z "$main_version" ]; then

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -15,7 +15,9 @@ runs:
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'
       shell: bash
-      run: st-pr-issue-linkage
+      run: |
+        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+        st-pr-issue-linkage
 
     - name: Reject auto-close linkage keywords
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Pull Request

## Summary

- Extends .venv/bin PATH workaround from #362 to the remaining composite actions (standards-compliance, version-divergence) and adds Semgrep OSS / Trivy GHAS check runs to the CI gates ruleset

## Issue Linkage

- Ref #368

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Also addresses #367. The version-divergence action was found during audit — st-version invocations also lacked the PATH fix.