### PR TITLE
fix: st-validate not found for standard-tooling self-CI

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -23,12 +23,18 @@ on:
           Container image name suffix (e.g. python, go, base). Defaults
           to the language input. Callers whose language is "shell" or
           "none" should pass "base".
+      container-tag:
+        type: string
+        required: false
+        description: >-
+          Container image tag for non-matrix jobs (e.g. common).
+          Defaults to "latest".
 
 jobs:
   common:
     name: common
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,13 +9,25 @@ on:
       run-release:
         type: boolean
         default: true
+      container-suffix:
+        type: string
+        required: false
+        description: >-
+          Container image name suffix for the version-bump job
+          (e.g. python, base). Defaults to "base".
+      container-tag:
+        type: string
+        required: false
+        description: >-
+          Container image tag for the version-bump job.
+          Defaults to "latest".
 
 jobs:
   version-bump:
     name: version-bump
     if: ${{ inputs.run-release }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -21,6 +21,18 @@ on:
           Disable for languages CodeQL does not support (e.g. shell).
         type: boolean
         default: true
+      container-suffix:
+        type: string
+        required: false
+        description: >-
+          Container image name suffix for the standards job
+          (e.g. python, base). Defaults to "base".
+      container-tag:
+        type: string
+        required: false
+        description: >-
+          Container image tag for the standards job.
+          Defaults to "latest".
 
 permissions:
   contents: read
@@ -31,7 +43,7 @@ jobs:
     name: standards
     if: ${{ inputs.run-standards }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -2,8 +2,8 @@ name: Install standard-tooling
 description: >-
   Reads the pinned standard-tooling version from standard-tooling.toml
   and installs it via uv tool install. When the consumer repo is
-  standard-tooling itself, skips the install so CI validates the PR's
-  code instead of the released version.
+  standard-tooling itself, runs uv sync to install from source so CI
+  validates the PR's code instead of the released version.
 
 runs:
   using: composite
@@ -16,7 +16,8 @@ runs:
       shell: bash
       run: |
         if grep -q '^name = "standard-tooling"' pyproject.toml 2>/dev/null; then
-          echo "Consumer repo is standard-tooling itself — skipping uv tool install"
+          echo "Consumer repo is standard-tooling itself — installing from source"
+          uv sync --frozen --group dev
           exit 0
         fi
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix st-validate not found for standard-tooling self-CI by adding uv sync and container override inputs

## Issue Linkage

- Ref #373

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Two-part fix for st-validate not found when CI runs against the
standard-tooling repository itself.

**Part 1 — Composite action:** When the setup action detects the
consumer repo is standard-tooling, it now runs
`uv sync --frozen --group dev` to install CLI tools from source
into `.venv/bin/`, instead of just skipping installation entirely.

**Part 2 — Container overrides:** The `common` (ci-quality),
`standards` (ci-security), and `version-bump` (ci-release) jobs
previously hardcoded `dev-base:latest`. Each now accepts
`container-suffix` and/or `container-tag` inputs so callers can
provide a Python-capable container where `uv sync` can run.

Default behavior is unchanged — all inputs default to `dev-base:latest`.
Standard-tooling (the consumer side, out of scope here) will pass
`container-suffix: python` and `container-tag: '3.14'` to use
`dev-python:3.14`.