### PR TITLE
feat(version-bump-pr): deterministic tracking-issue lookup and hard assertions

### DIFF
--- a/actions/cd/release/version-bump-pr/action.yml
+++ b/actions/cd/release/version-bump-pr/action.yml
@@ -1,11 +1,12 @@
 name: Version bump PR
 description: >-
   Computes the next patch version, creates a branch from develop that merges
-  main, bumps the version via vrg-version, and opens a PR.  Skips if develop
-  already has the expected next version.  The PR is not auto-merged — callers
-  consume the `pr-url` output and drive the merge themselves (e.g. via
-  `vrg-merge-when-green` from a release skill) because org-wide auto-merge
-  is disabled.
+  main, bumps the version via vrg-version, and opens a PR.  Fails if develop
+  already has the expected next version (the upstream version-divergence gate
+  should prevent this; this check is its hard backstop).  The PR is not
+  auto-merged — callers consume the `pr-url` output and drive the merge
+  themselves (e.g. via `vrg-merge-when-green` from a release skill) because
+  org-wide auto-merge is disabled.
 
 inputs:
   current-version:
@@ -27,13 +28,6 @@ inputs:
       GitHub App token used for PR creation.  Must be passed from the caller
       because composite actions cannot access secrets directly.
     required: true
-  tracking-issue:
-    description: >-
-      Issue number for the release tracking issue (e.g. 42).  Used for PR body
-      issue linkage.  If omitted, the action searches for an open issue titled
-      "release: <current-version>" in the current repository.
-    required: false
-    default: ""
   pr-body-extra:
     description: >-
       Additional text appended to the PR body (e.g. dependency refresh notes).
@@ -45,11 +39,8 @@ outputs:
     description: The computed next patch version.
     value: ${{ steps.next.outputs.version }}
   pr-url:
-    description: URL of the created PR (empty if bump was not needed).
+    description: URL of the created PR.
     value: ${{ steps.create-pr.outputs.pr-url }}
-  bump-needed:
-    description: "'true' if a bump PR was created, 'false' if skipped."
-    value: ${{ steps.check.outputs.needed }}
 
 runs:
   using: composite
@@ -66,8 +57,7 @@ runs:
         echo "version=$next" >> "$GITHUB_OUTPUT"
         echo "branch=release/bump-version-$next" >> "$GITHUB_OUTPUT"
 
-    - name: Check if develop already has next version
-      id: check
+    - name: Assert develop does not already have next version
       shell: bash
       run: |
         git fetch origin develop
@@ -75,13 +65,13 @@ runs:
         develop_version=$(cd /tmp/develop-check && vrg-version show 2>/dev/null) || true
         git worktree remove /tmp/develop-check 2>/dev/null || true
         if [ "$develop_version" = "${{ steps.next.outputs.version }}" ]; then
-          echo "needed=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "needed=true" >> "$GITHUB_OUTPUT"
+          echo "::error::develop already has version ${{ steps.next.outputs.version }}." \
+               "This should never happen — the CI version-divergence gate should" \
+               "prevent it. Investigate before retrying."
+          exit 1
         fi
 
     - name: Create bump branch and merge main
-      if: steps.check.outputs.needed == 'true'
       shell: bash
       # -X theirs resolves add/add CHANGELOG conflicts on first-release repos
       # where develop's scaffolding CHANGELOG diverges from main's generated
@@ -92,17 +82,15 @@ runs:
         git merge origin/main --no-edit -X theirs
 
     - name: Bump version
-      if: steps.check.outputs.needed == 'true'
       shell: bash
       run: vrg-version bump
 
     - name: Run post-bump command
-      if: steps.check.outputs.needed == 'true' && inputs.post-bump-command != ''
+      if: inputs.post-bump-command != ''
       shell: bash
       run: ${{ inputs.post-bump-command }}
 
     - name: Commit and push
-      if: steps.check.outputs.needed == 'true'
       shell: bash
       run: |
         git add -A
@@ -114,39 +102,17 @@ runs:
 
     - name: Resolve tracking issue
       id: tracking
-      if: steps.check.outputs.needed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token }}
       run: |
-        issue="${{ inputs.tracking-issue }}"
-        if [ -n "$issue" ]; then
-          echo "Using explicit tracking-issue input: #${issue}"
-        else
-          echo "Searching for issue titled \"release: ${{ inputs.current-version }}\"..."
-          issue=$(gh issue list \
-            --state all \
-            --limit 200 \
-            --json number,title \
-            --jq ".[] | select(.title == \"release: ${{ inputs.current-version }}\") | .number" \
-            | head -1) || true
-          if [ -n "$issue" ]; then
-            echo "Found tracking issue: #${issue}"
-          else
-            echo "No tracking issue found — PR will have no issue linkage"
-          fi
-        fi
-        if [ -n "$issue" ]; then
-          echo "number=$issue" >> "$GITHUB_OUTPUT"
-          echo "linkage=Ref #${issue}" >> "$GITHUB_OUTPUT"
-        else
-          echo "number=" >> "$GITHUB_OUTPUT"
-          echo "linkage=" >> "$GITHUB_OUTPUT"
-        fi
+        issue=$(vrg-resolve-tracking-issue)
+        echo "Resolved tracking issue: #${issue}"
+        echo "number=$issue" >> "$GITHUB_OUTPUT"
+        echo "linkage=Ref #${issue}" >> "$GITHUB_OUTPUT"
 
     - name: Create and configure PR
       id: create-pr
