### PR TITLE
feat(ci): fail CI on CodeQL findings at warning level or above

### DIFF
--- a/actions/ci/security/codeql/action.yml
+++ b/actions/ci/security/codeql/action.yml
@@ -28,3 +28,34 @@ runs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{ inputs.language }}"
+        output: ${{ runner.temp }}/codeql-sarif
+
+    - name: Fail on CodeQL findings
+      shell: bash
+      run: |
+        sarif_dir="${{ runner.temp }}/codeql-sarif"
+
+        shopt -s nullglob
+        sarif_files=("$sarif_dir"/*.sarif)
+        if [ "${#sarif_files[@]}" -eq 0 ]; then
+          echo "::error::No SARIF files found in $sarif_dir"
+          exit 1
+        fi
+
+        count=$(jq --slurp \
+          '[.[].runs[]?.results[]?
+            | select(.level == "warning" or .level == "error")]
+          | length' \
+          "${sarif_files[@]}")
+
+        if [ "$count" -gt 0 ]; then
+          echo "::error::CodeQL found $count finding(s) at warning level or above"
+          jq --slurp -r \
+            '.[].runs[]?.results[]?
+              | select(.level == "warning" or .level == "error")
+              | "  \(.level): \(.ruleId) — \(.message.text)"' \
+            "${sarif_files[@]}"
+          exit 1
+        fi
+
+        echo "No CodeQL findings at warning level or above."


### PR DESCRIPTION
# Pull Request

## Summary

- Add post-analysis SARIF enforcement step to CodeQL action

## Issue Linkage

- Ref #556

## Notes

- Checks SARIF output for warning/error findings and exits non-zero, enforcing zero-tolerance security policy across all consuming repos without per-repo branch protection config