### PR TITLE
Extract inline workflow logic into composite actions

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -37,18 +37,6 @@ jobs:
       - name: Install standard-tooling
         uses: ./actions/setup/standard-tooling
 
-      - name: Detect ecosystem
-        id: ecosystem
-        shell: bash
-        run: |
-          # Absolute path: a project venv can shadow python3 (see #418).
-          lang=$(/usr/local/bin/python3 -c "
-          import tomllib, pathlib
-          cfg = tomllib.loads(pathlib.Path('standard-tooling.toml').read_text())
-          print(cfg['project']['primary-language'])
-          ")
-          echo "language=$lang" >> "$GITHUB_OUTPUT"
-
       - name: Run pre-deploy command
         if: inputs.pre-deploy-command != ''
         shell: bash
@@ -56,19 +44,8 @@ jobs:
           PRE_DEPLOY_COMMAND: ${{ inputs.pre-deploy-command }}
         run: eval "$PRE_DEPLOY_COMMAND"
 
-      - name: Determine mike command
-        id: mike
-        shell: bash
-        run: |
-          if [ "${{ steps.ecosystem.outputs.language }}" = "python" ]; then
-            echo "cmd=uv run mike" >> "$GITHUB_OUTPUT"
-          else
-            echo "cmd=mike" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Deploy docs
         uses: ./actions/docs-deploy
         with:
           version-command: st-version show --major-minor
           mkdocs-config: ${{ inputs.mkdocs-config || 'docs/site/mkdocs.yml' }}
-          mike-command: ${{ steps.mike.outputs.cmd }}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -89,46 +89,14 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
-        env:
-          INPUT_LANGUAGE: ${{ inputs.language }}
-          INPUT_CONTAINER_TAG: ${{ inputs.container-tag }}
-          INPUT_REGISTRY_PUBLISH: ${{ inputs.registry-publish }}
-        run: |
-          if [ "$INPUT_LANGUAGE" != "base" ] && \
-             [ "$INPUT_CONTAINER_TAG" = "latest" ]; then
-            echo "::error::language '${INPUT_LANGUAGE}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
-            exit 1
-          fi
-          if [ "$INPUT_REGISTRY_PUBLISH" = "true" ] && \
-             [ "$INPUT_LANGUAGE" = "base" ]; then
-            echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
-            exit 1
-          fi
+        uses: ./actions/publish/validate-inputs
+        with:
+          language: ${{ inputs.language }}
+          container-tag: ${{ inputs.container-tag }}
+          registry-publish: ${{ inputs.registry-publish }}
 
       - name: Install standard-tooling
         uses: wphillipmoore/standard-actions/actions/setup/standard-tooling@develop
-
-      - name: Configure Maven credentials
-        if: inputs.registry-publish && inputs.language == 'java'
-        shell: bash
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'XML'
-          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
-            <servers>
-              <server>
-                <id>central</id>
-                <username>${env.MAVEN_USERNAME}</username>
-                <password>${env.MAVEN_PASSWORD}</password>
-              </server>
-            </servers>
-          </settings>
-          XML
-          if [ -n "$GPG_PRIVATE_KEY" ]; then
-            echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-          fi
 
       - name: Extract version
         id: version
@@ -146,123 +114,36 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Derive ecosystem commands
+      - name: Resolve release artifacts
         if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false'
-        id: commands
-        env:
-          LANG: ${{ inputs.language }}
-        run: |
-          build="${{ inputs.build-command }}"
-          if [ -z "$build" ]; then
-            case "$LANG" in
-              python) build="uv build" ;;
-              rust) build="cargo build --release" ;;
-              ruby) build="gem build *.gemspec" ;;
-              java) build="./mvnw -B package -DskipTests" ;;
-              *) build="" ;;
-            esac
-          fi
-          echo "build=$build" >> "$GITHUB_OUTPUT"
-
-          publish="${{ inputs.registry-publish-command }}"
-          if [ -z "$publish" ]; then
-            case "$LANG" in
-              rust) publish="cargo publish" ;;
-              ruby) publish="gem push *.gem" ;;
-              java) publish="./mvnw -B deploy -DskipTests" ;;
-              *) publish="" ;;
-            esac
-          fi
-          echo "publish=$publish" >> "$GITHUB_OUTPUT"
-
-          case "$LANG" in
-            rust) echo "credential-secret=CARGO_REGISTRY_TOKEN" >> "$GITHUB_OUTPUT" ;;
-            ruby) echo "credential-secret=RUBYGEMS_API_KEY" >> "$GITHUB_OUTPUT" ;;
-            java) echo "credential-secret=CENTRAL_TOKEN" >> "$GITHUB_OUTPUT" ;;
-            *) echo "credential-secret=" >> "$GITHUB_OUTPUT" ;;
-          esac
-
-      - name: Prepare version-dependent inputs
-        if: >-
-          inputs.registry-publish &&
           steps.tag_check.outputs.exists == 'false'
         id: resolved
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          SBOM_OUTPUT_FILE: ${{ inputs.sbom-output-file }}
           RELEASE_ARTIFACTS: ${{ inputs.release-artifacts }}
         run: |
