### PR TITLE
fix(version-bump-pr): pass --commit origin/main to vrg-resolve-tracking-issue

### DIFF
--- a/actions/cd/release/version-bump-pr/action.yml
+++ b/actions/cd/release/version-bump-pr/action.yml
@@ -106,7 +106,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.app-token }}
       run: |
-        issue=$(vrg-resolve-tracking-issue)
+        issue=$(vrg-resolve-tracking-issue --commit origin/main)
         echo "Resolved tracking issue: #${issue}"
         echo "number=$issue" >> "$GITHUB_OUTPUT"
         echo "linkage=Ref #${issue}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Pull Request

## Summary

- Pass --commit origin/main to vrg-resolve-tracking-issue so the tool inspects the merge commit rather than the bump commit

## Issue Linkage

- Ref #502

## Notes

- The tool-side fix shipped in vergil-tooling#873 but the action should pass the correct commit to avoid relying on the fallback path.