### PR TITLE
fix(cd): migrate from app-id to client-id for GitHub App token

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -48,7 +48,7 @@ on:
         type: string
         default: ""
     secrets:
-      APP_ID:
+      APP_CLIENT_ID:
         required: true
       APP_PRIVATE_KEY:
         required: true
@@ -173,7 +173,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Version bump PR

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
       # The App (APP_CLIENT_ID/APP_PRIVATE_KEY) has workflows:write granted.
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,12 +26,12 @@ jobs:
       # Generate the App token first so checkout can use it. The freeze-
       # internal-refs step below modifies .github/workflows/*.yml, and
       # GITHUB_TOKEN is forbidden from pushing workflow-file changes.
-      # The App (APP_ID/APP_PRIVATE_KEY) has workflows:write granted.
+      # The App (APP_CLIENT_ID/APP_PRIVATE_KEY) has workflows:write granted.
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Switches `create-github-app-token@v3` from the deprecated `app-id` parameter to `client-id` in both `cd.yml` and `cd-release.yml`
- Renames the reusable workflow secret from `APP_ID` to `APP_CLIENT_ID`
- `APP_CLIENT_ID` secret has been set on all 4 repos (vergil-actions, vergil-tooling, vergil-docker, vergil-claude-plugin)

## Context

The JWT decode failure (#466) may be caused by a regression in the `app-id` code path. Migrating to `client-id` eliminates the deprecation warning and tests the new code path before further debugging.

Callers of `cd-release.yml` in other repos will need to update their secret passthrough from `APP_ID` to `APP_CLIENT_ID`.

Ref #466
Ref #467