### PR TITLE
ci: rename release caller key to version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       language: shell
       run-codeql: false
 
-  release:
+  version:
     uses: ./.github/workflows/ci-version-bump.yml
     with:
       language: shell


### PR DESCRIPTION
# Pull Request

## Summary

- Rename release caller key to version in ci.yml, completing the check name migration

## Issue Linkage

- Ref #442

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- Renames the release caller job key to version in ci.yml, changing the GitHub check context from release / version-bump to version / version-bump. All consumer repos already use the version key. This was the last holdout per commit cd594d0. Ref wphillipmoore/standard-tooling#664