### PR TITLE
fix(publish): make container-tag a required input

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,9 +8,9 @@ on:
         type: string
         required: true
       container-tag:
-        description: Dev container image tag override.
+        description: Dev container image tag (e.g. 3.14, 1.26).
         type: string
-        default: "latest"
+        required: true
       build-command:
         description: Override ecosystem-derived build command.
         type: string


### PR DESCRIPTION
# Pull Request

## Summary

- Remove invalid 'latest' default from container-tag and make it required, since no language-specific dev container image publishes a :latest tag

## Issue Linkage

- Ref #402

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Callers must now explicitly specify the tag matching their supported language version (e.g. 3.14, 1.26)