### PR TITLE
fix(ci): sync pre-commit hook with canonical template

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,18 +2,22 @@
 # pre-commit gate — admits vrg-commit-driven commits and legitimate
 # derived-commit workflows; rejects raw `git commit`.
 #
-# Source-of-truth contract: in vergil-tooling
-# docs/specs/host-level-tool.md "Git hooks".
-# Companion: `git.run` in vergil-tooling sets VRG_COMMIT_CONTEXT=1
+# Source-of-truth contract: docs/specs/host-level-tool.md "Git hooks".
+# Companion: src/standard_tooling/bin/commit.py sets VRG_COMMIT_CONTEXT=1
 # before invoking `git commit`.
+#
+# TODO(plugin#87): the "See ..." pointer below references
+# docs/repository-standards.md (markdown). When vergil-tooling-plugin
+# #87's structured config (st-config.{yml,toml}) lands, update this
+# pointer to the new config doc.
 
 # Admit vrg-commit-driven commits. Print a diagnostic so the admission
 # is visible — this branch is also the documented escape hatch
 # (`VRG_COMMIT_CONTEXT=1 git commit ...`) and any silent admit would
 # make manual workarounds invisible in the commit output.
 if [[ "${VRG_COMMIT_CONTEXT:-}" == "1" ]]; then
-  echo "pre-commit gate: admitted (VRG_COMMIT_CONTEXT=1)" >&2
-  exit 0
+	echo "pre-commit gate: admitted (VRG_COMMIT_CONTEXT=1)" >&2
+	exit 0
 fi
 
 # Admit derived-commit workflows that legitimately invoke `git commit`
@@ -21,9 +25,9 @@ fi
 # merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
 case "${GIT_REFLOG_ACTION:-}" in
 amend | cherry-pick | revert | rebase* | merge*)
-  echo "pre-commit gate: admitted (GIT_REFLOG_ACTION=${GIT_REFLOG_ACTION})" >&2
-  exit 0
-  ;;
+	echo "pre-commit gate: admitted (GIT_REFLOG_ACTION=${GIT_REFLOG_ACTION})" >&2
+	exit 0
+	;;
 esac
 
 echo "ERROR: raw 'git commit' is blocked. Use 'vrg-commit' instead." >&2


### PR DESCRIPTION
# Pull Request

## Summary

- Byte-for-byte copy of canonical pre-commit hook template from vergil-tooling, fixing comment drift and tabs-vs-spaces introduced by a prior AI agent

## Issue Linkage

- Ref #541

## Notes

- -