### PR TITLE
chore(deps): remove redundant vergil-tooling key from vergil.toml

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -18,4 +18,3 @@ docs = true
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"


### PR DESCRIPTION
# Pull Request

## Summary

- Removes the now-redundant vergil-tooling key from [dependencies] in vergil.toml, since vergil-tooling#755 consolidated the section to only require the vergil key.

## Issue Linkage

- Ref #485

## Notes

- -