### PR TITLE
docs(release): fix broken cross-references in actions/index.md

### DIFF
--- a/docs/site/docs/actions/index.md
+++ b/docs/site/docs/actions/index.md
@@ -1,43 +1,32 @@
 # Action Reference
 
-All actions are composite GitHub Actions located under the `actions/` directory.
-Each action is self-contained with an `action.yml` definition and optional
-supporting scripts.
+All actions are composite GitHub Actions located under the `actions/` directory,
+organized by pipeline phase. Each action is self-contained with an `action.yml`
+definition and optional supporting scripts.
 
 ## Available actions
 
-### CI & Validation
+### CI
 
-- **[standards-compliance](standards-compliance.md)** — PR-specific compliance
-  checks: issue linkage and auto-close keyword rejection.
-
-### Documentation
-
-- **[docs-deploy](docs-deploy.md)** — Deploys MkDocs documentation using mike
-  for versioned documentation.
-
-### Python
-
-- **[python/setup](python-setup.md)** — Sets up Python, installs uv, and
-  configures dependency caching.
-
-### Security
-
-- **[security/codeql](security-codeql.md)** — Runs GitHub CodeQL static
+- **[ci/security/standards-compliance](ci-security-standards-compliance.md)** —
+  PR-specific compliance checks: issue linkage and auto-close keyword rejection.
+- **[ci/security/codeql](ci-security-codeql.md)** — Runs GitHub CodeQL static
   analysis for a single language.
-- **[security/semgrep](security-semgrep.md)** — Runs Semgrep SAST scanning with
-  language-specific and cross-cutting security rulesets.
-- **[security/trivy](security-trivy.md)** — Runs Trivy vulnerability scanning,
-  SBOM generation, or container image scanning.
+- **[ci/security/semgrep](ci-security-semgrep.md)** — Runs Semgrep SAST scanning
+  with language-specific and cross-cutting security rulesets.
+- **[ci/version-bump/version-divergence](ci-version-bump-version-divergence.md)**
+  — Verifies that the PR branch version differs from the main branch version.
 
-### Publishing
+### CD
 
-- **[publish/tag-and-release](publish-tag-and-release.md)** — Creates annotated
-  git tags and GitHub Releases.
-- **[publish/version-bump-pr](publish-version-bump-pr.md)** — Automates
+- **[cd/release/tag-and-release](cd-release-tag-and-release.md)** — Creates
+  annotated git tags and GitHub Releases.
+- **[cd/release/version-bump-pr](cd-release-version-bump-pr.md)** — Automates
   post-release version bump PRs.
+- **[cd/docs/deploy](cd-docs-deploy.md)** — Deploys MkDocs documentation using
+  mike for versioned documentation.
 
-### Release Gates
+### Shared
 
-- **[release-gates/version-divergence](release-gates-version-divergence.md)** —
-  Verifies that the PR branch version differs from the main branch version.
+- **[shared/security/trivy](shared-security-trivy.md)** — Runs Trivy
+  vulnerability scanning, SBOM generation, or container image scanning.


### PR DESCRIPTION
# Pull Request

## Summary

- Update actions/index.md to use the new namespaced doc filenames from #440. Removes the defunct python/setup entry and reorganizes sections to match the CI/CD/Shared pipeline phase structure.

## Issue Linkage

- Ref #458

## Notes

- -