### PR TITLE
fix(ci): guard version-divergence fetch against credential race

### DIFF
--- a/actions/ci/version-bump/version-divergence/action.yml
+++ b/actions/ci/version-bump/version-divergence/action.yml
@@ -33,7 +33,10 @@ runs:
 
     - name: Fetch main branch
       shell: bash
-      run: git fetch origin main --depth=1
+      run: |
+        if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+          git fetch origin main --depth=1
+        fi
 
     - name: Compare versions
       id: compare


### PR DESCRIPTION
# Pull Request

## Summary

- Guard git fetch origin main so it only runs when origin/main is not already a local ref, eliminating intermittent credential-helper race failures in container jobs

## Issue Linkage

- Ref #561

## Notes

- -