### PR TITLE
refactor(cd): remove version-bump-pr and rolling-tag from release pipeline

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -39,19 +39,7 @@ on:
         description: Files to attach to release ($VERSION placeholder).
         type: string
         default: ""
-      post-bump-command:
-        description: Override post-bump command for version-bump-pr.
-        type: string
-        default: ""
-      extra-files:
-        description: Additional files for version bump commit.
-        type: string
-        default: ""
     secrets:
-      APP_CLIENT_ID:
-        required: true
-      APP_PRIVATE_KEY:
-        required: true
       CARGO_REGISTRY_TOKEN:
         required: false
       RUBYGEMS_API_KEY:
@@ -79,7 +67,6 @@ jobs:
         shell: bash
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
       attestations: write
     steps:
@@ -167,20 +154,3 @@ jobs:
           git push --no-thin origin "$TAG" --force
           git clone --depth 1 --branch "$TAG" "$repo_url" "$tmp"
           rm -rf "$tmp"
-
-      - name: Generate app token for bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          post-bump-command: ${{ inputs.post-bump-command }}
-          extra-files: ${{ inputs.extra-files }}
-          app-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: cd
@@ -70,13 +69,6 @@ jobs:
         uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@develop
         with:
           version: ${{ steps.version.outputs.version }}
-
-      - name: Version bump PR
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@develop
-        with:
-          current-version: ${{ steps.version.outputs.version }}
-          app-token: ${{ steps.app-token.outputs.token }}
 
   docs:
     uses: ./.github/workflows/cd-docs.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,10 @@ look in `actions/{phase}/{domain}/`. Cross-phase actions live in
   validation
 - `actions/cd/release/registry-publish` — Build and publish pipeline
   for any supported language ecosystem
-- `actions/cd/release/tag-and-release` — Annotated git tags, rolling
-  minor tags, and GitHub Releases
-- `actions/cd/release/version-bump-pr` — Post-release version bump PRs
+- `actions/cd/release/tag-and-release` — Annotated git tags, changelog
+  boundary tags, and GitHub Releases
+- `actions/cd/release/version-bump-pr` — **(deprecated)** Post-release
+  version bump PRs; now handled by `vrg-release` orchestrator
 - `actions/cd/docs/deploy` — MkDocs Material + mike versioned
   documentation deployment
 - `actions/shared/security/trivy` — Trivy vulnerability scanning

--- a/actions/cd/release/tag-and-release/action.yml
+++ b/actions/cd/release/tag-and-release/action.yml
@@ -1,7 +1,8 @@
 name: Tag and release
 description: >-
-  Creates an annotated git tag, a develop changelog boundary tag, and a
-  GitHub Release.  All mutating steps are skipped when the tag already exists,
+  Creates an annotated git tag, a develop changelog boundary tag, and a GitHub
+  Release.  Rolling minor tags (vX.Y) are handled by vrg-promote in the release
+  orchestrator.  All mutating steps are skipped when the tag already exists,
   making the action safe to re-run.
 
 inputs:
@@ -37,12 +38,6 @@ outputs:
   tag-created:
     description: "'true' if a new tag was created, 'false' if it already existed."
     value: ${{ steps.check.outputs.created }}
-  rolling-tag:
-    description: >-
-      The rolling major.minor tag (e.g. v1.2) that was created or updated.
-      Empty when tag-created is false.
-    value: ${{ steps.rolling.outputs.tag }}
-
 runs:
   using: composite
   steps:
@@ -116,14 +111,3 @@ runs:
         fi
         gh release create "${release_args[@]}"
 
-    - name: Create or update rolling minor tag
-      id: rolling
-      if: steps.check.outputs.created == 'true'
-      shell: bash
-      run: |
-        minor="${{ inputs.version }}"
-        minor="${minor%.*}"
-        rolling_tag="${{ inputs.tag-prefix }}${minor}"
-        git tag -f "$rolling_tag" HEAD
-        git push -f origin "$rolling_tag"
-        echo "tag=${rolling_tag}" >> "$GITHUB_OUTPUT"

