### PR TITLE
chore(cd): unpin create-github-app-token back to @v3

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Generate app token for bump PR
         if: steps.tag_check.outputs.exists == 'false'
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -173,7 +173,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
+          app-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Version bump PR

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
       # The App (APP_CLIENT_ID/APP_PRIVATE_KEY) has workflows:write granted.
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
+          app-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
# Pull Request

## Summary

- Reverts create-github-app-token from @v3.2.0 back to @v3 in cd.yml and cd-release.yml, now that dev-base ships a newer actionlint (vergil-docker#198) and the workaround from #469 is no longer needed.

## Issue Linkage

- Ref #470

## Notes

- -