### PR TITLE
fix(ci): replace hardcoded container images with input-driven prefix

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [develop, main]
   workflow_dispatch:
+    inputs:
+      container-prefix:
+        type: string
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 permissions:
   contents: write
@@ -18,7 +24,7 @@ jobs:
     name: "cd / release"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    container: ghcr.io/vergil-project/prod-base:latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     defaults:
       run:
         shell: bash
@@ -80,5 +86,7 @@ jobs:
 
   docs:
     uses: ./.github/workflows/cd-docs.yml
+    with:
+      container-prefix: ${{ inputs.container-prefix || 'prod' }}
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: [develop, main]
   workflow_dispatch:
-    inputs:
-      container-prefix:
-        type: string
-        default: prod
-        description: >-
-          Container image name prefix (prod or dev). Defaults to "prod".
 
 permissions:
   contents: write
@@ -24,7 +18,7 @@ jobs:
     name: "cd / release"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
+    container: ghcr.io/vergil-project/prod-base:latest
     defaults:
       run:
         shell: bash
@@ -86,7 +80,5 @@ jobs:
 
   docs:
     uses: ./.github/workflows/cd-docs.yml
-    with:
-      container-prefix: ${{ inputs.container-prefix || 'prod' }}
     permissions:
       contents: write

--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -2,6 +2,13 @@ name: Ops — GitHub Config
 
 on:
   workflow_call:
+    inputs:
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
 
 permissions:
   contents: read
@@ -10,7 +17,7 @@ jobs:
   github-config:
     name: github-config
     runs-on: ubuntu-latest
-    container: ghcr.io/vergil-project/dev-base:latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -71,13 +71,18 @@ ghcr.io/vergil-project/<prefix>-<suffix>:<tag>
 
 The **prefix** defaults to `prod` and selects which image variant to use.
 Every reusable workflow accepts a `container-prefix` input that overrides
-this default.
+this default. The Docker images are part of the development and deployment
+environment only — there is no runtime dependency on them from the
+artifacts these workflows produce.
 
 ### Overriding the prefix
 
-When validating changes to the dev Docker images, consumer workflows can
-pass `container-prefix: dev` to run CI against the development images
-instead of the production images:
+To test against development Docker images, pass `container-prefix: dev`
+to the reusable workflow calls in the consumer's `ci.yml`, `cd.yml`, or
+`ops.yml`. Override a single workflow call to test one phase, or override
+all calls in a file to run the full CI/CD pipeline against dev images.
+
+**Single workflow override:**
 
 ```yaml
 jobs:
@@ -89,14 +94,38 @@ jobs:
       container-prefix: dev
 ```
 
-Add `container-prefix: dev` to each reusable workflow call in the
-consumer's `ci.yml`, `cd.yml`, or `ops.yml`. When done testing, remove the
-overrides to return to the production images.
+**Full CI file override** (add `container-prefix: dev` to every call):
 
-!!! warning "Do not commit dev overrides"
-    The `container-prefix: dev` override is for local validation of Docker
-    image changes. Do not merge it to `develop` or `main` — production
-    workflows must always use the `prod` images.
+```yaml
+jobs:
+  quality:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+      container-prefix: dev
+
+  security:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    with:
+      language: python
+      container-prefix: dev
+
+  test:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-test.yml@v2.0
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+      container-prefix: dev
+```
+
+Committing and pushing the overrides is expected when running a full
+end-to-end integration test of the dev images through CI and CD. Remove
+the overrides once the dev images have been validated and promoted to
+prod.
+
+For local-only validation, `vrg-docker-run` uses the dev-base image by
+default — no workflow changes are needed.
 
 ## Reference freezing
 

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -60,6 +60,44 @@ jobs:
       language: python
 ```
 
+## Container image prefix
+
+All reusable workflows run inside container images from the
+`ghcr.io/vergil-project/` registry. The image name follows the pattern:
+
+```text
+ghcr.io/vergil-project/<prefix>-<suffix>:<tag>
+```
+
+The **prefix** defaults to `prod` and selects which image variant to use.
+Every reusable workflow accepts a `container-prefix` input that overrides
+this default.
+
+### Overriding the prefix
+
+When validating changes to the dev Docker images, consumer workflows can
+pass `container-prefix: dev` to run CI against the development images
+instead of the production images:
+
+```yaml
+jobs:
+  quality:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    with:
+      language: python
+      versions: '["3.12", "3.13", "3.14"]'
+      container-prefix: dev
+```
+
+Add `container-prefix: dev` to each reusable workflow call in the
+consumer's `ci.yml`, `cd.yml`, or `ops.yml`. When done testing, remove the
+overrides to return to the production images.
+
+!!! warning "Do not commit dev overrides"
+    The `container-prefix: dev` override is for local validation of Docker
+    image changes. Do not merge it to `develop` or `main` — production
+    workflows must always use the `prod` images.
+
 ## Reference freezing
 
 The workflow source files reference composite actions via `@develop` during

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -125,7 +125,7 @@ the overrides once the dev images have been validated and promoted to
 prod.
 
 For local validation using development containers, see the
-[`vrg-docker-run` documentation](https://vergil-project.github.io/vergil-tooling/cli/vrg-docker-run/)
+[`vrg-docker-run` documentation](https://vergil-project.github.io/vergil-tooling/reference/cli-tools-overview/#vrg-docker-run)
 for instructions on specifying the container prefix.
 
 ## Reference freezing

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -124,8 +124,16 @@ end-to-end integration test of the dev images through CI and CD. Remove
 the overrides once the dev images have been validated and promoted to
 prod.
 
-For local-only validation, `vrg-docker-run` uses the dev-base image by
-default — no workflow changes are needed.
+For local validation via `vrg-docker-run`, set the image prefix in
+`vergil.toml`:
+
+```toml
+[docker]
+image-prefix = "dev"
+```
+
+`vrg-docker-run` reads this value and selects the corresponding container
+image. The default is `prod` when the `[docker]` section is absent.
 
 ## Reference freezing
 

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -124,16 +124,9 @@ end-to-end integration test of the dev images through CI and CD. Remove
 the overrides once the dev images have been validated and promoted to
 prod.
 
-For local validation via `vrg-docker-run`, set the image prefix in
-`vergil.toml`:
-
-```toml
-[docker]
-image-prefix = "dev"
-```
-
-`vrg-docker-run` reads this value and selects the corresponding container
-image. The default is `prod` when the `[docker]` section is absent.
+For local validation using development containers, see the
+[`vrg-docker-run` documentation](https://vergil-project.github.io/vergil-tooling/cli/vrg-docker-run/)
+for instructions on specifying the container prefix.
 
 ## Reference freezing
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace hardcoded container image refs in ops-github-config.yml and cd.yml with the standard container-prefix input pattern, and document the override mechanism

## Issue Linkage

- Ref #512

## Notes

- -