--- a/docs/site/docs/actions/cd-release-tag-and-release.md
+++ b/docs/site/docs/actions/cd-release-tag-and-release.md
@@ -4,6 +4,11 @@ Creates an annotated git tag, a develop changelog boundary tag, and a GitHub
 Release. All mutating steps are skipped when the tag already exists, making the
 action safe to re-run.
 
+!!! note "Rolling minor tags"
+    Rolling minor tags (e.g. `v1.2`) are no longer created by this action.
+    They are now managed by `vrg-promote` in the release orchestrator's
+    `promote` phase.
+
 ## Usage
 
 ```yaml
@@ -32,7 +37,6 @@ action safe to re-run.
 | ------ | ------------- |
 | `tag` | The full tag name that was (or would be) created (e.g. `v1.2.3`). |
 | `tag-created` | `true` if a new tag was created, `false` if it already existed. |
-| `rolling-tag` | The rolling `major.minor` tag that was created or updated (e.g. `v1.2`). Empty when `tag-created` is `false`. |
 
 ## Permissions
 
@@ -52,10 +56,6 @@ action safe to re-run.
    enables changelog generation between releases.
 6. **Create GitHub Release** — Uses `gh release create` with the provided title,
    notes, and optional artifacts.
-7. **Create or update rolling minor tag** — Extracts the `major.minor` portion
-   of the version (e.g. `1.2` from `1.2.3`), then force-creates and
-   force-pushes a rolling tag (e.g. `v1.2`). This allows consumers to pin
-   `@v1.2` and automatically receive patch releases.
 
 ## Examples
 

--- a/docs/site/docs/actions/cd-release-version-bump-pr.md
+++ b/docs/site/docs/actions/cd-release-version-bump-pr.md
@@ -1,34 +1,23 @@
 # publish/version-bump-pr
 
+!!! warning "Deprecated"
+    This action is no longer invoked by the CD release pipeline. The release
+    orchestrator (`vrg-release`) now handles back-merge and version bump
+    directly via its `back-merge-bump` phase. See
+    [vergil-tooling#1069](https://github.com/vergil-project/vergil-tooling/issues/1069).
+
 Computes the next patch version, creates a branch from develop that merges main,
 updates the version file(s) via `vrg-version bump`, and opens a PR. Fails if
 develop already has the expected next version — the upstream version-divergence
 CI gate should prevent this; this check is its hard backstop.
-
-The tracking issue is resolved deterministically from the merge commit on main
-via `vrg-resolve-tracking-issue`. If the tool cannot find the tracking issue,
-the action fails — no PR is created without issue linkage.
-
-The PR is **not auto-merged** — org-wide auto-merge is disabled. Callers
-consume the `pr-url` output and drive the merge themselves (for example,
-via `vrg-merge-when-green` from a release skill).
-
-## Usage
-
-```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
-  with:
-    current-version: "1.2.3"
-    app-token: ${{ steps.app-token.outputs.token }}
-```
 
 ## Inputs
 
 | Name | Required | Default | Description |
 | ------ | ---------- | --------- | ------------- |
 | `current-version` | **Yes** | — | The version that was just published (e.g. `1.2.3`). |
-| `app-token` | **Yes** | — | GitHub App token for PR creation. Must be passed from the caller because composite actions cannot access secrets directly. |
-| `post-bump-command` | No | `""` | Shell command to run after `vrg-version bump` and before commit (e.g. `uv lock --upgrade`). |
+| `app-token` | **Yes** | — | GitHub App token for PR creation. |
+| `post-bump-command` | No | `""` | Shell command to run after `vrg-version bump` and before commit. |
 | `extra-files` | No | `""` | Space-separated list of additional files to `git add` before committing. |
 | `pr-body-extra` | No | `""` | Additional text appended to the PR body. |
 
@@ -38,68 +27,3 @@ via `vrg-merge-when-green` from a release skill).
 | ------ | ------------- |
 | `next-version` | The computed next patch version. |
 | `pr-url` | URL of the created PR. |
-
-## Permissions
-
-- `contents: write` (required for branch creation and pushing)
-
-!!! note "App token required"
-    The `app-token` input must be a GitHub App installation token (not the
-    default `GITHUB_TOKEN`). This is necessary because PRs created by
-    `GITHUB_TOKEN` do not trigger CI workflows.
-
-## Behavior
-
-1. **Compute next version** — Increments the patch component of
-   `current-version` (e.g. `1.2.3` becomes `1.2.4`).
-2. **Assert develop version** — Fetches `origin/develop` and extracts the
-   current version via `vrg-version show`. If it already matches the next
-   version, the action **fails** with a diagnostic error. This is a backstop
-   for the CI version-divergence gate — if it fires, something has gone wrong
-   and requires human investigation.
-3. **Create bump branch** — Creates `release/bump-version-<next>` from
-   `origin/develop` and merges `origin/main` to pick up release artifacts.
-4. **Bump version** — Runs `vrg-version bump` to update version files.
-5. **Post-bump command** — Optionally runs a command (e.g. lock file refresh).
-6. **Commit and push** — Commits the version file (and any extra files) with
-   message `chore: bump version to <next>`.
-7. **Resolve tracking issue** — Calls `vrg-resolve-tracking-issue` to
-   deterministically extract the release tracking issue number from the merge
-   commit on main. The tool reads the merge commit message, extracts the PR
-   number, reads the PR body, and extracts the `Ref #N` linkage. If the tool
-   fails, the action fails — no PR is created without issue linkage.
-8. **Create PR** — Opens a PR targeting `develop` with `Ref #<issue>` linkage
-   in the body, and emits its URL as the `pr-url` output. Does not attempt to
-   merge — callers drive the merge once CI is green.
-
-## Examples
-
-### Minimal
-
-```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
-  with:
-    current-version: ${{ steps.release.outputs.version }}
-    app-token: ${{ steps.app-token.outputs.token }}
-```
-
-### Python project with lock file refresh
-
-```yaml
-- uses: vergil-project/vergil-actions/actions/cd/release/version-bump-pr@v2.0
-  with:
-    current-version: "1.0.0"
-    post-bump-command: "uv lock --upgrade && uv export --no-hashes -o requirements.txt"
-    extra-files: "uv.lock requirements.txt"
-    app-token: ${{ steps.app-token.outputs.token }}
-```
-
-## GitHub configuration
-
-- **GitHub App** — A GitHub App installation token is required for the
-  `app-token` input. The app must have permissions to create branches, push
-  commits, and create/merge pull requests.
-- **Merge policy** — The PR is not auto-merged. The release workflow agent
-  drives the merge via `vrg-merge-when-green` after CI passes.
-- **Branch protection** — The `develop` branch must allow PR merges from the
-  GitHub App.


