### PR TITLE
docs: update site documentation to post-migration names

### DIFF
--- a/docs/site/docs/actions/cd-docs-deploy.md
+++ b/docs/site/docs/actions/cd-docs-deploy.md
@@ -6,7 +6,7 @@ git configuration, version detection, and mike deploy/set-default.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v2.0
   with:
     version-command: cat VERSION | cut -d. -f1,2
     mkdocs-config: docs/site/mkdocs.yml
@@ -51,7 +51,7 @@ rather than calling the composite action directly:
 ```yaml
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     permissions:
       contents: write
 ```
@@ -61,7 +61,7 @@ jobs:
 ### Direct usage (standalone)
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v2.0
   with:
     version-command: cat VERSION | cut -d. -f1,2
 ```
@@ -69,7 +69,7 @@ jobs:
 ### Python repo with uv-managed dependencies
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v2.0
   with:
     version-command: cat VERSION | cut -d. -f1,2
     mike-command: uv run mike

--- a/docs/site/docs/actions/cd-release-tag-and-release.md
+++ b/docs/site/docs/actions/cd-release-tag-and-release.md
@@ -7,7 +7,7 @@ action safe to re-run.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v2.0
   with:
     version: "1.2.3"
     release-title: mqrestadmin
@@ -62,7 +62,7 @@ action safe to re-run.
 ### Standard library release
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v2.0
   with:
     version: ${{ steps.version.outputs.version }}
     release-title: mqrestadmin
@@ -72,7 +72,7 @@ action safe to re-run.
 ### Release with build artifacts
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@v2.0
   with:
     version: "2.0.0"
     release-title: myapp

--- a/docs/site/docs/actions/cd-release-version-bump-pr.md
+++ b/docs/site/docs/actions/cd-release-version-bump-pr.md
@@ -11,7 +11,7 @@ via `st-merge-when-green` from a release skill).
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: "1.2.3"
     version-file: VERSION
@@ -81,7 +81,7 @@ via `st-merge-when-green` from a release skill).
 ### Simple VERSION file bump
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: ${{ steps.release.outputs.version }}
     version-file: VERSION
@@ -94,7 +94,7 @@ via `st-merge-when-green` from a release skill).
 ### Python project with lock file refresh
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v1.5
+- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: "1.0.0"
     version-file: pyproject.toml

--- a/docs/site/docs/actions/ci-security-codeql.md
+++ b/docs/site/docs/actions/ci-security-codeql.md
@@ -6,7 +6,7 @@ language.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v2.0
   with:
     language: python
     queries: "+security-extended"
@@ -48,7 +48,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: vergil-project/vergil-actions/actions/ci/security/codeql@v1.5
+      - uses: vergil-project/vergil-actions/actions/ci/security/codeql@v2.0
         with:
           language: python
 ```
@@ -56,7 +56,7 @@ jobs:
 ### Go CodeQL analysis
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v2.0
   with:
     language: go
 ```

--- a/docs/site/docs/actions/ci-security-semgrep.md
+++ b/docs/site/docs/actions/ci-security-semgrep.md
@@ -6,7 +6,7 @@ rulesets.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v2.0
   with:
     language: python
     extra-config: "p/owasp-top-ten"
@@ -62,7 +62,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v1.5
+      - uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v2.0
         with:
           language: python
 ```
@@ -70,7 +70,7 @@ jobs:
 ### Go with additional OWASP rules
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v2.0
   with:
     language: golang
     extra-config: "p/owasp-top-ten"

--- a/docs/site/docs/actions/ci-security-standards-compliance.md
+++ b/docs/site/docs/actions/ci-security-standards-compliance.md
@@ -7,7 +7,7 @@ Repository profile, markdown, and other structural validations are handled by
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v2.0
 ```
 
 ## Inputs
@@ -37,7 +37,7 @@ Both steps only run on `pull_request` events.
 - uses: actions/checkout@v6
   with:
     fetch-depth: 0
-- uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v2.0
 ```
 
 ## GitHub configuration

