### PR TITLE
fix: normalize st-* command availability across install paths

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -1,10 +1,3 @@
-# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
-# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
-# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
-# to PATH so that st-validate itself (standard-tooling self-install case) and
-# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
-# a harmless no-op for non-Python repos where .venv does not exist.
-
 name: CI Audit
 
 on:
@@ -44,6 +37,4 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run dependency audit
-        run: |
-          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-          st-validate --check audit
+        run: st-validate --check audit

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1,10 +1,3 @@
-# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
-# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
-# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
-# to PATH so that st-validate itself (standard-tooling self-install case) and
-# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
-# a harmless no-op for non-Python repos where .venv does not exist.
-
 name: CI Quality
 
 on:
@@ -43,9 +36,7 @@ jobs:
         uses: ./actions/setup/standard-tooling
 
       - name: Run common quality checks
-        run: |
-          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-          st-validate --check common
+        run: st-validate --check common
 
   lint:
     name: lint / ${{ matrix.version }}
@@ -66,9 +57,7 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run lint
-        run: |
-          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-          st-validate --check lint
+        run: st-validate --check lint
 
   typecheck:
     name: typecheck / ${{ matrix.version }}
@@ -89,6 +78,4 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run typecheck
-        run: |
-          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-          st-validate --check typecheck
+        run: st-validate --check typecheck

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,10 +1,3 @@
-# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
-# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
-# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
-# to PATH so that st-validate itself (standard-tooling self-install case) and
-# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
-# a harmless no-op for non-Python repos where .venv does not exist.
-
 name: CI Test
 
 on:
@@ -44,6 +37,4 @@ jobs:
         run: uv sync --group dev --frozen
 
       - name: Run unit tests
-        run: |
-          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-          st-validate --check test
+        run: st-validate --check test

--- a/actions/release-gates/version-divergence/action.yml
+++ b/actions/release-gates/version-divergence/action.yml
@@ -39,7 +39,6 @@ runs:
       id: compare
       shell: bash
       run: |
-        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
         head_version=$(${{ inputs.head-version-command }})
 
         if ! main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || [ -z "$main_version" ]; then

--- a/actions/setup/standard-tooling/action.yml
+++ b/actions/setup/standard-tooling/action.yml
@@ -18,6 +18,7 @@ runs:
         if grep -q '^name = "standard-tooling"' pyproject.toml 2>/dev/null; then
           echo "Consumer repo is standard-tooling itself — installing from source"
           uv sync --frozen --group dev
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
           exit 0
         fi
 

--- a/actions/standards-compliance/action.yml
+++ b/actions/standards-compliance/action.yml
@@ -15,9 +15,7 @@ runs:
     - name: Validate pull request issue linkage
       if: github.event_name == 'pull_request'
       shell: bash
-      run: |
-        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
-        st-pr-issue-linkage
+      run: st-pr-issue-linkage
 
     - name: Reject auto-close linkage keywords
       if: github.event_name == 'pull_request'

