### PR TITLE
fix(cd): verify tag is resolvable after push, resync if needed

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -267,6 +267,22 @@ jobs:
           version: ${{ steps.version.outputs.version }}
           release-artifacts: ${{ steps.resolved.outputs.release-artifacts }}
 
+      - name: Verify tag is resolvable from remote
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          repo_url="https://github.com/${{ github.repository }}"
+          tmp="$(mktemp -d)"
+          if git clone --depth 1 --branch "$TAG" "$repo_url" "$tmp" 2>/dev/null; then
+            rm -rf "$tmp"
+            exit 0
+          fi
+          echo "::warning::Tag $TAG has missing objects on remote — resyncing"
+          git push --no-thin origin "$TAG" --force
+          git clone --depth 1 --branch "$TAG" "$repo_url" "$tmp"
+          rm -rf "$tmp"
+
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'
         id: app-token


### PR DESCRIPTION
# Pull Request

## Summary

- Add post-publish shallow-clone check to catch missing git objects after tag push

## Issue Linkage

- Ref wphillipmoore/standard-tooling#664

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- After v1.4.32, consumers could not install from the published tag because
the tagged commit referenced git objects missing from the remote. The root
cause was a gap in git pack negotiation during the release branch push.

This adds a post-publish verification step to cd-release.yml that
shallow-clones the just-pushed tag from the public remote URL. If the
clone fails (missing objects), it resyncs the tag with --no-thin and
retries. If the resync also fails, the CD job goes red.

Placement: after "Tag and release", before "Generate app token for bump PR".

See spec: wphillipmoore/standard-tooling@develop:docs/specs/2026-05-09-post-publish-tag-verification-design.md