--- a/docs/site/docs/actions/ci-version-bump-version-divergence.md
+++ b/docs/site/docs/actions/ci-version-bump-version-divergence.md
@@ -6,7 +6,7 @@ the step if the two versions are identical.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v2.0
   with:
     head-version-command: cat VERSION
     main-version-command: git show origin/main:VERSION
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v1.5
+      - uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v2.0
         with:
           head-version-command: cat VERSION
           main-version-command: git show origin/main:VERSION
@@ -58,7 +58,7 @@ jobs:
 ### Python project version check
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v2.0
   with:
     head-version-command: >-
       grep -oP 'version\s*=\s*"\K[^"]+' pyproject.toml

--- a/docs/site/docs/actions/shared-security-trivy.md
+++ b/docs/site/docs/actions/shared-security-trivy.md
@@ -5,7 +5,7 @@ Runs Trivy vulnerability scanning, SBOM generation, or container image scanning.
 ## Usage
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: fs
     scan-ref: "."
@@ -78,7 +78,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+      - uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
         with:
           scan-type: fs
 ```
@@ -86,7 +86,7 @@ jobs:
 ### Container image scan
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: image
     scan-ref: "myapp:latest"
@@ -95,7 +95,7 @@ jobs:
 ### SBOM generation (advisory only)
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: sbom
     output-file: sbom.cdx.json
@@ -104,7 +104,7 @@ jobs:
 ### Custom SARIF category for matrix builds
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: fs
     sarif-category: "trivy-fs-${{ matrix.target }}"

--- a/docs/site/docs/ci-gates/index.md
+++ b/docs/site/docs/ci-gates/index.md
@@ -20,7 +20,7 @@ organized by category using job name prefixes:
 
 ## Key concepts
 
-- **Reusable workflows** — v1.5.0 introduced
+- **Reusable workflows** — v2.0.0 introduced
   [reusable CI workflows](../workflows/index.md) that produce the canonical
   check names automatically. Consuming repositories call these workflows
   rather than assembling jobs by hand.

--- a/docs/site/docs/ci-gates/repository-rulesets.md
+++ b/docs/site/docs/ci-gates/repository-rulesets.md
@@ -143,13 +143,13 @@ Rulesets can be updated programmatically using the GitHub API:
 
 ```bash
 # List rulesets for a repository
-gh api repos/wphillipmoore/{repo}/rulesets \
+gh api repos/vergil-project/{repo}/rulesets \
   --jq '.[] | {id: .id, name: .name}'
 
 # View a specific ruleset
-gh api repos/wphillipmoore/{repo}/rulesets/{id}
+gh api repos/vergil-project/{repo}/rulesets/{id}
 
 # Update required status checks
-gh api --method PUT repos/wphillipmoore/{repo}/rulesets/{id} \
+gh api --method PUT repos/vergil-project/{repo}/rulesets/{id} \
   --input payload.json
 ```

--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -80,7 +80,7 @@ skip standards and security while PR CI (tier 3) runs the full suite:
 
 ```yaml
 security-and-standards:
-  uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+  uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
   with:
     language: <lang>
     run-standards: ${{ inputs.run-release-gates || 'true' }}

--- a/docs/site/docs/ci-gates/security-scanning.md
+++ b/docs/site/docs/ci-gates/security-scanning.md
@@ -56,7 +56,7 @@ control flow, and language-specific patterns.
   project.
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/codeql@v2.0
   with:
     language: python
 ```
@@ -75,7 +75,7 @@ Default rulesets enabled for every scan:
 Additional rulesets can be added via `extra-config`:
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v1.5
+- uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v2.0
   with:
     language: golang
     extra-config: "p/owasp-top-ten"
@@ -99,7 +99,7 @@ By default, only `CRITICAL` and `HIGH` severity vulnerabilities are reported.
 This can be adjusted:
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: fs
     severity: "CRITICAL,HIGH,MEDIUM"
@@ -111,7 +111,7 @@ By default, Trivy exits with code `1` when vulnerabilities are found, failing
 the CI check. Set `exit-code: "0"` for advisory-only mode:
 
 ```yaml
-- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v1.5
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
   with:
     scan-type: fs
     exit-code: "0"

--- a/docs/site/docs/configuration.md
+++ b/docs/site/docs/configuration.md
@@ -13,7 +13,7 @@ are configured in **Settings > Secrets and variables > Actions**.
 | Secret | Required by | Purpose |
 | ------ | ----------- | ------- |
 | `PROJECT_TOKEN` | All repositories | Adds new issues to the GitHub Project via the `add-to-project` workflow |
-| `APP_ID` | Library repositories | GitHub App identifier for `publish/version-bump-pr` |
+| `APP_CLIENT_ID` | Library repositories | GitHub App Client ID for `publish/version-bump-pr` |
 | `APP_PRIVATE_KEY` | Library repositories | GitHub App signing key for `publish/version-bump-pr` |
 
 ### PROJECT_TOKEN
@@ -38,7 +38,7 @@ token with the `project` scope.
 6. Set the secret in each repository:
 
 ```bash
-gh secret set PROJECT_TOKEN --repo wphillipmoore/<repo> --body "<token>"
+gh secret set PROJECT_TOKEN --repo vergil-project/<repo> --body "<token>"
 ```
 
 !!! warning "Do not pipe tokens via stdin"
@@ -47,7 +47,7 @@ gh secret set PROJECT_TOKEN --repo wphillipmoore/<repo> --body "<token>"
     can corrupt the secret value during encryption, causing "Bad credentials"
     errors at runtime that are difficult to diagnose.
 
-### APP_ID and APP_PRIVATE_KEY
+### APP_CLIENT_ID and APP_PRIVATE_KEY
 
 These secrets are used together to generate a GitHub App installation token at
 publish time. The token is passed to the
@@ -64,6 +64,7 @@ trigger CI normally and can auto-merge.
 | ---------- | ------ | ------- |
 | Contents | Read & write | Create branches, push commits |
 | Pull requests | Read & write | Create and merge PRs |
+| Workflows | Read & write | Push commits that modify workflow files |
 | Metadata | Read-only | Required by GitHub (always enabled) |
 
 **Creation steps:**
@@ -74,7 +75,7 @@ trigger CI normally and can auto-merge.
 4. Under **Permissions > Repository permissions**, grant the permissions listed
    above.
 5. Disable webhooks (not needed).
-6. Create the app and note the **App ID** from the app's settings page.
+6. Create the app and note the **Client ID** from the app's settings page.
 7. Under **Private keys**, click **Generate a private key**. Save the downloaded
    `.pem` file.
 8. Under **Install App**, install it on your account and grant access to the
@@ -82,8 +83,8 @@ trigger CI normally and can auto-merge.
 9. Set the secrets in each library repository:
 
 ```bash
-gh secret set APP_ID --repo wphillipmoore/<repo> --body "<app-id>"
-gh secret set APP_PRIVATE_KEY --repo wphillipmoore/<repo> --body "$(cat <path-to-private-key>.pem)"
+gh secret set APP_CLIENT_ID --repo vergil-project/<repo> --body "<client-id>"
+gh secret set APP_PRIVATE_KEY --repo vergil-project/<repo> --body "$(cat <path-to-private-key>.pem)"
 ```
 
 **Key rotation:** Generate a new private key from the app's settings page, update
@@ -148,7 +149,7 @@ The `GITHUB_TOKEN` is insufficient in two cases:
 1. **GitHub Project access** — The `GITHUB_TOKEN` cannot interact with
    user-owned Projects v2. The `PROJECT_TOKEN` (classic PAT) is required.
 2. **CI-triggering PRs** — PRs created by `GITHUB_TOKEN` do not trigger
