### PR TITLE
fix(publish): add registry-publish flag and make language/container-tag optional

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,11 +6,15 @@ on:
       language:
         description: Primary language (matches dev container image suffix).
         type: string
-        required: true
+        default: "base"
       container-tag:
         description: Dev container image tag (e.g. 3.14, 1.26).
         type: string
-        required: true
+        default: "latest"
+      registry-publish:
+        description: Publish build artifacts to an external package registry.
+        type: boolean
+        default: false
       build-command:
         description: Override ecosystem-derived build command.
         type: string
@@ -79,6 +83,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.language }}" != "base" ] && \
+             [ "${{ inputs.container-tag }}" = "latest" ]; then
+            echo "::error::language '${{ inputs.language }}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
+            exit 1
+          fi
+          if [ "${{ inputs.registry-publish }}" = "true" ] && \
+             [ "${{ inputs.language }}" = "base" ]; then
+            echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
+            exit 1
+          fi
 
       - name: Install standard-tooling
         uses: wphillipmoore/standard-actions/actions/setup/standard-tooling@develop

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,7 +101,7 @@ jobs:
         uses: wphillipmoore/standard-actions/actions/setup/standard-tooling@develop
 
       - name: Configure Maven credentials
-        if: inputs.language == 'java'
+        if: inputs.registry-publish && inputs.language == 'java'
         shell: bash
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -141,7 +141,9 @@ jobs:
           fi
 
       - name: Derive ecosystem commands
-        if: steps.tag_check.outputs.exists == 'false'
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
         id: commands
         env:
           LANG: ${{ inputs.language }}
@@ -179,7 +181,9 @@ jobs:
       # ── Release pipeline (gated on new tag) ────────────────────────
 
       - name: Prepare version-dependent inputs
-        if: steps.tag_check.outputs.exists == 'false'
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
         id: resolved
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -192,11 +196,14 @@ jobs:
             >> "$GITHUB_OUTPUT"
 
       - name: Ensure dist directory
-        if: steps.tag_check.outputs.exists == 'false'
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
         run: mkdir -p dist
 
       - name: Build
         if: >-
+          inputs.registry-publish &&
           steps.tag_check.outputs.exists == 'false' &&
           steps.commands.outputs.build != ''
         env:
@@ -205,6 +212,7 @@ jobs:
 
       - name: Attest build provenance
         if: >-
+          inputs.registry-publish &&
           steps.tag_check.outputs.exists == 'false' &&
           inputs.attestation-subject-path != ''
         uses: actions/attest-build-provenance@v4
@@ -213,6 +221,7 @@ jobs:
 
       - name: Generate SBOM
         if: >-
+          inputs.registry-publish &&
           steps.tag_check.outputs.exists == 'false' &&
           inputs.sbom-output-file != ''
         uses: wphillipmoore/standard-actions/actions/security/trivy@develop
@@ -222,12 +231,14 @@ jobs:
 
       - name: Publish to PyPI
         if: >-