--- a/docs/plans/2026-05-09-normalize-st-command-availability.md
+++ b/docs/plans/2026-05-09-normalize-st-command-availability.md
@@ -1,0 +1,321 @@
+# Normalize st-* Command Availability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `st-*` command availability for the standard-tooling self-install path by adding a single `GITHUB_PATH` line to the setup action, then remove all per-call-site PATH workarounds that are no longer needed.
+
+**Architecture:** The `setup/standard-tooling` action's self-install branch runs `uv sync --frozen --group dev`, which installs into `.venv/bin/` (not on PATH). We add one line — `echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"` — to register that directory with the runner's inter-step PATH mechanism. This makes `st-*` commands available to all subsequent steps without per-step workarounds. Then we clean up the 5 files that carry those workarounds.
+
+**Tech Stack:** GitHub Actions YAML (composite actions and reusable workflows)
+
+---
+
+### Task 1: Add GITHUB_PATH to the setup action
+
+**Files:**
+- Modify: `actions/setup/standard-tooling/action.yml:18-21`
+
+- [ ] **Step 1: Add the GITHUB_PATH line**
+
+In `actions/setup/standard-tooling/action.yml`, add `echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"` after the `uv sync` line in the self-install branch. The full `run:` block becomes:
+
+```yaml
+    - name: Install standard-tooling
+      shell: bash
+      run: |
+        if grep -q '^name = "standard-tooling"' pyproject.toml 2>/dev/null; then
+          echo "Consumer repo is standard-tooling itself — installing from source"
+          uv sync --frozen --group dev
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+          exit 0
+        fi
+
+        TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::standard-tooling.toml not found or missing version tag"
+          exit 1
+        fi
+        uv tool install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+```
+
+- [ ] **Step 2: Validate the setup action**
+
+Run: `st-docker-run -- st-validate`
+
+Expected: PASS — the new line is valid YAML and valid shell.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add actions/setup/standard-tooling/action.yml
+git commit -m "fix: add GITHUB_PATH for st-* commands in self-install path
+
+Ref #403"
+```
+
+---
+
+### Task 2: Remove PATH workaround from ci-audit.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-audit.yml:1-6,48`
+
+- [ ] **Step 1: Remove the 6-line comment block**
+
+Delete lines 1–6 (the `# PATH workaround (#362): ...` comment block) from the top of `.github/workflows/ci-audit.yml`:
+
+```yaml
+# PATH workaround (#362): GitHub Actions overrides the container WORKDIR to
+# /__w/<repo>/<repo>, so the Docker image's /workspace/.venv/bin PATH entry
+# never resolves.  Each st-validate step prepends $GITHUB_WORKSPACE/.venv/bin
+# to PATH so that st-validate itself (standard-tooling self-install case) and
+# dev tools it invokes (ruff, mypy, pytest, pip-audit) are findable.  This is
+# a harmless no-op for non-Python repos where .venv does not exist.
+```
+
+- [ ] **Step 2: Remove the PATH line from the run step**
+
+In the `Run dependency audit` step, change the `run:` block from:
+
+```yaml
+      - name: Run dependency audit
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check audit
+```
+
+to:
+
+```yaml
+      - name: Run dependency audit
+        run: st-validate --check audit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci-audit.yml
+git commit -m "refactor: remove PATH workaround from ci-audit.yml
+
+The setup/standard-tooling action now handles this via GITHUB_PATH.
+
+Ref #403"
+```
+
+---
+
+### Task 3: Remove PATH workarounds from ci-quality.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-quality.yml:1-6,47,70,93`
+
+- [ ] **Step 1: Remove the 6-line comment block**
+
+Delete lines 1–6 (the same `# PATH workaround (#362): ...` comment block) from the top of `.github/workflows/ci-quality.yml`.
+
+- [ ] **Step 2: Remove the PATH line from the common job**
+
+In the `Run common quality checks` step, change:
+
+```yaml
+      - name: Run common quality checks
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check common
+```
+
+to:
+
+```yaml
+      - name: Run common quality checks
+        run: st-validate --check common
+```
+
+- [ ] **Step 3: Remove the PATH line from the lint job**
+
+In the `Run lint` step, change:
+
+```yaml
+      - name: Run lint
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check lint
+```
+
+to:
+
+```yaml
+      - name: Run lint
+        run: st-validate --check lint
+```
+
+- [ ] **Step 4: Remove the PATH line from the typecheck job**
+
+In the `Run typecheck` step, change:
+
+```yaml
+      - name: Run typecheck
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check typecheck
+```
+
+to:
+
+```yaml
+      - name: Run typecheck
+        run: st-validate --check typecheck
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci-quality.yml
+git commit -m "refactor: remove PATH workarounds from ci-quality.yml
+
+Removes the comment block and three per-step PATH lines (common,
+lint, typecheck). The setup/standard-tooling action now handles
+this via GITHUB_PATH.
+
+Ref #403"
+```
+
+---
+
+### Task 4: Remove PATH workaround from ci-test.yml
+
+**Files:**
+- Modify: `.github/workflows/ci-test.yml:1-6,48`
+
+- [ ] **Step 1: Remove the 6-line comment block**
+
+Delete lines 1–6 (the `# PATH workaround (#362): ...` comment block) from the top of `.github/workflows/ci-test.yml`.
+
+- [ ] **Step 2: Remove the PATH line from the run step**
+
+In the `Run unit tests` step, change:
+
+```yaml
+      - name: Run unit tests
+        run: |
+          PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+          st-validate --check test
+```
+
+to:
+
+```yaml
+      - name: Run unit tests
+        run: st-validate --check test
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci-test.yml
+git commit -m "refactor: remove PATH workaround from ci-test.yml
+
+The setup/standard-tooling action now handles this via GITHUB_PATH.
+
+Ref #403"
+```
+
+---
+
+### Task 5: Remove PATH workaround from standards-compliance action
+
+**Files:**
+- Modify: `actions/standards-compliance/action.yml:19`
+
+- [ ] **Step 1: Remove the PATH line**
+
+In the `Validate pull request issue linkage` step, change:
+
+```yaml
+    - name: Validate pull request issue linkage
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+        st-pr-issue-linkage
+```
+
+to:
+
+```yaml
+    - name: Validate pull request issue linkage
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: st-pr-issue-linkage
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add actions/standards-compliance/action.yml
+git commit -m "refactor: remove PATH workaround from standards-compliance action
+
+The setup/standard-tooling action now handles this via GITHUB_PATH.
+
+Ref #403"
+```
+
+---
+
+### Task 6: Remove PATH workaround from version-divergence action
+
+**Files:**
+- Modify: `actions/release-gates/version-divergence/action.yml:42`
+
+- [ ] **Step 1: Remove the PATH line**
+
+In the `Compare versions` step, change:
+
+```yaml
+    - name: Compare versions
+      id: compare
+      shell: bash
+      run: |
+        PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"
+        head_version=$(${{ inputs.head-version-command }})
+```
+
+to:
+
+```yaml
+    - name: Compare versions
+      id: compare
+      shell: bash
+      run: |
+        head_version=$(${{ inputs.head-version-command }})
+```
+
+Note: this step keeps its `run: |` block because it has multiple lines of shell logic beyond the PATH line.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add actions/release-gates/version-divergence/action.yml
+git commit -m "refactor: remove PATH workaround from version-divergence action
+
+The setup/standard-tooling action now handles this via GITHUB_PATH.
+
+Ref #403"
+```
+
+---
+
+### Task 7: Final validation
+
+- [ ] **Step 1: Run full validation**
+
+Run: `st-docker-run -- st-validate`
+
+Expected: PASS — all YAML linting, actionlint, shellcheck, and markdownlint checks pass.
+
+- [ ] **Step 2: Review the full diff**
+
+Run: `git diff HEAD~6 --stat` to confirm the change footprint matches the spec:
+- 1 file with a line added (`actions/setup/standard-tooling/action.yml`)
+- 5 files with lines removed (3 workflow files + 2 composite actions)
+- No other files modified

--- a/docs/specs/2026-05-09-normalize-st-command-availability-design.md
+++ b/docs/specs/2026-05-09-normalize-st-command-availability-design.md
@@ -4,7 +4,7 @@
 
 **Date:** 2026-05-09
 
-**Status:** Draft
+**Status:** Ready for implementation
 
 ## Problem
 
@@ -88,7 +88,11 @@ IPC:
    prepends the entries to `PATH` for all subsequent steps.
 
 This sidesteps the UNIX constraint that a child process cannot modify its
-parent's environment.
+parent's environment. Because `$GITHUB_WORKSPACE` resolves to the runner's
+actual workspace mount point (`/__w/<repo>/<repo>`), this also eliminates the
+container WORKDIR mismatch described in the existing comment blocks (issue
+#362): the Docker image bakes `/workspace/.venv/bin` into PATH, but GitHub
+Actions mounts the workspace elsewhere, so that entry never resolves.
 
 ### Change to the setup action
 
@@ -154,3 +158,6 @@ After applying the fix, the standard-tooling repository's CI workflows (which
 consume these reusable workflows) should pass without any per-step PATH
 manipulation. The immediate validation is that the standard-tooling v1.4.29
 publish workflow succeeds at the `st-version show` step that currently fails.
+Additionally, the standard-tooling CI quality workflow (ci-quality.yml) —
+which currently uses per-step PATH workarounds in its lint, typecheck, and
+format jobs — should pass without them after the setup action change.

--- a/docs/specs/2026-05-09-normalize-st-command-availability-design.md
+++ b/docs/specs/2026-05-09-normalize-st-command-availability-design.md
@@ -1,0 +1,156 @@
+# Normalize st-* Command Availability Design
+
+**Issue:** [#403 — fix: normalize st-* command availability across install paths in setup/standard-tooling](https://github.com/wphillipmoore/standard-actions/issues/403)
+
+**Date:** 2026-05-09
+
+**Status:** Draft
+
+## Problem
+
+The `setup/standard-tooling` composite action has two install paths that
+leave `st-*` commands in different locations:
+
+- **Consumer repos:** `uv tool install "standard-tooling @ ..."` installs
+  `st-*` binaries to the system tool path. Commands are on PATH. Works
+  everywhere.
+- **Standard-tooling itself (self-install):** `uv sync --frozen --group dev`
+  installs into `.venv/bin/`, which is not on PATH. Commands require either
+  PATH manipulation or `uv run` to invoke.
+
+This inconsistency forces downstream workflows to apply per-call-site PATH
+workarounds, and files that omit the workaround break when consumed by the
+standard-tooling repository. This is blocking the standard-tooling v1.4.29
+release.
+
+### Current state
+
+**Pattern 1 — per-step PATH workaround (5 call sites):**
+
+Each step that invokes `st-*` prepends `$GITHUB_WORKSPACE/.venv/bin` to
+PATH inline. Four of the five files carry a multi-line comment block
+(referencing issue #362) explaining the workaround.
+
+| File | Workaround |
+|------|-----------|
+| `.github/workflows/ci-audit.yml` | Comment block + PATH line |
+| `.github/workflows/ci-quality.yml` | Comment block + 3 PATH lines |
+| `.github/workflows/ci-test.yml` | Comment block + PATH line |
+| `actions/standards-compliance/action.yml` | PATH line (no comment) |
+| `actions/release-gates/version-divergence/action.yml` | PATH line (no comment) |
+
+**Pattern 2 — no workaround (4 call sites):**
+
+These call `st-*` directly. They work for consumer repos but fail for
+standard-tooling itself.
+
+| File | Broken command |
+|------|---------------|
+| `.github/workflows/publish.yml` | `st-version show` |
+| `.github/workflows/publish-release.yml` | `st-version show` |
+| `.github/workflows/ci-release.yml` | `st-version show` / `st-version show --ref` |
+| `actions/publish/version-bump-pr/action.yml` | `st-version show` / `st-version bump` |
+
+## Rejected approaches
+
+### Use `uv tool install .` for self-install
+
+This would put `st-*` on the system tool path for both install paths.
+Rejected because standard-tooling's CI must dog-food the venv — tests, lint,
+and type-checking run against the development environment, not an installed
+snapshot.
+
+### Replicate Pattern 1 to all call sites
+
+Adding `PATH="$GITHUB_WORKSPACE/.venv/bin:$PATH"` to every step that invokes
+`st-*` would fix Pattern 2 files, but scatters environment-specific
+workarounds across every call site. The existing comment blocks documenting
+this workaround are a smell, not a pattern to replicate.
+
+### Use `uv run` for all invocations
+
+`uv run st-version show` finds `.venv/bin` automatically, but does not work
+for non-Python consumer repos that have no `pyproject.toml`.
+
+## Chosen approach: GITHUB_PATH in the setup action
+
+### Mechanism
+
+`$GITHUB_PATH` is a GitHub Actions runner feature for inter-step PATH
+modification. It is not environment variable inheritance — it is file-based
+IPC:
+
+1. Before each step, the runner creates a temporary file and exports its path
+   as `$GITHUB_PATH`.
+2. When a step runs `echo "/some/dir" >> "$GITHUB_PATH"`, it appends a line
+   to that file.
+3. After the step exits, the runner (the parent process) reads the file and
+   prepends the entries to `PATH` for all subsequent steps.
+
+This sidesteps the UNIX constraint that a child process cannot modify its
+parent's environment.
+
+### Change to the setup action
+
+In `actions/setup/standard-tooling/action.yml`, add one line to the
+self-install branch:
+
+```yaml
+- name: Install standard-tooling
+  shell: bash
+  run: |
+    if grep -q '^name = "standard-tooling"' pyproject.toml 2>/dev/null; then
+      echo "Consumer repo is standard-tooling itself — installing from source"
+      uv sync --frozen --group dev
+      echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      exit 0
+    fi
+
+    TAG=$(sed -n 's/^[[:space:]]*standard-tooling[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' standard-tooling.toml)
+    if [ -z "${TAG:-}" ]; then
+      echo "::error::standard-tooling.toml not found or missing version tag"
+      exit 1
+    fi
+    uv tool install "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${TAG}"
+```
+
+After this step completes, `st-*` commands (and dev tools such as ruff, mypy,
+pytest, pip-audit) are on PATH for every subsequent step in the job.
+
+### Cleanup: remove per-call-site workarounds
+
+With the fix centralized in the setup action, all existing per-step PATH
+workarounds become dead code. Remove them:
+
+| File | Remove |
+|------|--------|
+| `.github/workflows/ci-audit.yml` | 6-line comment block (lines 1-6), `PATH=...` line |
+| `.github/workflows/ci-quality.yml` | 6-line comment block (lines 1-6), 3 `PATH=...` lines |
+| `.github/workflows/ci-test.yml` | 6-line comment block (lines 1-6), `PATH=...` line |
+| `actions/standards-compliance/action.yml` | `PATH=...` line |
+| `actions/release-gates/version-divergence/action.yml` | `PATH=...` line |
+
+Pattern 2 files require **no changes** — they already call `st-*` directly,
+and the setup action now ensures that works.
+
+## Scope
+
+### In scope
+
+- One-line addition to `actions/setup/standard-tooling/action.yml`
+- Removal of PATH workaround lines and comment blocks from 5 files
+
+### Out of scope
+
+- Consumer repo behavior (unaffected — they take the `uv tool install`
+  branch, which already puts `st-*` on PATH)
+- The `uv sync --frozen --group dev` install mechanism
+- Workflow structure or step ordering
+- Any changes to the standard-tooling repository itself
+
+## Validation
+
+After applying the fix, the standard-tooling repository's CI workflows (which
+consume these reusable workflows) should pass without any per-step PATH
+manipulation. The immediate validation is that the standard-tooling v1.4.29
+publish workflow succeeds at the `st-version show` step that currently fails.


### PR DESCRIPTION
# Pull Request

## Summary

- Add GITHUB_PATH for st-* commands in self-install path

## Issue Linkage

- Ref #403

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- ## Summary

- Add `echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"` to the
  self-install branch of `setup/standard-tooling`, so st-* commands
  (and dev tools like ruff, mypy, pytest, pip-audit) are on PATH for
  all subsequent steps in the job.
- Remove per-call-site PATH workarounds from 5 files (ci-audit.yml,
  ci-quality.yml, ci-test.yml, standards-compliance/action.yml,
  version-divergence/action.yml) that are now dead code.
- Pattern 2 files (publish.yml, publish-release.yml, ci-release.yml,
  version-bump-pr/action.yml) already call st-* directly and need
  no changes.

## Testing

- st-validate: all checks passed (yamllint, actionlint, markdownlint,
  repo-profile)
- Full validation of st-* command availability deferred to CI — the
  standard-tooling repo's CI workflows consume these reusable
  workflows and will exercise the fix.