### PR TITLE
fix(ops): add dev-base container to github-config job

### DIFF
--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -10,6 +10,7 @@ jobs:
   github-config:
     name: github-config
     runs-on: ubuntu-latest
+    container: ghcr.io/vergil-project/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Add dev-base container to the ops-github-config workflow, which was the only reusable workflow running on bare ubuntu-latest without it, causing uv: command not found during vergil-tooling setup

## Issue Linkage

- Ref #510

## Notes

- -