-   workflow runs. The GitHub App token (`APP_ID` + `APP_PRIVATE_KEY`) is
+   workflow runs. The GitHub App token (`APP_CLIENT_ID` + `APP_PRIVATE_KEY`) is
    required for the version bump PR to trigger CI and auto-merge.
 
 ## Auto-merge
@@ -188,12 +189,12 @@ Create three rulesets per the standard configuration:
 ### 3. Secrets
 
 - [ ] Set `PROJECT_TOKEN` (all repositories)
-- [ ] Set `APP_ID` and `APP_PRIVATE_KEY` (library repositories only)
+- [ ] Set `APP_CLIENT_ID` and `APP_PRIVATE_KEY` (library repositories only)
 
 ```bash
-gh secret set PROJECT_TOKEN --repo wphillipmoore/<repo> --body "<token>"
-gh secret set APP_ID --repo wphillipmoore/<repo> --body "<app-id>"
-gh secret set APP_PRIVATE_KEY --repo wphillipmoore/<repo> --body "$(cat <key>.pem)"
+gh secret set PROJECT_TOKEN --repo vergil-project/<repo> --body "<token>"
+gh secret set APP_CLIENT_ID --repo vergil-project/<repo> --body "<client-id>"
+gh secret set APP_PRIVATE_KEY --repo vergil-project/<repo> --body "$(cat <key>.pem)"
 ```
 
 ### 4. GitHub App installation

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -6,12 +6,12 @@ Reference actions from this repository using the full path with a rolling minor
 tag pin:
 
 ```yaml
-uses: vergil-project/vergil-actions/actions/<action-path>@v1.5
+uses: vergil-project/vergil-actions/actions/<action-path>@v2.0
 ```
 
 !!! note "Tag pinning"
-    Pin to a rolling minor tag (e.g., `@v1.5`) to automatically receive patch
-    releases. Pin to an exact tag (e.g., `@v1.5.1`) for full reproducibility.
+    Pin to a rolling minor tag (e.g., `@v2.0`) to automatically receive patch
+    releases. Pin to an exact tag (e.g., `@v2.0.1`) for full reproducibility.
 
 ## Minimal workflow example
 
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v1.5
+      - uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v2.0
 ```
 
 ## Consuming reusable workflows
@@ -40,7 +40,7 @@ Reusable workflows produce canonical check names across all repositories.
 Reference workflows using the full path to the workflow file:
 
 ```yaml
-uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
 ```
 
 ### CI workflow example
@@ -57,13 +57,13 @@ permissions:
 
 jobs:
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     permissions:
       contents: read
       security-events: write
@@ -86,13 +86,13 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
     with:
       language: python
     secrets: inherit
@@ -119,4 +119,4 @@ by the same PR that modifies them — no separate integration testing step is
 needed.
 
 Consuming repositories use the full remote reference
-(`vergil-project/vergil-actions/actions/...@v1.5`).
+(`vergil-project/vergil-actions/actions/...@v2.0`).

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,12 +1,12 @@
-# Standard Actions
+# Vergil Actions
 
 Shared GitHub Actions library providing reusable composite actions for CI/CD
 across all managed repositories.
 
 ## Status
 
-**Stable (v1.x)** — Actions and reusable workflows are consumed by pinning to
-a rolling minor tag (e.g., `@v1.5`), which automatically receives patch
+**Stable (v2.x)** — Actions and reusable workflows are consumed by pinning to
+a rolling minor tag (e.g., `@v2.0`), which automatically receives patch
 releases.
 
 ## Action categories
@@ -58,6 +58,6 @@ repositories. See [Reusable Workflows](workflows/index.md) for details.
 ## Canonical standards
 
 This repository follows the
-[Standards and Conventions](https://github.com/wphillipmoore/standards-and-conventions)
+[vergil-tooling](https://github.com/vergil-project/vergil-tooling)
 repository for commit messages, branching, versioning, and code management
 practices.

--- a/docs/site/docs/workflows/ci-audit.md
+++ b/docs/site/docs/workflows/ci-audit.md
@@ -21,7 +21,7 @@ Dependency audit workflow.
 ```yaml
 jobs:
   audit:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'