-      if: steps.check.outputs.needed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token }}
@@ -156,16 +122,12 @@ runs:
           extra=$'\n'"${{ inputs.pr-body-extra }}"
         fi
 
-        linkage="${{ steps.tracking.outputs.linkage }}"
-
         body_file=$(mktemp)
         {
           echo "Automated patch version bump after publishing ${{ inputs.current-version }}."
           echo ""
-          if [ -n "$linkage" ]; then
-            echo "$linkage"
-            echo ""
-          fi
+          echo "${{ steps.tracking.outputs.linkage }}"
+          echo ""
           echo "This merges \`main\` back into \`develop\` to pick up the release tag and any"
           echo "other release-branch artifacts, then sets the working version to the next"
           echo "expected patch release. Change this to a minor or major bump if the next"

--- a/docs/site/docs/actions/cd-release-version-bump-pr.md
+++ b/docs/site/docs/actions/cd-release-version-bump-pr.md
@@ -1,12 +1,17 @@
 # publish/version-bump-pr
 
 Computes the next patch version, creates a branch from develop that merges main,
-updates the version file(s) via regex replacement, and opens a PR. Skips if
-develop already has the expected next version.
+updates the version file(s) via `vrg-version bump`, and opens a PR. Fails if
+develop already has the expected next version — the upstream version-divergence
+CI gate should prevent this; this check is its hard backstop.
+
+The tracking issue is resolved deterministically from the merge commit on main
+via `vrg-resolve-tracking-issue`. If the tool cannot find the tracking issue,
+the action fails — no PR is created without issue linkage.
 
 The PR is **not auto-merged** — org-wide auto-merge is disabled. Callers
 consume the `pr-url` output and drive the merge themselves (for example,
-via `st-merge-when-green` from a release skill).
+via `vrg-merge-when-green` from a release skill).
 
 ## Usage
 
@@ -14,10 +19,6 @@ via `st-merge-when-green` from a release skill).
 - uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: "1.2.3"
-    version-file: VERSION
-    version-regex: "^(\\d+\\.\\d+\\.)\\d+$"
-    version-replacement: "\\g<1>{version}"
-    develop-version-command: "cat"
     app-token: ${{ steps.app-token.outputs.token }}
 ```
 
@@ -26,14 +27,8 @@ via `st-merge-when-green` from a release skill).
 | Name | Required | Default | Description |
 | ------ | ---------- | --------- | ------------- |
 | `current-version` | **Yes** | — | The version that was just published (e.g. `1.2.3`). |
-| `version-file` | **Yes** | — | Path to the file containing the version string. |
-| `version-regex` | **Yes** | — | Python regex to match the version line. Use capture groups for parts to preserve. |
-| `version-replacement` | **Yes** | — | Python replacement string. Use `{version}` as a placeholder for the computed next version. |
-| `develop-version-command` | **Yes** | — | Shell command to extract the version from the version file on develop. Receives file content on stdin. |
 | `app-token` | **Yes** | — | GitHub App token for PR creation. Must be passed from the caller because composite actions cannot access secrets directly. |
-| `version-regex-multiline` | No | `false` | Set to `true` to pass `re.MULTILINE` to the regex substitution. |
-| `post-bump-command` | No | `""` | Shell command to run after version file edit and before commit (e.g. `uv lock --upgrade && uv export ...`). |
-| `tracking-issue` | No | `""` | Issue number for the release tracking issue (e.g. `42`). If omitted, the action searches for an open issue titled `release: <current-version>`. |
+| `post-bump-command` | No | `""` | Shell command to run after `vrg-version bump` and before commit (e.g. `uv lock --upgrade`). |
 | `extra-files` | No | `""` | Space-separated list of additional files to `git add` before committing. |
 | `pr-body-extra` | No | `""` | Additional text appended to the PR body. |
 
@@ -42,8 +37,7 @@ via `st-merge-when-green` from a release skill).
 | Name | Description |
 | ------ | ------------- |
 | `next-version` | The computed next patch version. |
-| `pr-url` | URL of the created PR (empty if bump was not needed). |
-| `bump-needed` | `true` if a bump PR was created, `false` if skipped. |
+| `pr-url` | URL of the created PR. |
 
 ## Permissions
 
@@ -58,36 +52,34 @@ via `st-merge-when-green` from a release skill).
 
 1. **Compute next version** — Increments the patch component of
    `current-version` (e.g. `1.2.3` becomes `1.2.4`).
-2. **Check develop** — Fetches `origin/develop` and extracts the current version
-   using `develop-version-command`. If it already matches the next version,
-   skips all remaining steps.
-3. **Create bump branch** — Creates `chore/bump-version-<next>` from
+2. **Assert develop version** — Fetches `origin/develop` and extracts the
+   current version via `vrg-version show`. If it already matches the next
+   version, the action **fails** with a diagnostic error. This is a backstop
+   for the CI version-divergence gate — if it fires, something has gone wrong
+   and requires human investigation.
+3. **Create bump branch** — Creates `release/bump-version-<next>` from
    `origin/develop` and merges `origin/main` to pick up release artifacts.
-4. **Update version file** — Uses Python regex substitution to replace the
-   version string in the specified file.
+4. **Bump version** — Runs `vrg-version bump` to update version files.
 5. **Post-bump command** — Optionally runs a command (e.g. lock file refresh).
 6. **Commit and push** — Commits the version file (and any extra files) with
    message `chore: bump version to <next>`.
-7. **Resolve tracking issue** — If `tracking-issue` is provided, uses that issue
-   number. Otherwise, searches for an open issue titled
-   `release: <current-version>`. If found, a `Ref #<number>` linkage line is
-   added to the PR body. Diagnostic output is logged in either case.
-8. **Create PR** — Opens a PR targeting `develop` and emits its URL as the
-   `pr-url` output. Does not attempt to merge — callers drive the merge
-   once CI is green.
+7. **Resolve tracking issue** — Calls `vrg-resolve-tracking-issue` to
+   deterministically extract the release tracking issue number from the merge
+   commit on main. The tool reads the merge commit message, extracts the PR
+   number, reads the PR body, and extracts the `Ref #N` linkage. If the tool
+   fails, the action fails — no PR is created without issue linkage.
+8. **Create PR** — Opens a PR targeting `develop` with `Ref #<issue>` linkage
+   in the body, and emits its URL as the `pr-url` output. Does not attempt to
+   merge — callers drive the merge once CI is green.
 
 ## Examples
 