-          echo "sbom-output-file=${SBOM_OUTPUT_FILE//\$VERSION/$VERSION}" \
-            >> "$GITHUB_OUTPUT"
           echo "release-artifacts=${RELEASE_ARTIFACTS//\$VERSION/$VERSION}" \
             >> "$GITHUB_OUTPUT"
 
-      - name: Ensure dist directory
+      - name: Build and publish
         if: >-
-          inputs.registry-publish &&
+          contains(fromJSON('["python","java","ruby","rust","go"]'), inputs.language) &&
           steps.tag_check.outputs.exists == 'false'
-        run: mkdir -p dist
-
-      - name: Build
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          steps.commands.outputs.build != ''
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: ${{ steps.commands.outputs.build }}
-
-      - name: Attest build provenance
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.attestation-subject-path != ''
-        uses: actions/attest-build-provenance@v4
+        uses: ./actions/publish/registry-publish
         with:
-          subject-path: ${{ inputs.attestation-subject-path }}
-
-      - name: Generate SBOM
-        if: >-
-          inputs.registry-publish &&
-          steps.tag_check.outputs.exists == 'false' &&
-          inputs.sbom-output-file != ''
-        uses: wphillipmoore/standard-actions/actions/security/trivy@develop
-        with:
-          scan-type: sbom
-          output-file: ${{ steps.resolved.outputs.sbom-output-file }}
-
-      - name: Publish to PyPI
-        if: >-
-          inputs.registry-publish &&
-          inputs.language == 'python' &&
-          steps.tag_check.outputs.exists == 'false'
-        run: uv publish dist/*
-
-      - name: Publish to registry
-        if: >-
-          inputs.registry-publish &&
-          inputs.language != 'python' &&
-          steps.commands.outputs.publish != '' &&
-          steps.tag_check.outputs.exists == 'false'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          guard="${{ steps.commands.outputs.credential-secret }}"
-          if [ -n "$guard" ]; then
-            val=$(printenv "$guard" 2>/dev/null || true)
-            if [ -z "$val" ]; then
-              echo "::notice::${guard} not configured — skipping publish"
-              exit 0
-            fi
-          fi
-          ${{ steps.commands.outputs.publish }}
+          language: ${{ inputs.language }}
+          version: ${{ steps.version.outputs.version }}
+          registry-publish: ${{ inputs.registry-publish }}
+          build-command: ${{ inputs.build-command }}
+          publish-command: ${{ inputs.registry-publish-command }}
+          attestation-subject-path: ${{ inputs.attestation-subject-path }}
+          sbom-output-file: ${{ inputs.sbom-output-file }}
+          cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          rubygems-api-key: ${{ secrets.RUBYGEMS_API_KEY }}
+          central-username: ${{ secrets.CENTRAL_USERNAME }}
+          central-token: ${{ secrets.CENTRAL_TOKEN }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,53 +59,11 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Rewrite internal action refs so the tagged snapshot is
-      # self-consistent. Two passes:
-      #   1. ./actions/X  → wphillipmoore/standard-actions/actions/X@<tag>
-      #   2. ...@develop  → ...@<tag>
-      # The commit is reachable only via the tag — never pushed to
-      # develop or main.
       - name: Freeze internal refs to release tag
         if: steps.tag_check.outputs.exists == 'false'
-        env:
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          mapfile -t files < <(find .github/workflows actions \
-            -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
-          for f in "${files[@]}"; do
-            sed -i.bak -E "s|\./actions/([^[:space:]]+)|wphillipmoore/standard-actions/actions/\1@${RELEASE_TAG}|g" "$f"
-            sed -i.bak -E "s|(wphillipmoore/standard-actions/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g" "$f"
-            rm -f "$f.bak"
-          done
-          if ! git diff --quiet; then
-            git add .github/workflows actions
-            git commit -m "chore(release): freeze internal refs to ${RELEASE_TAG}"
-          fi
-
-      - name: Validate no unfrozen internal refs
-        if: steps.tag_check.outputs.exists == 'false'
-        run: |
-          set -euo pipefail
-          mapfile -t files < <(find .github/workflows actions \
-            -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
-          failed=0
-          for f in "${files[@]}"; do
-            if grep -nE 'uses:\s+\./actions/' "$f"; then
-              echo "::error file=${f}::Unfrozen relative action ref (./actions/)"
-              failed=1
-            fi
-            if grep -nE 'wphillipmoore/standard-actions/[^@[:space:]]+@develop' "$f"; then
-              echo "::error file=${f}::Unfrozen @develop action ref"
-              failed=1
-            fi
-          done
-          if [ "${failed}" -ne 0 ]; then
-            echo "::error::Internal refs were not fully frozen — aborting"
-            exit 1
-          fi
+        uses: ./actions/publish/freeze-internal-refs
+        with:
+          tag: ${{ steps.version.outputs.tag }}
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'

--- a/actions/docs-deploy/action.yml
+++ b/actions/docs-deploy/action.yml
@@ -15,11 +15,11 @@ inputs:
     default: docs/site/mkdocs.yml
   mike-command:
     description: >-
-      Command to run mike. Set to "uv run mike" for Python repos that
-      manage their own dependencies via their project's virtual
-      environment.
+      Command to run mike. Auto-detected from standard-tooling.toml when
+      omitted: "uv run mike" for Python repos, "mike" otherwise. Set
+      explicitly to override.
     required: false
-    default: mike
+    default: ""
 runs:
   using: composite
   steps:
@@ -41,6 +41,28 @@ runs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git config --global --add safe.directory '*'
+
+    - name: Resolve mike command
+      id: mike-cmd
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        INPUT_MIKE_COMMAND: ${{ steps.mike-cmd.outputs.cmd }}
+      run: |
+        if [ -n "$INPUT_MIKE_COMMAND" ]; then
+          echo "cmd=$INPUT_MIKE_COMMAND" >> "$GITHUB_OUTPUT"
+        else
+          lang=$(/usr/local/bin/python3 -c "
+          import tomllib, pathlib
+          cfg = tomllib.loads(pathlib.Path('standard-tooling.toml').read_text())
+          print(cfg['project']['primary-language'])
+          ")
+          if [ "$lang" = "python" ]; then
+            echo "cmd=uv run mike" >> "$GITHUB_OUTPUT"
+          else
+            echo "cmd=mike" >> "$GITHUB_OUTPUT"
+          fi
+        fi
 
     - name: Determine version
       id: version
@@ -172,19 +194,19 @@ runs:
       working-directory: ${{ github.workspace }}
       run: |
         if [ -n "${{ steps.version.outputs.alias }}" ]; then
-          ${{ inputs.mike-command }} deploy \
+          ${{ steps.mike-cmd.outputs.cmd }} deploy \
             -F ${{ inputs.mkdocs-config }} --push --update-aliases \
             ${{ steps.version.outputs.version }} \
             ${{ steps.version.outputs.alias }}
-          ${{ inputs.mike-command }} set-default \
+          ${{ steps.mike-cmd.outputs.cmd }} set-default \
             -F ${{ inputs.mkdocs-config }} --push latest
         else
-          ${{ inputs.mike-command }} deploy -F ${{ inputs.mkdocs-config }} --push ${{ steps.version.outputs.version }}
+          ${{ steps.mike-cmd.outputs.cmd }} deploy -F ${{ inputs.mkdocs-config }} --push ${{ steps.version.outputs.version }}
           # Set dev as default if no default exists yet (pre-release repos)
-          CURRENT_DEFAULT=$(${{ inputs.mike-command }} list \
+          CURRENT_DEFAULT=$(${{ steps.mike-cmd.outputs.cmd }} list \
             -F ${{ inputs.mkdocs-config }} 2>/dev/null \
             | grep '\[default\]' || true)
           if [ -z "$CURRENT_DEFAULT" ]; then
-            ${{ inputs.mike-command }} set-default -F ${{ inputs.mkdocs-config }} --push dev
+            ${{ steps.mike-cmd.outputs.cmd }} set-default -F ${{ inputs.mkdocs-config }} --push dev
           fi
         fi

--- a/actions/publish/freeze-internal-refs/action.yml
+++ b/actions/publish/freeze-internal-refs/action.yml
@@ -1,0 +1,72 @@
+name: Freeze internal refs
+description: >-
+  Rewrites relative action refs (./actions/X) and @develop refs to
+  absolute tagged refs across all workflow and action YAML files, then
+  validates no unfrozen refs remain. Commits the result.
+
+inputs:
+  tag:
+    description: Release tag to freeze to (e.g. v1.5.20).
+    required: true
+  owner-repo:
+    description: Owner/repo string for absolute refs.
+    required: false
+    default: ${{ github.repository }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git identity
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Freeze refs
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
+        OWNER_REPO: ${{ inputs.owner-repo }}
+      run: |
+        set -euo pipefail
+        mapfile -t files < <(find .github/workflows actions \
+          -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+        for f in "${files[@]}"; do
+          sed -i.bak -E "/uses:/s|\./actions/([^[:space:]]+)|${OWNER_REPO}/actions/\1@${RELEASE_TAG}|g" "$f"
+          sed -i.bak -E "/uses:/s|(${OWNER_REPO}/[^@[:space:]]+)@develop|\1@${RELEASE_TAG}|g" "$f"
+          rm -f "$f.bak"
+        done
+
+    - name: Validate no unfrozen refs
+      shell: bash
+      env:
+        OWNER_REPO: ${{ inputs.owner-repo }}
+      run: |
+        set -euo pipefail
+        mapfile -t files < <(find .github/workflows actions \
+          -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)
+        failed=0
+        for f in "${files[@]}"; do
+          if grep -nE 'uses:\s+\./actions/' "$f"; then
+            echo "::error file=${f}::Unfrozen relative action ref (./actions/)"
+            failed=1
+          fi
+          if grep -nE "${OWNER_REPO}/[^@[:space:]]+@develop" "$f"; then
+            echo "::error file=${f}::Unfrozen @develop action ref"
+            failed=1
+          fi
+        done
+        if [ "${failed}" -ne 0 ]; then
+          echo "::error::Internal refs were not fully frozen — aborting"
+          exit 1
+        fi
+
+    - name: Commit frozen refs
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
+      run: |
+        if ! git diff --quiet; then
+          git add .github/workflows actions
+          git commit -m "chore(release): freeze internal refs to ${RELEASE_TAG}"
+        fi

--- a/actions/publish/registry-publish/action.yml
+++ b/actions/publish/registry-publish/action.yml
@@ -1,0 +1,197 @@
+name: Registry publish
+description: >-
+  Full build-and-publish pipeline for any supported language ecosystem.
+  Handles command derivation, credential provisioning, build,
+  attestation, SBOM generation, and publish execution.
+
+inputs:
+  language:
+    description: Primary language (python, rust, ruby, java, go).
+    required: true
+  version:
+    description: Semver version string (e.g. 1.2.3).
+    required: true
+  registry-publish:
+    description: Whether to execute the final registry publish step.
+    required: false
+    default: "false"
+  build-command:
+    description: Override ecosystem-derived build command.
+    required: false
+    default: ""
+  publish-command:
+    description: Override ecosystem-derived publish command.
+    required: false
+    default: ""
+  attestation-subject-path:
+    description: Glob for build provenance attestation. Leave empty to skip.
+    required: false
+    default: ""
+  sbom-output-file:
+    description: SBOM output path ($VERSION placeholder). Leave empty to skip.
+    required: false
+    default: ""
+  cargo-registry-token:
+    description: "Rust: crates.io token."
+    required: false
+    default: ""
+  rubygems-api-key:
+    description: "Ruby: RubyGems API key."
+    required: false
+    default: ""
+  central-username:
+    description: "Java: Maven Central username."
+    required: false
+    default: ""
+  central-token:
+    description: "Java: Maven Central token."
+    required: false
+    default: ""
+  gpg-private-key:
+    description: "Java: GPG signing key."
+    required: false
+    default: ""
+  gpg-passphrase:
+    description: "Java: GPG passphrase."
+    required: false
+    default: ""
+
+outputs:
+  build-command:
+    description: Resolved build command (derived or overridden).
+    value: ${{ steps.commands.outputs.build }}
+  publish-command:
+    description: Resolved publish command (derived or overridden).
+    value: ${{ steps.commands.outputs.publish }}
+  sbom-output-file:
+    description: Resolved SBOM path (empty if skipped).
+    value: ${{ steps.resolve.outputs.sbom-output-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Derive ecosystem commands
+      id: commands
+      shell: bash
+      env:
+        INPUT_LANGUAGE: ${{ inputs.language }}
+        INPUT_BUILD_COMMAND: ${{ inputs.build-command }}
+        INPUT_PUBLISH_COMMAND: ${{ inputs.publish-command }}
+      run: |
+        build="$INPUT_BUILD_COMMAND"
+        if [ -z "$build" ]; then
+          case "$INPUT_LANGUAGE" in
+            python) build="uv build" ;;
+            rust)   build="cargo build --release" ;;
+            ruby)   build="gem build *.gemspec" ;;
+            java)   build="./mvnw -B package -DskipTests" ;;
+            go)     build="go build ./..." ;;
+            *)
+              echo "::error::unrecognized language '${INPUT_LANGUAGE}' — cannot derive build command"
+              exit 1
+              ;;
+          esac
+        fi
+        echo "build=$build" >> "$GITHUB_OUTPUT"
+
+        publish="$INPUT_PUBLISH_COMMAND"
+        if [ -z "$publish" ]; then
+          case "$INPUT_LANGUAGE" in
+            python) publish="uv publish dist/*" ;;
+            rust)   publish="cargo publish" ;;
+            ruby)   publish="gem push *.gem" ;;
+            java)   publish="./mvnw -B deploy -DskipTests" ;;
+            go)     publish="" ;;
+            *)
+              echo "::error::unrecognized language '${INPUT_LANGUAGE}' — cannot derive publish command"
+              exit 1
+              ;;
+          esac
+        fi
+        echo "publish=$publish" >> "$GITHUB_OUTPUT"
+
+        case "$INPUT_LANGUAGE" in
+          rust) echo "credential-secret=CARGO_REGISTRY_TOKEN" >> "$GITHUB_OUTPUT" ;;
+          ruby) echo "credential-secret=RUBYGEMS_API_KEY" >> "$GITHUB_OUTPUT" ;;
+          java) echo "credential-secret=CENTRAL_TOKEN" >> "$GITHUB_OUTPUT" ;;
+          *)    echo "credential-secret=" >> "$GITHUB_OUTPUT" ;;
+        esac
+
+    - name: Configure Maven credentials
+      if: inputs.language == 'java'
+      shell: bash
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml << 'XML'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+          <servers>
+            <server>
+              <id>central</id>
+              <username>${env.MAVEN_USERNAME}</username>
+              <password>${env.MAVEN_PASSWORD}</password>
+            </server>
+          </servers>
+        </settings>
+        XML
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        fi
+
+    - name: Resolve version placeholders
+      id: resolve
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        SBOM_OUTPUT_FILE: ${{ inputs.sbom-output-file }}
+      run: |
+        echo "sbom-output-file=${SBOM_OUTPUT_FILE//\$VERSION/$VERSION}" \
+          >> "$GITHUB_OUTPUT"
+
+    - name: Ensure dist directory
+      shell: bash
+      run: mkdir -p dist
+
+    - name: Build
+      if: steps.commands.outputs.build != ''
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        BUILD_CMD: ${{ steps.commands.outputs.build }}
+      run: eval "$BUILD_CMD"
+
+    - name: Attest build provenance
+      if: inputs.attestation-subject-path != ''
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-path: ${{ inputs.attestation-subject-path }}
+
+    - name: Generate SBOM
+      if: inputs.sbom-output-file != ''
+      uses: wphillipmoore/standard-actions/actions/security/trivy@develop
+      with:
+        scan-type: sbom
+        output-file: ${{ steps.resolve.outputs.sbom-output-file }}
+
+    - name: Publish
+      if: inputs.registry-publish == 'true' && steps.commands.outputs.publish != ''
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        PUBLISH_CMD: ${{ steps.commands.outputs.publish }}
+        CREDENTIAL_SECRET: ${{ steps.commands.outputs.credential-secret }}
+        CARGO_REGISTRY_TOKEN: ${{ inputs.cargo-registry-token }}
+        GEM_HOST_API_KEY: ${{ inputs.rubygems-api-key }}
+        MAVEN_USERNAME: ${{ inputs.central-username }}
+        MAVEN_PASSWORD: ${{ inputs.central-token }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
+      run: |
+        if [ -n "$CREDENTIAL_SECRET" ]; then
+          val=$(printenv "$CREDENTIAL_SECRET" 2>/dev/null || true)
+          if [ -z "$val" ]; then
+            echo "::notice::${CREDENTIAL_SECRET} not configured — skipping publish"
+            exit 0
+          fi
+        fi
+        eval "$PUBLISH_CMD"

--- a/actions/publish/validate-inputs/action.yml
+++ b/actions/publish/validate-inputs/action.yml
@@ -1,0 +1,53 @@
+name: Validate publish inputs
+description: >-
+  Pre-flight validation for cd-release inputs. Fails early on invalid
+  input combinations.
+
+inputs:
+  language:
+    description: Primary language string.
+    required: true
+  container-tag:
+    description: Dev container image tag.
+    required: true
+  registry-publish:
+    description: Whether publishing is enabled.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        INPUT_LANGUAGE: ${{ inputs.language }}
+        INPUT_CONTAINER_TAG: ${{ inputs.container-tag }}
+        INPUT_REGISTRY_PUBLISH: ${{ inputs.registry-publish }}
+      run: |
+        supported_languages="python java ruby rust go"
+
+        if [ "$INPUT_LANGUAGE" != "base" ] && \
+           [ "$INPUT_CONTAINER_TAG" = "latest" ]; then
+          echo "::error::language '${INPUT_LANGUAGE}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
+          exit 1
+        fi
+
+        if [ "$INPUT_REGISTRY_PUBLISH" = "true" ] && \
+           [ "$INPUT_LANGUAGE" = "base" ]; then
+          echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
+          exit 1
+        fi
+
+        if [ "$INPUT_REGISTRY_PUBLISH" = "true" ]; then
+          found=0
+          for lang in $supported_languages; do
+            if [ "$INPUT_LANGUAGE" = "$lang" ]; then
+              found=1
+              break
+            fi
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::unsupported language '${INPUT_LANGUAGE}' for registry publishing (supported: ${supported_languages})"
+            exit 1
+          fi
+        fi


### PR DESCRIPTION
# Pull Request

## Summary

- Extract all inline logic from reusable workflows into composite actions

## Issue Linkage

- Ref #436

## Notes

- ## Changes

Three new composite actions and one modification to an existing action:

### New actions

- **`actions/publish/validate-inputs`** — Pre-flight validation for cd-release
  inputs. Fails early on invalid input combinations including a new check
  for unsupported languages with registry-publish enabled.

- **`actions/publish/registry-publish`** — Full build-and-publish pipeline for
  any supported language ecosystem. Handles command derivation, credential
  provisioning, build, attestation, SBOM generation, and publish execution.
  Fixes: `LANG` env var collision with locale, `${{ }}` interpolation in bash
  replaced with `env:` for security.

- **`actions/publish/freeze-internal-refs`** — Rewrites relative action refs
  and `@develop` refs to absolute tagged refs, validates no unfrozen refs
  remain, and commits the result. Improvement: sed replacements now scoped to
  `uses:` lines only.

### Modified action

- **`actions/docs-deploy`** — Auto-detects mike command from
  `standard-tooling.toml` when `mike-command` input is omitted. Python repos
  get `uv run mike`, others get `mike`.

### Workflow simplifications

- **`cd-release.yml`** — ~90 lines of inline logic replaced with two `uses:` calls
- **`cd.yml`** — ~40 lines of ref-freezing bash replaced with one `uses:` call
- **`cd-docs.yml`** — ~14 lines of language detection removed; docs-deploy handles it

### Behavioral changes

- Build/attest/SBOM now runs for all supported languages (not just when
  `registry-publish` is true). The `registry-publish` flag still gates the
  final publish step only.
- Go language support added to ecosystem command derivation.
- Explicit validation error for unsupported languages with registry-publish.

## Test plan

- [ ] `st-docker-run -- st-validate` passes (actionlint, yamllint, shellcheck, markdownlint)
- [ ] No workflow file contains a bash `case` statement
- [ ] No workflow file contains inline credential provisioning
- [ ] `cd-release.yml` contains only trivial glue bash (version extraction, tag check, artifact resolution)
- [ ] `cd.yml` contains only trivial glue bash (version extraction, tag check)
- [ ] `cd-docs.yml` contains no multi-line bash blocks