### PR DESCRIPTION
# Pull Request

## Summary

- Remove version-bump-pr invocation and rolling-tag step from CD release pipeline; now handled by vrg-release orchestrator

## Issue Linkage

- Ref #575

## Notes

- The release orchestrator (`vrg-release`) now handles version bumping and rolling tag promotion directly, making the CD-pipeline versions of these steps redundant.

## Changes

### Removed from `cd-release.yml` (reusable workflow)
- `version-bump-pr` step and its app-token generation step
- `post-bump-command` and `extra-files` inputs
- `APP_CLIENT_ID` and `APP_PRIVATE_KEY` secrets
- `pull-requests: write` permission (no longer needed)

### Removed from `cd.yml` (vergil-actions own CD)
- `version-bump-pr` step (app token kept for `freeze-internal-refs`)
- `pull-requests: write` permission

### Removed from `tag-and-release` action
- Rolling minor tag step (`git tag -f vX.Y HEAD && git push -f`)
- `rolling-tag` output

### Documentation
- `cd-release-version-bump-pr.md` marked as deprecated with pointer to vrg-release
- `cd-release-tag-and-release.md` updated to remove rolling tag references
- `CLAUDE.md` architecture section updated

## What now handles these responsibilities

| Previously | Now |
|---|---|
| `version-bump-pr` action in CD pipeline | `vrg-release` orchestrator `back-merge-bump` phase |
| Rolling tag in `tag-and-release` action | `vrg-release` orchestrator `promote` phase (via `vrg-promote`) |

## Testing

After this merges, the next release of any consumer repo will rely on `vrg-release` for the back-merge PR and rolling tag. The CD pipeline will only handle tagging, GitHub Release creation, and registry publishing.