### PR TITLE
fix(ops): simplify ops-github-config to use default failure notifications

### DIFF
--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   github-config:
@@ -19,66 +18,6 @@ jobs:
         uses: ./actions/setup/standard-tooling
 
       - name: Audit GitHub configuration
-        id: audit
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set +e
-          st-github-config audit --repo "${{ github.repository }}" 2>&1 \
-            | tee /tmp/audit-output.txt
-          rc=$?
-          set -e
-          if [ $rc -eq 0 ]; then
-            echo "compliant=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "compliant=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Manage drift issue
-        if: always() && steps.audit.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          TITLE="ops: GitHub configuration drift detected"
-
-          EXISTING=$(
-            gh issue list --repo "$REPO" --state open --label ops \
-              --search "in:title \"$TITLE\"" \
-              --json number --jq '.[0].number // empty'
-          )
-
-          if [ "${{ steps.audit.outputs.compliant }}" = "true" ]; then
-            if [ -n "$EXISTING" ]; then
-              gh issue close "$EXISTING" --repo "$REPO" \
-                --comment "Audit passed — configuration is now compliant."
-            fi
-            exit 0
-          fi
-
-          st-ensure-label --repo "$REPO" --name ops \
-            --description "Operational maintenance" --color "0E8A16"
-
-          {
-            echo "Scheduled audit detected configuration drift from the"
-            echo "canonical baseline."
-            echo ""
-            echo '```'
-            cat /tmp/audit-output.txt
-            echo '```'
-            echo ""
-            echo "**Remediation:**"
-            echo '```bash'
-            echo "st-github-config diff  --repo $REPO   # review drift"
-            echo "st-github-config apply --repo $REPO   # apply fixes"
-            echo '```'
-          } > /tmp/issue-body.md
-
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$REPO" \
-              --body-file /tmp/issue-body.md
-          else
-            gh issue create --repo "$REPO" --title "$TITLE" \
-              --body-file /tmp/issue-body.md --label ops
-          fi
-          exit 1
+        run: st-github-config audit --repo "${{ github.repository }}"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove issue creation/update/close logic from ops-github-config workflow and rely on GitHub Actions default failure notifications instead

## Issue Linkage

- Ref #431

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Drops issues:write permission; simplifies audit step to run st-github-config audit directly and exit non-zero on drift