### PR TITLE
chore(ci): add missing container-tag and container-suffix parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       language: shell
       versions: '["latest"]'
       container-suffix: base
+      container-tag: 'latest'
 
   security:
     uses: ./.github/workflows/ci-security.yml
@@ -27,8 +28,12 @@ jobs:
     with:
       language: shell
       run-codeql: false
+      container-suffix: base
+      container-tag: 'latest'
 
   version:
     uses: ./.github/workflows/ci-version-bump.yml
     with:
       language: shell
+      container-suffix: base
+      container-tag: 'latest'


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag and container-suffix parameters to reusable workflow calls in ci.yml

## Issue Linkage

- Ref #557

## Notes

- Addresses vergil-project/vergil-tooling#1015, vergil-project/vergil-tooling#1013, and vergil-project/vergil-tooling#976. Quality was missing container-tag. Security and version were missing both container-tag and container-suffix. Repository-standards.md was audited and found clean (minimal doc with no commit/PR script sections).