### PR TITLE
fix(ci): add missing contents:read permission to security scanner jobs

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -65,6 +65,7 @@ jobs:
     if: ${{ inputs.run-security && inputs.run-codeql }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout code
@@ -80,6 +81,7 @@ jobs:
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout code
@@ -96,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Pull Request

## Summary

- Add contents:read to codeql, trivy, and semgrep job-level permissions to fix intermittent checkout failures

## Issue Linkage

- Ref #568

## Notes

- -