+          inputs.registry-publish &&
           inputs.language == 'python' &&
           steps.tag_check.outputs.exists == 'false'
         run: uv publish dist/*
 
       - name: Publish to registry
         if: >-
+          inputs.registry-publish &&
           inputs.language != 'python' &&
           steps.commands.outputs.publish != '' &&
           steps.tag_check.outputs.exists == 'false'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -85,14 +85,18 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
+        env:
+          INPUT_LANGUAGE: ${{ inputs.language }}
+          INPUT_CONTAINER_TAG: ${{ inputs.container-tag }}
+          INPUT_REGISTRY_PUBLISH: ${{ inputs.registry-publish }}
         run: |
-          if [ "${{ inputs.language }}" != "base" ] && \
-             [ "${{ inputs.container-tag }}" = "latest" ]; then
-            echo "::error::language '${{ inputs.language }}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
+          if [ "$INPUT_LANGUAGE" != "base" ] && \
+             [ "$INPUT_CONTAINER_TAG" = "latest" ]; then
+            echo "::error::language '${INPUT_LANGUAGE}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
             exit 1
           fi
-          if [ "${{ inputs.registry-publish }}" = "true" ] && \
-             [ "${{ inputs.language }}" = "base" ]; then
+          if [ "$INPUT_REGISTRY_PUBLISH" = "true" ] && \
+             [ "$INPUT_LANGUAGE" = "base" ]; then
             echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
             exit 1
           fi

--- a/docs/plans/2026-05-09-registry-publish-flag.md
+++ b/docs/plans/2026-05-09-registry-publish-flag.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a `registry-publish` boolean input to `publish-release.yml` so callers explicitly opt in to external registry publication, then update all 11 fleet callers to specify `language`, `container-tag`, and (where applicable) `registry-publish: true`.
+**Goal:** Add a `registry-publish` boolean input to `publish-release.yml` that gates all registry-specific steps, make `language` and `container-tag` optional with defaults, and update all 11 fleet callers.
 
-**Architecture:** The reusable workflow gains one new optional boolean input (`registry-publish`, default `false`). Steps that are only meaningful for external registry publication — Maven credential config, ecosystem command derivation, build, attestation, SBOM, and registry publish — are gated behind this flag. Steps that every repo needs (checkout, standard-tooling install, version extract, tag check, tag-and-release, version-bump-pr) remain ungated. Each fleet caller's `publish-release.yml` is updated to pass `language`, `container-tag`, and `registry-publish` as appropriate.
+**Architecture:** The reusable workflow gains one new boolean input (`registry-publish`, default `false`) and a validation step that catches invalid input combinations early. Nine existing steps are gated behind this flag. `language` and `container-tag` become optional with defaults (`base`/`latest`) so non-language repos can omit them. Fleet callers are updated to pass the appropriate inputs.
 
 **Tech Stack:** GitHub Actions reusable workflows (YAML), `st-validate` for validation.
 
@@ -14,67 +14,68 @@
 
 ### Current state
 
-`publish-release.yml` in standard-actions has two required inputs (`language`, `container-tag`) and several optional inputs for build/publish customization. The workflow runs every step for every caller — registry-publish steps are only skipped incidentally when derived commands are empty or credentials are missing.
+`publish-release.yml` has two required inputs (`language`, `container-tag`). Registry-specific steps run unconditionally (or are skipped only incidentally when derived commands are empty). Only `standard-tooling` passes `language: python`; the other 10 callers pass no `with:` inputs.
 
-All 11 fleet callers are pinned to `@v1.5`. Only `standard-tooling` passes `language: python`; the other 10 pass no `with:` inputs at all.
+### Spec
 
-### Which repos publish to an external registry?
+`docs/specs/2026-05-09-registry-publish-flag-design.md`
 
-| Repository | Language | Registry | Publishes? |
-|---|---|---|---|
-| standard-tooling | python | PyPI | Yes |
-| mq-rest-admin-python | python | PyPI | Yes |
-| mq-rest-admin-go | go | (Go module proxy) | Yes |
-| mq-rest-admin-java | java | Maven Central | Yes |
-| mq-rest-admin-ruby | ruby | RubyGems | Yes |
-| mq-rest-admin-rust | rust | crates.io | Yes |
-| ai-research-methodology | python | PyPI | TBD (has pyproject.toml) |
-| standard-tooling-plugin | claude-plugin | none | No |
-| mq-rest-admin-common | none | none | No |
-| mq-rest-admin-dev-environment | shell | none | No |
-| mq-rest-admin-template | none | none | No |
+### Issues
 
-### Container image tags (from standard-tooling-docker)
-
-- `dev-python`: 3.12, 3.13, 3.14
-- `dev-go`: 1.25, 1.26
-- `dev-java`: 17, 21
-- `dev-ruby`: 3.2, 3.3, 3.4
-- `dev-rust`: 1.92, 1.93
-- `dev-base`: latest
-
-Non-language repos (`primary-language` of `none`, `shell`, `claude-plugin`) use `dev-base:latest`.
+- [#411](https://github.com/wphillipmoore/standard-actions/issues/411) — make PyPI publishing opt-in
+- [#412](https://github.com/wphillipmoore/standard-actions/issues/412) — add registry-publish flag and update fleet
 
 ---
 
-## Task 1: Add `registry-publish` input and gate steps in `publish-release.yml`
+## Task 1: Modify inputs and add validation step in publish-release.yml
 
 **Files:**
 - Modify: `.github/workflows/publish-release.yml:4-58` (inputs section)
-- Modify: `.github/workflows/publish-release.yml:86-233` (conditional steps)
+- Modify: `.github/workflows/publish-release.yml:77-84` (insert validation step after checkout)
 
-### Input changes
+- [ ] **Step 1: Change `language` from required to optional with default**
 
-- [ ] **Step 1: Revert `language` and `container-tag` to optional with defaults**
+In `.github/workflows/publish-release.yml`, replace:
 
-`language` defaults to `base`, `container-tag` defaults to `latest`. This lets non-language repos omit them without error, while language repos still specify them explicitly.
+```yaml
+      language:
+        description: Primary language (matches dev container image suffix).
+        type: string
+        required: true
+```
 
-In `.github/workflows/publish-release.yml`, change the `language` and `container-tag` inputs:
+with:
 
 ```yaml
       language:
         description: Primary language (matches dev container image suffix).
         type: string
         default: "base"
+```
+
+- [ ] **Step 2: Change `container-tag` from required to optional with default**
+
+Replace:
+
+```yaml
+      container-tag:
+        description: Dev container image tag (e.g. 3.14, 1.26).
+        type: string
+        required: true
+```
+
+with:
+
+```yaml
       container-tag:
         description: Dev container image tag (e.g. 3.14, 1.26).
         type: string
         default: "latest"
 ```
 
-- [ ] **Step 2: Add the `registry-publish` input**
+- [ ] **Step 3: Add `registry-publish` input**
 
-Add after `container-tag`:
+Add after the `container-tag` input block:
 
 ```yaml
       registry-publish:
@@ -83,166 +84,26 @@ Add after `container-tag`:
         default: false
 ```
 
-- [ ] **Step 3: Gate the Maven credential step on `registry-publish`**
+- [ ] **Step 4: Add the input validation step**
 
-Change line 87's `if` from:
-
-```yaml
-        if: inputs.language == 'java'
-```
-
-to:
+Insert a new step immediately after "Checkout code" (after line 81) and before "Install standard-tooling":
 
 ```yaml
-        if: inputs.registry-publish && inputs.language == 'java'
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.language }}" != "base" ] && \
+             [ "${{ inputs.container-tag }}" = "latest" ]; then
+            echo "::error::language '${{ inputs.language }}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
+            exit 1
+          fi
+          if [ "${{ inputs.registry-publish }}" = "true" ] && \
+             [ "${{ inputs.language }}" = "base" ]; then
+            echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
+            exit 1
+          fi
 ```
 
-- [ ] **Step 4: Gate the "Derive ecosystem commands" step on `registry-publish`**
-
-Change line 127's `if` from:
-
-```yaml
-        if: steps.tag_check.outputs.exists == 'false'
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-- [ ] **Step 5: Gate the "Ensure dist directory" step on `registry-publish`**
-
-Change line 178's `if` from:
-
-```yaml
-        if: steps.tag_check.outputs.exists == 'false'
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-- [ ] **Step 6: Gate the "Prepare version-dependent inputs" step on `registry-publish`**
-
-Change line 165's `if` from:
-
-```yaml
-        if: steps.tag_check.outputs.exists == 'false'
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-- [ ] **Step 7: Gate the "Build" step on `registry-publish`**
-
-Change the `if` from:
-
-```yaml
-        if: >-
-          steps.tag_check.outputs.exists == 'false' &&
-          steps.commands.outputs.build != ''
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          steps.commands.outputs.build != ''
-```
-
-- [ ] **Step 8: Gate the "Attest build provenance" step on `registry-publish`**
-
-Change the `if` from:
-
-```yaml
-        if: >-
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.attestation-subject-path != ''
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.attestation-subject-path != ''
-```
-
-- [ ] **Step 9: Gate the "Generate SBOM" step on `registry-publish`**
-
-Change the `if` from:
-
-```yaml
-        if: >-
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.sbom-output-file != ''
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.sbom-output-file != ''
-```
-
-- [ ] **Step 10: Gate the "Publish to PyPI" step on `registry-publish`**
-
-Change the `if` from:
-
-```yaml
-        if: >-
-          inputs.language == 'python' &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          inputs.language == 'python' &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-- [ ] **Step 11: Gate the "Publish to registry" step on `registry-publish`**
-
-Change the `if` from:
-
-```yaml
-        if: >-
-          inputs.language != 'python' &&
-          steps.commands.outputs.publish != '' &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-to:
-
-```yaml
-        if: >-
-          inputs.registry-publish &&
-          inputs.language != 'python' &&
-          steps.commands.outputs.publish != '' &&
-          steps.tag_check.outputs.exists == 'false'
-```
-
-- [ ] **Step 12: Run validation**
+- [ ] **Step 5: Run validation**
 
 ```bash
 st-docker-run -- st-validate
@@ -250,287 +111,564 @@ st-docker-run -- st-validate
 
 Expected: all checks pass.
 
-- [ ] **Step 13: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-st-commit --type fix --scope publish \
-  --message "add registry-publish flag and make language/container-tag optional with defaults" \
-  --body "Steps that publish to external registries (build, attest, SBOM, PyPI, registry publish, Maven creds, ecosystem command derivation) are now gated behind the new registry-publish boolean input (default false). language defaults to base and container-tag defaults to latest so non-language repos can omit them. Ref #402" \
-  --agent claude
+git add .github/workflows/publish-release.yml
+```
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(publish): make language/container-tag optional, add registry-publish input
+
+language defaults to base and container-tag defaults to latest so
+non-language repos can omit them. A new registry-publish boolean input
+(default false) is added for use in the next commit. Input validation
+catches invalid combinations: language-specific images with latest tag,
+and registry-publish without a language. Ref #411, #412
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
 ```
 
 ---
 
-## Task 2: Update fleet caller — standard-tooling
-
-This repo publishes to PyPI.
+## Task 2: Gate registry-specific steps behind `registry-publish`
 
 **Files:**
-- Modify: `/Users/pmoore/dev/github/standard-tooling/.github/workflows/publish-release.yml`
+- Modify: `.github/workflows/publish-release.yml` (conditional steps throughout)
 
-- [ ] **Step 1: Update the workflow**
+All changes in this task prepend `inputs.registry-publish &&` to existing `if` conditions on nine steps.
 
-Change the `with:` block from:
+- [ ] **Step 1: Gate "Configure Maven credentials"**
 
-```yaml
-    with:
-      language: python
-```
-
-to:
+Replace:
 
 ```yaml
-    with:
-      language: python
-      container-tag: "3.14"
-      registry-publish: true
+      - name: Configure Maven credentials
+        if: inputs.language == 'java'
 ```
 
-- [ ] **Step 2: Commit**
+with:
+
+```yaml
+      - name: Configure Maven credentials
+        if: inputs.registry-publish && inputs.language == 'java'
+```
+
+- [ ] **Step 2: Gate "Derive ecosystem commands"**
+
+Replace:
+
+```yaml
+      - name: Derive ecosystem commands
+        if: steps.tag_check.outputs.exists == 'false'
+```
+
+with:
+
+```yaml
+      - name: Derive ecosystem commands
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+- [ ] **Step 3: Gate "Prepare version-dependent inputs"**
+
+Replace:
+
+```yaml
+      - name: Prepare version-dependent inputs
+        if: steps.tag_check.outputs.exists == 'false'
+```
+
+with:
+
+```yaml
+      - name: Prepare version-dependent inputs
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+- [ ] **Step 4: Gate "Ensure dist directory"**
+
+Replace:
+
+```yaml
+      - name: Ensure dist directory
+        if: steps.tag_check.outputs.exists == 'false'
+```
+
+with:
+
+```yaml
+      - name: Ensure dist directory
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+- [ ] **Step 5: Gate "Build"**
+
+Replace:
+
+```yaml
+      - name: Build
+        if: >-
+          steps.tag_check.outputs.exists == 'false' &&
+          steps.commands.outputs.build != ''
+```
+
+with:
+
+```yaml
+      - name: Build
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false' &&
+          steps.commands.outputs.build != ''
+```
+
+- [ ] **Step 6: Gate "Attest build provenance"**
+
+Replace:
+
+```yaml
+      - name: Attest build provenance
+        if: >-
+          steps.tag_check.outputs.exists == 'false' &&
+          inputs.attestation-subject-path != ''
+```
+
+with:
+
+```yaml
+      - name: Attest build provenance
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false' &&
+          inputs.attestation-subject-path != ''
+```
+
+- [ ] **Step 7: Gate "Generate SBOM"**
+
+Replace:
+
+```yaml
+      - name: Generate SBOM
+        if: >-
+          steps.tag_check.outputs.exists == 'false' &&
+          inputs.sbom-output-file != ''
+```
+
+with:
+
+```yaml
+      - name: Generate SBOM
+        if: >-
+          inputs.registry-publish &&
+          steps.tag_check.outputs.exists == 'false' &&
+          inputs.sbom-output-file != ''
+```
+
+- [ ] **Step 8: Gate "Publish to PyPI"**
+
+Replace:
+
+```yaml
+      - name: Publish to PyPI
+        if: >-
+          inputs.language == 'python' &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+with:
+
+```yaml
+      - name: Publish to PyPI
+        if: >-
+          inputs.registry-publish &&
+          inputs.language == 'python' &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+- [ ] **Step 9: Gate "Publish to registry"**
+
+Replace:
+
+```yaml
+      - name: Publish to registry
+        if: >-
+          inputs.language != 'python' &&
+          steps.commands.outputs.publish != '' &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+with:
+
+```yaml
+      - name: Publish to registry
+        if: >-
+          inputs.registry-publish &&
+          inputs.language != 'python' &&
+          steps.commands.outputs.publish != '' &&
+          steps.tag_check.outputs.exists == 'false'
+```
+
+- [ ] **Step 10: Run validation**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify container-tag and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+st-docker-run -- st-validate
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add .github/workflows/publish-release.yml
+```
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(publish): gate registry-specific steps behind registry-publish input
+
+Nine steps that are only meaningful for external registry publication
+(Maven creds, ecosystem command derivation, build, attestation, SBOM,
+PyPI publish, registry publish, dist directory, version-dependent
+inputs) are now gated behind the registry-publish boolean input.
+Callers must opt in with registry-publish: true. Ref #411, #412
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
 ```
 
 ---
 
-## Task 3: Update fleet caller — mq-rest-admin-python
+## Task 3: Update fleet callers — publishing repos
 
-This repo publishes to PyPI.
+These 5 repos publish to an external package registry. Each gets `language`, `container-tag`, and `registry-publish: true`.
 
 **Files:**
 - Modify: `/Users/pmoore/dev/github/mq-rest-admin-python/.github/workflows/publish-release.yml`
+- Modify: `/Users/pmoore/dev/github/mq-rest-admin-go/.github/workflows/publish-release.yml`
+- Modify: `/Users/pmoore/dev/github/mq-rest-admin-java/.github/workflows/publish-release.yml`
+- Modify: `/Users/pmoore/dev/github/mq-rest-admin-ruby/.github/workflows/publish-release.yml`
+- Modify: `/Users/pmoore/dev/github/mq-rest-admin-rust/.github/workflows/publish-release.yml`
 
-- [ ] **Step 1: Update the workflow**
-
-Add a `with:` block:
+All 5 repos currently have identical workflow files with no `with:` block:
 
 ```yaml
+jobs:
+  publish:
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+- [ ] **Step 1: Update mq-rest-admin-python**
+
+In `/Users/pmoore/dev/github/mq-rest-admin-python/.github/workflows/publish-release.yml`, replace:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: python
       container-tag: "3.14"
       registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Commit mq-rest-admin-python**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/mq-rest-admin-python && git add .github/workflows/publish-release.yml
 ```
 
----
+```bash
+cd /Users/pmoore/dev/github/mq-rest-admin-python && git commit -m "$(cat <<'EOF'
+fix(ci): specify language, container-tag, and registry-publish in publish-release caller
 
-## Task 4: Update fleet caller — mq-rest-admin-go
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
 
-This repo publishes as a Go module.
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
 
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-go/.github/workflows/publish-release.yml`
+- [ ] **Step 3: Update mq-rest-admin-go**
 
-- [ ] **Step 1: Update the workflow**
-
-Add a `with:` block:
+In `/Users/pmoore/dev/github/mq-rest-admin-go/.github/workflows/publish-release.yml`, replace:
 
 ```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: go
       container-tag: "1.26"
       registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 4: Commit mq-rest-admin-go**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/mq-rest-admin-go && git add .github/workflows/publish-release.yml
 ```
 
----
+```bash
+cd /Users/pmoore/dev/github/mq-rest-admin-go && git commit -m "$(cat <<'EOF'
+fix(ci): specify language, container-tag, and registry-publish in publish-release caller
 
-## Task 5: Update fleet caller — mq-rest-admin-java
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
 
-This repo publishes to Maven Central.
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
 
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-java/.github/workflows/publish-release.yml`
+- [ ] **Step 5: Update mq-rest-admin-java**
 
-- [ ] **Step 1: Update the workflow**
-
-Add a `with:` block:
+In `/Users/pmoore/dev/github/mq-rest-admin-java/.github/workflows/publish-release.yml`, replace:
 
 ```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: java
       container-tag: "17"
       registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 6: Commit mq-rest-admin-java**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/mq-rest-admin-java && git add .github/workflows/publish-release.yml
 ```
 
----
+```bash
+cd /Users/pmoore/dev/github/mq-rest-admin-java && git commit -m "$(cat <<'EOF'
+fix(ci): specify language, container-tag, and registry-publish in publish-release caller
 
-## Task 6: Update fleet caller — mq-rest-admin-ruby
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
 
-This repo publishes to RubyGems.
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
 
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-ruby/.github/workflows/publish-release.yml`
+- [ ] **Step 7: Update mq-rest-admin-ruby**
 
-- [ ] **Step 1: Update the workflow**
-
-Add a `with:` block:
+In `/Users/pmoore/dev/github/mq-rest-admin-ruby/.github/workflows/publish-release.yml`, replace:
 
 ```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: ruby
       container-tag: "3.4"
       registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 8: Commit mq-rest-admin-ruby**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/mq-rest-admin-ruby && git add .github/workflows/publish-release.yml
 ```
 
----
+```bash
+cd /Users/pmoore/dev/github/mq-rest-admin-ruby && git commit -m "$(cat <<'EOF'
+fix(ci): specify language, container-tag, and registry-publish in publish-release caller
 
-## Task 7: Update fleet caller — mq-rest-admin-rust
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
 
-This repo publishes to crates.io.
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
 
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-rust/.github/workflows/publish-release.yml`
+- [ ] **Step 9: Update mq-rest-admin-rust**
 
-- [ ] **Step 1: Update the workflow**
-
-Add a `with:` block:
+In `/Users/pmoore/dev/github/mq-rest-admin-rust/.github/workflows/publish-release.yml`, replace:
 
 ```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: rust
       container-tag: "1.93"
       registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 10: Commit mq-rest-admin-rust**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/mq-rest-admin-rust && git add .github/workflows/publish-release.yml
+```
+
+```bash
+cd /Users/pmoore/dev/github/mq-rest-admin-rust && git commit -m "$(cat <<'EOF'
+fix(ci): specify language, container-tag, and registry-publish in publish-release caller
+
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
 ```
 
 ---
 
-## Task 8: Update fleet caller — ai-research-methodology
+## Task 4: Update fleet callers — language-only repos
 
-This repo has a `pyproject.toml` — confirm with owner whether it publishes to PyPI. Assuming yes:
+These 2 repos need a Python container for their release pipeline but do not publish to PyPI. They pass `language` and `container-tag` but omit `registry-publish` (defaults to `false`).
 
 **Files:**
+- Modify: `/Users/pmoore/dev/github/standard-tooling/.github/workflows/publish-release.yml`
 - Modify: `/Users/pmoore/dev/github/ai-research-methodology/.github/workflows/publish-release.yml`
 
-- [ ] **Step 1: Update the workflow**
+- [ ] **Step 1: Update standard-tooling**
 
-Add a `with:` block:
+In `/Users/pmoore/dev/github/standard-tooling/.github/workflows/publish-release.yml`, replace:
 
 ```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: python
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
     with:
       language: python
       container-tag: "3.14"
-      registry-publish: true
+    secrets: inherit
 ```
 
-- [ ] **Step 2: Commit**
+- [ ] **Step 2: Commit standard-tooling**
 
 ```bash
-st-commit --type fix --scope ci \
-  --message "specify language, container-tag, and registry-publish in publish-release caller" \
-  --body "Required by standard-actions #402. Ref wphillipmoore/standard-actions#402" \
-  --agent claude
+cd /Users/pmoore/dev/github/standard-tooling && git add .github/workflows/publish-release.yml
+```
+
+```bash
+cd /Users/pmoore/dev/github/standard-tooling && git commit -m "$(cat <<'EOF'
+fix(ci): specify container-tag in publish-release caller
+
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Update ai-research-methodology**
+
+In `/Users/pmoore/dev/github/ai-research-methodology/.github/workflows/publish-release.yml`, replace:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
+
+with:
+
+```yaml
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    with:
+      language: python
+      container-tag: "3.14"
+    secrets: inherit
+```
+
+- [ ] **Step 4: Commit ai-research-methodology**
+
+```bash
+cd /Users/pmoore/dev/github/ai-research-methodology && git add .github/workflows/publish-release.yml
+```
+
+```bash
+cd /Users/pmoore/dev/github/ai-research-methodology && git commit -m "$(cat <<'EOF'
+fix(ci): specify language and container-tag in publish-release caller
+
+Required by standard-actions #412. Ref wphillipmoore/standard-actions#412
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
 ```
 
 ---
 
-## Task 9: Update fleet caller — standard-tooling-plugin
+## Task 5: Verify fleet callers — default repos
 
-No external registry. Uses `dev-base:latest`.
+These 4 repos don't publish to a registry and don't need a language-specific container. With the new defaults (`language: base`, `container-tag: latest`, `registry-publish: false`), they need no `with:` block. Verify they are correct as-is.
 
-**Files:**
-- Modify: `/Users/pmoore/dev/github/standard-tooling-plugin/.github/workflows/publish-release.yml`
+**Files (read-only verification):**
+- Verify: `/Users/pmoore/dev/github/standard-tooling-plugin/.github/workflows/publish-release.yml`
+- Verify: `/Users/pmoore/dev/github/mq-rest-admin-common/.github/workflows/publish-release.yml`
+- Verify: `/Users/pmoore/dev/github/mq-rest-admin-dev-environment/.github/workflows/publish-release.yml`
+- Verify: `/Users/pmoore/dev/github/mq-rest-admin-template/.github/workflows/publish-release.yml`
 
-- [ ] **Step 1: Update the workflow**
+- [ ] **Step 1: Verify all 4 repos have no `with:` block**
 
-No `with:` block needed — `language` defaults to `base`, `container-tag` defaults to `latest`, `registry-publish` defaults to `false`. The existing file already works as-is with the new defaults.
+For each of the 4 repos, confirm the workflow file contains:
 
-Verify the file has no `with:` block and leave it unchanged. No commit needed.
+```yaml
+jobs:
+  publish:
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.5
+    secrets: inherit
+```
 
----
-
-## Task 10: Update fleet caller — mq-rest-admin-common
-
-No external registry. Uses `dev-base:latest`.
-
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-common/.github/workflows/publish-release.yml`
-
-- [ ] **Step 1: Verify**
-
-No `with:` block needed — defaults apply. Leave unchanged. No commit needed.
-
----
-
-## Task 11: Update fleet caller — mq-rest-admin-dev-environment
-
-No external registry. Uses `dev-base:latest`.
-
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-dev-environment/.github/workflows/publish-release.yml`
-
-- [ ] **Step 1: Verify**
-
-No `with:` block needed — defaults apply. Leave unchanged. No commit needed.
-
----
-
-## Task 12: Update fleet caller — mq-rest-admin-template
-
-No external registry. Uses `dev-base:latest`.
-
-**Files:**
-- Modify: `/Users/pmoore/dev/github/mq-rest-admin-template/.github/workflows/publish-release.yml`
-
-- [ ] **Step 1: Verify**
-
-No `with:` block needed — defaults apply. Leave unchanged. No commit needed.
+No changes needed. The defaults (`base`/`latest`/`false`) match their requirements.
 
 ---
 
 ## Rollout Order
 
-The changes must be deployed in this order:
+1. **Tasks 1-2** — merge the `publish-release.yml` changes in standard-actions (moves floating `v1.5` tag)
+2. **Tasks 3-4** — push fleet caller updates to each repo
+3. **Task 5** — verify default repos still work (no code change, just confirmation)
 
-1. **Task 1** — merge the `publish-release.yml` changes in `standard-actions` and cut a new tag (e.g. `v1.6` or update `v1.5`)
-2. **Tasks 2-8** — update fleet callers to pin to the new tag and pass the new inputs
-3. **Tasks 9-12** — verify the non-language repos still work with defaults (no code change needed, but confirm CI passes after the tag update)
-
-If the `v1.5` tag is a floating tag (moved on each release), then the fleet callers must be updated *before* the tag moves — otherwise they'll break during the window between tag update and caller update. If `v1.5` is immutable, cut `v1.6` and update callers to reference `@v1.6`.
+The fleet is frozen — no releases will be triggered during the rollout window.

--- a/docs/specs/2026-05-09-registry-publish-flag-design.md
+++ b/docs/specs/2026-05-09-registry-publish-flag-design.md
@@ -1,0 +1,142 @@
+# Registry Publish Flag Design
+
+**Issues:**
+- [#411 — feat: make PyPI publishing opt-in for Python repos in publish-release workflow](https://github.com/wphillipmoore/standard-actions/issues/411)
+- [#412 — feat: add registry-publish flag to publish-release.yml and update fleet callers](https://github.com/wphillipmoore/standard-actions/issues/412)
+
+**Date:** 2026-05-09
+
+**Status:** Ready for implementation
+
+## Problem
+
+The `publish-release.yml` reusable workflow unconditionally runs registry
+publication steps for all callers. For Python repos, `uv publish dist/*`
+runs whenever `inputs.language == 'python'`, regardless of whether the repo
+has a PyPI trusted publisher configured. For non-Python repos, registry
+publish is skipped only incidentally when derived commands are empty or
+credentials are missing.
+
+This causes two problems:
+
+1. **PyPI publish failures** for Python repos that don't publish to PyPI
+   (e.g., standard-tooling, ai-research-methodology). The step fails with
+   a 422 "invalid-publisher" error, blocking releases.
+2. **Unnecessary inputs** for non-language repos. `language` and
+   `container-tag` are required even for repos that don't publish to any
+   registry and don't need a language-specific container.
+
+## Design
+
+### Approach
+
+Add a single `registry-publish` boolean input (default `false`) to the
+reusable workflow. Callers that publish to an external package registry
+opt in explicitly. Make `language` and `container-tag` optional with
+sensible defaults so non-language repos can omit them entirely.
+
+### Workflow input changes
+
+Three changes to `publish-release.yml` inputs:
+
+1. **`language`** — remove `required: true`, add `default: "base"`.
+   Non-language repos get the `dev-base` container image automatically.
+2. **`container-tag`** — remove `required: true`, add `default: "latest"`.
+   Pairs with the `base` default above.
+3. **`registry-publish`** (new) — `type: boolean`, `default: false`.
+   Opt-in flag that gates all registry-specific steps.
+
+The container image resolution is unchanged:
+`ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ inputs.container-tag }}`
+resolves to `dev-base:latest` by default. Note: the `latest` default is only
+valid when paired with `language: base` (the default). Language-specific
+container images (e.g., `dev-python`) do not publish a `:latest` tag, so
+callers that specify a language must also specify a `container-tag`.
+
+### Step gating
+
+`inputs.registry-publish` is prepended (with `&&`) to each gated step's
+existing `if` condition. No step restructuring or new jobs — just an
+additional boolean guard.
+
+**Gated behind `registry-publish`:**
+
+- Configure Maven credentials
+- Derive ecosystem commands
+- Prepare version-dependent inputs
+- Ensure dist directory
+- Build
+- Attest build provenance
+- Generate SBOM
+- Publish to PyPI
+- Publish to registry
+
+**New validation step (runs before any other logic):**
+
+- Validate input pairing: fail fast with a clear error if:
+  - `language != 'base'` and `container-tag == 'latest'` (language-specific
+    container images do not publish a `:latest` tag), or
+  - `registry-publish == true` and `language == 'base'` (registry publishing
+    requires a language to derive ecosystem build/publish commands).
+
+**Ungated (run for every release):**
+
+- Checkout code
+- Install standard-tooling
+- Extract version
+- Check if tag already exists
+- Tag and release
+- Generate app token for bump PR
+- Version bump PR
+
+### Fleet caller updates
+
+11 repos, split by whether they publish to an external registry:
+
+**Repos that publish (`registry-publish: true`):**
+
+| Repository | `language` | `container-tag` | `registry-publish` |
+|---|---|---|---|
+| mq-rest-admin-python | `python` | `3.14` | `true` |
+| mq-rest-admin-go | `go` | `1.26` | `true` |
+| mq-rest-admin-java | `java` | `17` | `true` |
+| mq-rest-admin-ruby | `ruby` | `3.4` | `true` |
+| mq-rest-admin-rust | `rust` | `1.93` | `true` |
+
+**Repos that need a language container but don't publish:**
+
+| Repository | `language` | `container-tag` | `registry-publish` |
+|---|---|---|---|
+| standard-tooling | `python` | `3.14` | _(default false)_ |
+| ai-research-methodology | `python` | `3.14` | _(default false)_ |
+
+**Repos that use all defaults (no `with:` block needed):**
+
+| Repository |
+|---|
+| standard-tooling-plugin |
+| mq-rest-admin-common |
+| mq-rest-admin-dev-environment |
+| mq-rest-admin-template |
+
+### Rollout
+
+The `v1.5` tag is floating. The change alters the semantic contract of
+`v1.5`: `language` and `container-tag` shift from required to optional with
+defaults, and registry-specific steps now require explicit opt-in. Existing
+callers that pass `language` and `container-tag` are unaffected. Callers
+that omit them will get `dev-base:latest` instead of a validation error.
+Since there are no external consumers, the plan is:
+
+1. Merge the `publish-release.yml` changes in standard-actions (moves `v1.5`).
+2. Immediately roll out fleet caller updates to pass `language`,
+   `container-tag`, and `registry-publish` as appropriate.
+
+## What this does NOT change
+
+- No new workflow jobs or step restructuring.
+- No changes to `standard-tooling.toml` — the `registry-publish` flag is a
+  workflow-level concern, not repo metadata.
+- No changes to the tag-and-release or version-bump-pr composite actions.
+- No changes to the existing credential-guard pattern on the non-Python
+  publish step (it remains as a secondary safeguard).

--- a/paad/pushback-reviews/2026-05-09-registry-publish-flag-design-pushback.md
+++ b/paad/pushback-reviews/2026-05-09-registry-publish-flag-design-pushback.md
@@ -1,0 +1,51 @@
+# Pushback Review: Registry Publish Flag Design
+
+**Date:** 2026-05-09
+**Spec:** `docs/specs/2026-05-09-registry-publish-flag-design.md`
+**Commit:** accf6c5
+
+## Source Control Conflicts
+
+### [1] container-tag "latest" default conflicts with recent commit rationale
+
+- **Commit:** 5bc316b (PR #410, merged same day)
+- **What the spec assumed:** `container-tag` can default to `"latest"` when made optional.
+- **What actually changed:** Commit 5bc316b made `container-tag` required, with the rationale: "The default of 'latest' was never valid — no language-specific dev container image publishes a :latest tag."
+- **Why this matters:** The spec proposes reverting `container-tag` to optional with `default: "latest"`. This is safe when paired with `language: base` (since `dev-base:latest` exists), but the commit's concern about language-specific images remains valid.
+- **Resolution:** Added a note to the spec clarifying that `latest` is only valid with `language: base`, and added a validation step to fail fast when the pairing is invalid.
+
+## Issues Reviewed
+
+### [2] No validation that language and container-tag are paired correctly
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** A caller could pass `language: python` without a `container-tag` and get `dev-python:latest`, which doesn't exist. This would fail at container pull time with a cryptic image-not-found error.
+- **Resolution:** Added a validation step to the spec that fails fast with a clear error if `language != 'base'` and `container-tag == 'latest'`.
+
+### [3] Rollout window risk between standard-actions merge and fleet updates
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** Between merging the workflow change and updating fleet callers, any release would silently skip registry publishing because `registry-publish` defaults to `false`.
+- **Resolution:** No spec change. The fleet is frozen — no releases will be triggered during this window. The fleet is managed as a unit, not independently.
+
+### [4] Existing implementation plan needs reconciliation
+- **Category:** Omission
+- **Severity:** Minor
+- **Issue:** The existing plan at `docs/plans/2026-05-09-registry-publish-flag.md` doesn't include the validation step and has incorrect fleet table entries (standard-tooling and ai-research-methodology listed as `registry-publish: true`).
+- **Resolution:** No spec change. The plan will be regenerated from the updated spec during the transition to implementation.
+
+### [5] registry-publish: true without a language silently does nothing
+- **Category:** Ambiguity
+- **Severity:** Minor
+- **Issue:** If a caller passes `registry-publish: true` but omits `language` (getting the `base` default), the ecosystem command derivation hits the wildcard fallback — no build command, no publish command. The registry-publish steps silently do nothing.
+- **Resolution:** Extended the validation step to also fail fast if `registry-publish == true` and `language == 'base'`.
+
+## Unresolved Issues
+
+None — all issues were addressed.
+
+## Summary
+
+- **Issues found:** 5 (1 source control conflict, 4 from critique)
+- **Issues resolved:** 5
+- **Spec status:** Ready for implementation


### PR DESCRIPTION
# Pull Request

## Summary

- Add registry-publish boolean input (default false) to gate all registry-specific steps, make language and container-tag optional with defaults, add input validation step

## Issue Linkage

- Ref #412

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- -