--- a/docs/site/docs/workflows/ci-quality.md
+++ b/docs/site/docs/workflows/ci-quality.md
@@ -38,7 +38,7 @@ files exist in the repository:
 ```yaml
 jobs:
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -35,7 +35,7 @@ permissions:
 ```yaml
 jobs:
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     permissions:
       contents: read
       security-events: write
@@ -48,7 +48,7 @@ To skip CodeQL for languages it does not support:
 ```yaml
 jobs:
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     permissions:
       contents: read
       security-events: write

--- a/docs/site/docs/workflows/ci-test.md
+++ b/docs/site/docs/workflows/ci-test.md
@@ -21,7 +21,7 @@ Unit and integration test workflow.
 ```yaml
 jobs:
   test:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'

--- a/docs/site/docs/workflows/ci-version-bump.md
+++ b/docs/site/docs/workflows/ci-version-bump.md
@@ -22,7 +22,7 @@ Version divergence gate workflow.
 ```yaml
 jobs:
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: python
 ```
@@ -32,7 +32,7 @@ To skip version gates (e.g., for infrastructure repos that don't version):
 ```yaml
 jobs:
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
     with:
       language: shell
       run-release: false

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -1,6 +1,6 @@
 # Reusable Workflows
 
-v1.5.0 introduced reusable CI workflows that provide canonical job and check
+v2.0.0 introduced reusable CI workflows that provide canonical job and check
 names across all managed repositories. Each workflow bundles one or more
 composite actions with the container, tooling, and permission setup needed
 to run them. CD workflows handle post-merge delivery (releases, documentation).
@@ -36,12 +36,12 @@ Reference workflows using the full path to the workflow file with a rolling
 minor tag pin:
 
 ```yaml
-uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
 ```
 
 !!! note "Tag pinning"
     The same tag pinning guidance applies as for composite actions. Pin to
-    `@v1.5` for automatic patch releases, or `@v1.5.0` for full
+    `@v2.0` for automatic patch releases, or `@v2.0.0` for full
     reproducibility.
 
 ## Permissions
@@ -52,7 +52,7 @@ declare the permissions each workflow needs at the job level:
 ```yaml
 jobs:
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v1.5
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
     permissions:
       contents: read
       security-events: write
@@ -64,5 +64,5 @@ jobs:
 
 The workflow source files reference composite actions via `@develop` during
 development. At release time, the publish workflow freezes all `@develop`
-references to the release tag (e.g., `@v1.5.0`), ensuring that a pinned
+references to the release tag (e.g., `@v2.0.0`), ensuring that a pinned
 workflow version uses the matching action versions.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: Standard Actions
-site_url: https://wphillipmoore.github.io/standard-actions/
+site_name: Vergil Actions
+site_url: https://vergil-project.github.io/vergil-actions/
 site_description: Shared GitHub Actions library for reusable CI and automation
-repo_url: https://github.com/wphillipmoore/standard-actions
-repo_name: standard-actions
+repo_url: https://github.com/vergil-project/vergil-actions
+repo_name: vergil-actions
 edit_uri: ""
 
 strict: true


### PR DESCRIPTION
# Pull Request

## Summary

- Update all site docs from pre-migration naming (Standard Actions, wphillipmoore org, v1.5 pins) to current naming (Vergil Actions, vergil-project org, v2.0 pins). Also updates APP_ID references to APP_CLIENT_ID and adds Workflows permission to the App permissions table.

## Issue Linkage

- Ref #476

## Notes

- -