### PR TITLE
feat(permissions): deploy permission model configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)"
+    ]
+  },
   "extraKnownMarketplaces": {
     "vergil-marketplace": {
       "source": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,17 @@ to a tag or branch reference.
 <https://github.com/wphillipmoore/standards-and-conventions>
 (local path: `../standards-and-conventions` if available)
 
+## Shell command policy
+
+Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
+instead of `gh` for all GitHub CLI operations. These wrappers enforce
+subcommand allowlists, flag deny lists, credential selection, and
+audit logging.
+
+Raw `git` and `gh` are denied by the permission model. If a command
+is not available through the wrappers, explain the situation to the
+human who can run it directly via `! <command>` in the prompt.
+
 ## Development Commands
 
 ### Environment Setup


### PR DESCRIPTION
# Pull Request

## Summary

- Deploy permission model configuration to vergil-actions

## Issue Linkage

- Ref #489

## Notes

- Deploy the VERGIL org permission model to vergil-actions.

- Add `Bash(vrg-*)` project-level allowlist to `.claude/settings.json`
- Add shell command policy section to CLAUDE.md directing agents to use `vrg-git`/`vrg-gh` wrappers instead of raw `git`/`gh`

Part of the org-wide permission model rollout (vergil-project/vergil-tooling#754, Tasks 7-8).