### PR TITLE
feat(permissions): deploy deny rules to project-level settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,12 @@
   "permissions": {
     "allow": [
       "Bash(vrg-*)"
+    ],
+    "deny": [
+      "Bash(git *)",
+      "Bash(*/git *)",
+      "Bash(gh *)",
+      "Bash(*/gh *)"
     ]
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
# Pull Request

## Summary

- Deploy deny rules to project-level settings

## Issue Linkage

- Ref #491

## Notes

- Add Bash(git *), Bash(*/git *), Bash(gh *), Bash(*/gh *) deny rules to .claude/settings.json. Project-level deny rules cannot be overridden and are automatically distributed to all collaborators.