### PR TITLE
fix(ci): accept container-tag input in ci-audit and ci-test workflows

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -16,6 +16,13 @@ on:
           Container image name suffix (e.g. python, go, base). Defaults
           to "base". Callers should pass their language-specific suffix
           (e.g. "python", "go") when needed.
+      container-tag:
+        type: string
+        required: false
+        description: >-
+          Container image tag. Accepted for interface consistency with
+          other CI workflows; matrix jobs use the versions input for
+          their container tag.
       container-prefix:
         type: string
         required: false

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,6 +16,13 @@ on:
           Container image name suffix (e.g. python, go, base). Defaults
           to "base". Callers should pass their language-specific suffix
           (e.g. "python", "go") when needed.
+      container-tag:
+        type: string
+        required: false
+        description: >-
+          Container image tag. Accepted for interface consistency with
+          other CI workflows; matrix jobs use the versions input for
+          their container tag.
       container-prefix:
         type: string
         required: false


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag input to ci-audit and ci-test for interface consistency with the other three CI workflows

## Issue Linkage

- Ref #536

## Notes

- Both ci-audit and ci-test now declare the container-tag input. The input is accepted but not referenced in the container expression — matrix jobs continue to use the versions input for their container tag. This prevents startup_failure when callers pass container-tag uniformly to all CI workflows.