### PR TITLE
docs(site): sweep documentation for consistency with recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,13 +133,36 @@ st-docker-run -- st-validate   # Canonical validation (runs in dev-base containe
 
 All actions live under `actions/` as composite GitHub Actions:
 
-- `actions/standards-compliance` — PR-specific compliance checks: issue
-  linkage and auto-close keyword rejection
+- `actions/docs-deploy` — MkDocs Material + mike versioned documentation
+  deployment
+- `actions/publish/tag-and-release` — Annotated git tags, rolling minor
+  tags, and GitHub Releases
+- `actions/publish/version-bump-pr` — Post-release version bump PRs
 - `actions/python/setup` — Python environment setup with uv and caching
+- `actions/release-gates/version-divergence` — Pre-merge version
+  validation
 - `actions/security/codeql` — CodeQL static analysis
 - `actions/security/semgrep` — Semgrep SAST scanning
 - `actions/security/trivy` — Trivy vulnerability scanning (filesystem,
   SBOM, container image)
+- `actions/setup/standard-tooling` — Installs standard-tooling from the
+  version pinned in `standard-tooling.toml`
+- `actions/standards-compliance` — PR-specific compliance checks: issue
+  linkage and auto-close keyword rejection
+
+### Reusable Workflows
+
+CI and CD workflows live under `.github/workflows/` and are consumed via
+`workflow_call`:
+
+- `ci-quality.yml` — Common linting, language-specific lint and typecheck
+- `ci-security.yml` — Standards compliance and security scanning
+- `ci-test.yml` — Unit and integration tests
+- `ci-audit.yml` — Dependency audit
+- `ci-version-bump.yml` — Version divergence gate
+- `cd-release.yml` — Full release pipeline (tag, build, publish, version
+  bump)
+- `cd-docs.yml` — MkDocs documentation deployment
 
 ### Self-Referencing CI
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,20 @@ application and library repositories without workflow drift.
 ## Repository layout
 
 ```text
-actions/
-  <action-name>/
-    action.yml
-    README.md
-    scripts/
+actions/                          Composite GitHub Actions
+  docs-deploy/                    MkDocs + mike versioned deployment
+  publish/                        Release tagging and version bumps
+  python/setup/                   Python environment with uv and caching
+  release-gates/                  Pre-merge version validation
+  security/                       CodeQL, Semgrep, Trivy scanning
+  setup/standard-tooling/         standard-tooling CLI installer
+  standards-compliance/           PR issue linkage enforcement
+.github/workflows/
+  ci.yml                          Local CI umbrella (pull_request)
+  ci-*.yml                        Reusable pre-merge CI gates
+  cd.yml                          Local CD umbrella (push to main/develop)
+  cd-*.yml                        Reusable post-merge delivery
+docs/site/                        MkDocs documentation source
 ```
 
 ## Branching and releases

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -17,5 +17,5 @@ Define development workflow standards for this repository.
 
 - Environment and tooling: [environment-and-tooling.md](environment-and-tooling.md)
 - Tooling dependencies: [tooling-dependencies.md](tooling-dependencies.md)
-- Validation: [validation.md](validation.md)
+- CD workflow ordering: [publish-workflow.md](publish-workflow.md)
 - Repository bootstrap: [../operations/repository-bootstrap.md](../operations/repository-bootstrap.md)

--- a/docs/site/docs/actions/docs-deploy.md
+++ b/docs/site/docs/actions/docs-deploy.md
@@ -11,8 +11,6 @@ git configuration, version detection, and mike deploy/set-default.
     version-command: cat VERSION | cut -d. -f1,2
     mkdocs-config: docs/site/mkdocs.yml
     mike-command: mike
