### PR TITLE
fix(ops): align CLAUDE.md shell policy with canonical template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,7 @@ All fields are required.
 
 Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
 instead of `gh` for all GitHub CLI operations. These wrappers enforce
-subcommand allowlists, flag deny lists, credential selection, and
-audit logging.
+subcommand allowlists, flag deny lists, and credential selection.
 
 Raw `git` and `gh` are denied by the permission model. If a command
 is not available through the wrappers, explain the situation to the


### PR DESCRIPTION
# Pull Request

## Summary

- Remove extra text that drifted from the vergil-tooling template, unblocking release preflight

## Issue Linkage

- Ref #521

## Notes

- The Shell command policy section had extra 'and audit logging' text not present in the canonical claude_md_consumer.md template. This caused vrg-github-repo-config audit to fail the verbatim substring match during vrg-release preflight.