### PR TITLE
fix(ops): use correct vrg-github-repo-config command name

### DIFF
--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Audit GitHub configuration
         env:
           GH_TOKEN: ${{ github.token }}
-        run: vrg-github-config audit --repo "${{ github.repository }}"
+        run: vrg-github-repo-config audit --repo "${{ github.repository }}"


### PR DESCRIPTION
# Pull Request

## Summary

- Fix incorrect command name in ops-github-config workflow — vrg-github-config does not exist, the correct entry point is vrg-github-repo-config

## Issue Linkage

- Ref #518

## Notes

- -