-    checkout-common: "false"
-    checkout-common-ref: develop
 ```
 
 ## Inputs
@@ -21,9 +19,7 @@ git configuration, version detection, and mike deploy/set-default.
 | ------ | ---------- | --------- | ------------- |
 | `version-command` | **Yes** | — | Shell command to extract the version string on main (e.g. `cat VERSION`, `grep -oP ... version.go`). |
 | `mkdocs-config` | No | `docs/site/mkdocs.yml` | Path to mkdocs.yml configuration file. |
-| `mike-command` | No | `mike` | Command to run mike. Set to `uv run mike` for Python repos that manage their own dependencies. When not `mike`, the action skips Python setup and MkDocs installation. |
-| `checkout-common` | No | `false` | Whether to checkout mq-rest-admin-common. |
-| `checkout-common-ref` | No | `develop` | Ref to checkout for mq-rest-admin-common. |
+| `mike-command` | No | `mike` | Command to run mike. Set to `uv run mike` for Python repos that manage their own dependencies via their project's virtual environment. |
 
 ## Permissions
 
@@ -31,41 +27,43 @@ git configuration, version detection, and mike deploy/set-default.
 
 ## Behavior
 
-1. **Checkout common** (optional) — If `checkout-common` is `true`, checks out
-   the `mq-rest-admin-common` repository for shared documentation fragments.
-2. **Set up Python 3.12** — Only when `mike-command` is `mike` (default).
-3. **Install MkDocs and mike** — `pip install mkdocs-material mike`. Skipped
-   when a custom `mike-command` is provided.
-4. **Configure git identity** — Sets the git user to `github-actions[bot]` for
-   the deploy commit.
-5. **Determine version** — On `main`, runs the `version-command` to extract the
+1. **Configure git identity** — Sets the git user to `github-actions[bot]` for
+   the deploy commit. Marks the workspace as a safe directory to avoid
+   dubious-ownership errors in container jobs.
+2. **Determine version** — On `main`, runs the `version-command` to extract the
    version and sets `alias=latest`. On all other branches, sets `version=dev`
    with no alias.
-6. **Deploy docs** — On `main`, runs `mike deploy --push --update-aliases
+3. **Stage changelog and release notes** — Copies `CHANGELOG.md` and
+   `releases/*.md` into the docs directory, and generates a release notes index
+   page sorted by semver. Uses system Python (`/usr/local/bin/python3`) to avoid
+   venv PATH shadowing.
+4. **Patch mkdocs nav** — Injects release version entries into the `mkdocs.yml`
+   nav under the Releases section.
+5. **Deploy docs** — On `main`, runs `mike deploy --push --update-aliases
    <version> latest` followed by `mike set-default --push latest`. On other
    branches, runs `mike deploy --push dev`.
 
-## Examples
+## Reusable workflow
 
-### Standard library deployment
+Docs deployment is typically consumed via the `cd-docs.yml` reusable workflow
+rather than calling the composite action directly:
 
 ```yaml
-name: Documentation
-on:
-  push:
-    branches: [develop, main]
-permissions:
-  contents: write
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
-        with:
-          version-command: cat VERSION | cut -d. -f1,2
+  docs:
+    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    permissions:
+      contents: write
+```
+
+## Examples
+
+### Direct usage (standalone)
+
+```yaml
+- uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
+  with:
+    version-command: cat VERSION | cut -d. -f1,2
 ```
 
 ### Python repo with uv-managed dependencies

--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -61,7 +61,7 @@ Each reusable workflow produces canonical check names. See
 | `ci-security.yml` | `CI Security / standards`, `CI Security / codeql`, `CI Security / trivy`, `CI Security / semgrep` |
 | `ci-quality.yml` | `CI Quality / common`, `CI Quality / lint / <version>`, `CI Quality / typecheck / <version>` |
 | `ci-audit.yml` | `CI Audit / dependencies / <version>` |
-| `ci-test.yml` | `CI Test / unit / <version>`, `CI Test / integration / <version>` |
+| `ci-test.yml` | `CI Test / unit / <version>` |
 | `ci-version-bump.yml` | `CI Version Bump / version-bump` |
 
 ## Reusable workflow flags

--- a/docs/site/docs/configuration.md
+++ b/docs/site/docs/configuration.md
@@ -205,8 +205,7 @@ gh secret set APP_PRIVATE_KEY --repo wphillipmoore/<repo> --body "$(cat <key>.pe
 
 - [ ] Add `add-to-project.yml` with the correct project URL
 - [ ] Add `ci.yml` with standard checks for the repository type
-- [ ] Add `docs.yml` if the repository has a documentation site
-- [ ] Add `cd.yml` if the repository publishes versioned artifacts
+- [ ] Add `cd.yml` with docs and/or release jobs as needed
 
 ### 6. CI gates activation
 

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -36,14 +36,14 @@ jobs:
 
 ## Consuming reusable workflows
 
