### PR TITLE
feat(ci): switch CI/CD container images to prod- prefix

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -11,6 +11,10 @@ on:
         description: Path to mkdocs.yml configuration file.
         type: string
         default: docs/site/mkdocs.yml
+      container-prefix:
+        description: Container image name prefix (prod or dev). Defaults to "prod".
+        type: string
+        default: prod
 
 permissions:
   contents: write
@@ -23,7 +27,7 @@ jobs:
   deploy:
     name: docs
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-base:latest
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -23,7 +23,7 @@ jobs:
   deploy:
     name: docs
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/prod-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -69,7 +69,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.language }}:${{ inputs.container-tag }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.language }}:${{ inputs.container-tag }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -4,13 +4,17 @@ on:
   workflow_call:
     inputs:
       language:
-        description: Primary language (matches dev container image suffix).
+        description: Primary language (matches container image suffix).
         type: string
         default: "base"
       container-tag:
-        description: Dev container image tag (e.g. 3.14, 1.26).
+        description: Container image tag (e.g. 3.14, 1.26).
         type: string
         default: "latest"
+      container-prefix:
+        description: Container image name prefix (prod or dev). Defaults to "prod".
+        type: string
+        default: prod
       registry-publish:
         description: Publish build artifacts to an external package registry.
         type: boolean
@@ -69,7 +73,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.language }}:${{ inputs.container-tag }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.language }}:${{ inputs.container-tag }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
     name: "cd / release"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/prod-base:latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -16,12 +16,18 @@ on:
           Container image name suffix (e.g. python, go, base). Defaults
           to the language input. Callers whose language is "shell" or
           "none" should pass "base".
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 jobs:
   dependencies:
     name: dependencies / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -21,7 +21,7 @@ jobs:
   dependencies:
     name: dependencies / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -27,7 +27,7 @@ jobs:
   common:
     name: common
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -41,7 +41,7 @@ jobs:
   lint:
     name: lint / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -62,7 +62,7 @@ jobs:
   typecheck:
     name: typecheck / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -22,12 +22,18 @@ on:
         description: >-
           Container image tag for non-matrix jobs (e.g. common).
           Defaults to "latest".
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 jobs:
   common:
     name: common
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -41,7 +47,7 @@ jobs:
   lint:
     name: lint / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
@@ -62,7 +68,7 @@ jobs:
   typecheck:
     name: typecheck / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -43,7 +43,7 @@ jobs:
     name: standards
     if: ${{ inputs.run-standards }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -88,7 +88,7 @@ jobs:
     name: semgrep
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-base:latest
+    container: ghcr.io/wphillipmoore/prod-base:latest
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -33,6 +33,12 @@ on:
         description: >-
           Container image tag for the standards job.
           Defaults to "latest".
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 permissions:
   contents: read
@@ -43,7 +49,7 @@ jobs:
     name: standards
     if: ${{ inputs.run-standards }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -88,7 +94,7 @@ jobs:
     name: semgrep
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-base:latest
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,7 +21,7 @@ jobs:
   unit:
     name: unit / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,12 +16,18 @@ on:
           Container image name suffix (e.g. python, go, base). Defaults
           to the language input. Callers whose language is "shell" or
           "none" should pass "base".
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 jobs:
   unit:
     name: unit / ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || inputs.language }}:${{ matrix.version }}
     strategy:
       matrix:
         version: ${{ fromJSON(inputs.versions) }}

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -27,7 +27,7 @@ jobs:
     name: version-bump
     if: ${{ inputs.run-release }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -21,13 +21,19 @@ on:
         description: >-
           Container image tag for the version-bump job.
           Defaults to "latest".
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 jobs:
   version-bump:
     name: version-bump
     if: ${{ inputs.run-release }}
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/prod-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
+    container: ghcr.io/wphillipmoore/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Switch all CI/CD workflow container image references from dev- to prod- prefix

## Issue Linkage

- Ref #446

## Testing

- markdownlint
- ci: actionlint
- ci: shellcheck

## Notes

- # Pull Request

## Summary

- Switch all CI/CD workflow container image references from `dev-` to `prod-` prefix
- 11 replacements across 8 workflow files: ci-quality, ci-test, ci-audit, ci-security, ci-version-bump, cd-docs, cd-release, cd

## Issue Linkage

- Ref #446

## Testing

- st-validate clean (markdownlint, shellcheck, yamllint, actionlint)

## Notes

- Phase 3 of the release workflow and image naming plan. Phase 1 (standard-tooling-docker workflow restructuring) and Phase 2 (standard-tooling consumer-side config) are merged.
- All consuming repos will now use `prod-` images for CI, which are built on main pushes and represent stable, released container images.