-### Simple VERSION file bump
+### Minimal
 
 ```yaml
 - uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: ${{ steps.release.outputs.version }}
-    version-file: VERSION
-    version-regex: "^(\\d+\\.\\d+\\.)\\d+$"
-    version-replacement: "\\g<1>{version}"
-    develop-version-command: "cat"
     app-token: ${{ steps.app-token.outputs.token }}
 ```
 
@@ -97,10 +89,6 @@ via `st-merge-when-green` from a release skill).
 - uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
   with:
     current-version: "1.0.0"
-    version-file: pyproject.toml
-    version-regex: '(version\s*=\s*")[\d.]+(")'
-    version-replacement: '\g<1>{version}\2'
-    develop-version-command: "grep -oP 'version\\s*=\\s*\"\\K[^\"]+'"
     post-bump-command: "uv lock --upgrade && uv export --no-hashes -o requirements.txt"
     extra-files: "uv.lock requirements.txt"
     app-token: ${{ steps.app-token.outputs.token }}
@@ -112,6 +100,6 @@ via `st-merge-when-green` from a release skill).
   `app-token` input. The app must have permissions to create branches, push
   commits, and create/merge pull requests.
 - **Merge policy** — The PR is not auto-merged. The release workflow agent
-  drives the merge via `st-merge-when-green` after CI passes.
+  drives the merge via `vrg-merge-when-green` after CI passes.
 - **Branch protection** — The `develop` branch must allow PR merges from the
   GitHub App.


### PR DESCRIPTION
# Pull Request

## Summary

- Replace title-scanning with deterministic tracking-issue lookup, hard-fail idempotency check

## Issue Linkage

- Ref #495

## Notes

- Two design flaws fixed in the version-bump-pr composite action:

**Deterministic tracking-issue lookup** — Removed the `tracking-issue` input
and the fragile title-scanning fallback that searched for issues titled
`release: <version>`. The action now calls `vrg-resolve-tracking-issue` to
deterministically extract the release tracking issue number from the merge
commit on main. If the tool cannot resolve the issue, the action fails hard —
no PR is created without issue linkage.

**Hard assertion on develop version** — The idempotency check that silently
skipped PR creation when develop already had the bumped version is now a hard
failure. The upstream CI version-divergence gate should prevent this condition;
if it fires, something has gone wrong and requires human investigation.

Also removed the `bump-needed` output (the action always creates a PR on
success) and updated the docs to reflect current inputs and behavior (the
docs still referenced removed inputs like `version-file` and `version-regex`
from a prior version of the action).

Dependency: vergil-project/vergil-tooling#858 (`vrg-resolve-tracking-issue`).