-v1.5.0 introduced reusable CI workflows that produce canonical check names.
+Reusable workflows produce canonical check names across all repositories.
 Reference workflows using the full path to the workflow file:
 
 ```yaml
 uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
 ```
 
-### Minimal workflow example using reusable workflows
+### CI workflow example
 
 ```yaml
 name: CI
@@ -69,6 +69,33 @@ jobs:
       security-events: write
     with:
       language: python
+```
+
+### CD workflow example
+
+```yaml
+name: CD
+
+on:
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docs:
+    uses: wphillipmoore/standard-actions/.github/workflows/cd-docs.yml@v1.5
+    permissions:
+      contents: write
+
+  release:
+    if: github.ref == 'refs/heads/main'
+    uses: wphillipmoore/standard-actions/.github/workflows/cd-release.yml@v1.5
+    with:
+      language: python
+    secrets: inherit
 ```
 
 See [Reusable Workflows](workflows/index.md) for the full list and

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -22,9 +22,10 @@ releases.
 
 ## Reusable workflows
 
-v1.5.0 introduced reusable CI workflows that provide canonical job and check
-names across all managed repositories. See
-[Reusable Workflows](workflows/index.md) for details.
+Reusable workflows provide canonical job and check names across all managed
+repositories. See [Reusable Workflows](workflows/index.md) for details.
+
+### CI (pre-merge)
 
 | Workflow | Purpose |
 | ---------- | --------- |
@@ -34,11 +35,18 @@ names across all managed repositories. See
 | [ci-test](workflows/ci-test.md) | Unit and integration tests |
 | [ci-version-bump](workflows/ci-version-bump.md) | Version divergence gate |
 
+### CD (post-merge)
+
+| Workflow | Purpose |
+| ---------- | --------- |
+| cd-release | Full release pipeline (tag, build, publish, version bump) |
+| cd-docs | MkDocs documentation deployment |
+
 ## Design principles
 
 - **Composite actions only** — No custom JavaScript or Docker actions. Every
   action is a composite `action.yml` with shell steps.
-- **Reusable workflows** — CI workflows are provided as reusable
+- **Reusable workflows** — CI and CD workflows are provided as reusable
   `workflow_call` templates that produce canonical check names across all
   consuming repositories.
 - **Self-referencing CI** — This repository's own CI uses `./actions/...` and

--- a/docs/site/docs/workflows/ci-audit.md
+++ b/docs/site/docs/workflows/ci-audit.md
@@ -8,6 +8,7 @@ Dependency audit workflow.
 | ------- | ------ | ---------- | --------- | ------------- |
 | `language` | string | yes | — | Primary language of the repository |
 | `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
+| `container-suffix` | string | no | `<language>` | Container image name suffix (e.g. `python`, `base`) |
 
 ## Jobs and check names
 

--- a/docs/site/docs/workflows/ci-quality.md
+++ b/docs/site/docs/workflows/ci-quality.md
@@ -8,6 +8,8 @@ Code quality and linting workflow.
 | ------- | ------ | ---------- | --------- | ------------- |
 | `language` | string | yes | — | Primary language of the repository |
 | `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
+| `container-suffix` | string | no | `<language>` | Container image name suffix (e.g. `python`, `base`) |
+| `container-tag` | string | no | `latest` | Container image tag for non-matrix jobs |
 
 ## Jobs and check names
 

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -10,6 +10,8 @@ Standards compliance and security scanning workflow.
 | `run-standards` | boolean | no | `true` | Run the standards-compliance job |
 | `run-security` | boolean | no | `true` | Run security scanner jobs (CodeQL, Semgrep, Trivy) |
 | `run-codeql` | boolean | no | `true` | Run CodeQL analysis (disable for unsupported languages like `shell`) |
+| `container-suffix` | string | no | `base` | Container image name suffix for the standards job |
+| `container-tag` | string | no | `latest` | Container image tag for the standards job |
 
 ## Required permissions
 

--- a/docs/site/docs/workflows/ci-test.md
+++ b/docs/site/docs/workflows/ci-test.md
@@ -8,19 +8,16 @@ Unit and integration test workflow.
 | ------- | ------ | ---------- | --------- | ------------- |
 | `language` | string | yes | — | Primary language of the repository |
 | `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
-| `integration-tests` | boolean | no | `false` | Enable integration test jobs |
+| `container-suffix` | string | no | `<language>` | Container image name suffix (e.g. `python`, `base`) |
 
 ## Jobs and check names
 
 | Job | Check name | Condition |
 | ----- | ------------ | ----------- |
 | `unit / <version>` | `CI Test / unit / <version>` | Always runs |
-| `integration / <version>` | `CI Test / integration / <version>` | `integration-tests` is true |
 
 ## Usage
 
-Unit tests only:
-
 ```yaml
 jobs:
   test:
@@ -28,22 +25,10 @@ jobs:
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
-```
-
-With integration tests:
-
-```yaml
-jobs:
-  test:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
-    with:
-      language: python
-      versions: '["3.12", "3.13", "3.14"]'
-      integration-tests: true
 ```
 
 ## Extension points
 
-The `unit` and `integration` jobs provide version matrix scaffolds.
-Consuming repositories customize these by forking the workflow or by
-running language-specific test commands in a separate workflow.
+The `unit` job provides a version matrix scaffold. Consuming repositories
+customize it by forking the workflow or by running language-specific test
+commands in a separate workflow.

--- a/docs/site/docs/workflows/ci-version-bump.md
+++ b/docs/site/docs/workflows/ci-version-bump.md
@@ -8,6 +8,8 @@ Version divergence gate workflow.
 | ------- | ------ | ---------- | --------- | ------------- |
 | `language` | string | yes | — | Primary language of the repository |
 | `run-release` | boolean | no | `true` | Run the version-bump verification job |
+| `container-suffix` | string | no | `base` | Container image name suffix (e.g. `python`, `base`) |
+| `container-tag` | string | no | `latest` | Container image tag (e.g. `3.14`, `1.26`) |
 
 ## Jobs and check names
 

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -3,7 +3,7 @@
 v1.5.0 introduced reusable CI workflows that provide canonical job and check
 names across all managed repositories. Each workflow bundles one or more
 composite actions with the container, tooling, and permission setup needed
-to run them.
+to run them. CD workflows handle post-merge delivery (releases, documentation).
 
 ## Why reusable workflows?
 
@@ -13,7 +13,7 @@ GitHub's checks UI. This guarantees consistent, canonical check names across
 repositories — a requirement for pattern-based required status checks in
 rulesets.
 
-## Available workflows
+## CI workflows (pre-merge)
 
 | Workflow | File | Purpose |
 | ---------- | ------ | --------- |
@@ -22,6 +22,13 @@ rulesets.
 | [CI Audit](ci-audit.md) | `ci-audit.yml` | Dependency audit |
 | [CI Test](ci-test.md) | `ci-test.yml` | Unit and integration tests |
 | [CI Version Bump](ci-version-bump.md) | `ci-version-bump.yml` | Version divergence gate |
+
+## CD workflows (post-merge)
+
+| Workflow | File | Purpose |
+| ---------- | ------ | --------- |
+| CD Release | `cd-release.yml` | Full release pipeline (tag, build, publish, version bump) |
+| CD Docs | `cd-docs.yml` | MkDocs documentation deployment |
 
 ## Consuming a reusable workflow
 


### PR DESCRIPTION
# Pull Request

## Summary

- Sweep all documentation for consistency with recent major changes (CI/CD workflow convention rename, registry-publish flag, system Python docs-deploy fix)

## Issue Linkage

- Ref #426

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Updates 14 documentation files to reflect recent changes:

- docs-deploy action docs: removed stale checkout-common/checkout-common-ref inputs, updated behavior to reflect current steps (system Python, changelog staging, nav patching), added cd-docs.yml reusable workflow reference
- Workflow docs: added CD workflows (cd-release, cd-docs) to workflows index and site index; added missing container-suffix/container-tag inputs to all CI workflow docs
- ci-test docs: removed non-existent integration-tests input and integration job
- required-checks: fixed ci-test check-name mapping (removed stale integration entry)
- configuration: updated onboarding checklist (cd.yml replaces separate docs.yml)
- CLAUDE.md: expanded composite actions list (was missing 5 of 9 actions), added reusable workflows section
- README: expanded repository layout to list all action directories and workflow patterns
- docs/development/overview.md: fixed broken validation.md link (now points to publish-workflow.md)
- getting-started: added CD workflow example alongside existing CI example