### PR TITLE
ci(semgrep): add SARIF warning-level enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,9 @@ Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
 instead of `gh` for all GitHub CLI operations. These wrappers enforce
 subcommand allowlists, flag deny lists, and credential selection.
 
-Raw `git` and `gh` are blocked by the `PreToolUse` hook guard. If a
-command is not available through the wrappers, explain the situation to
-the human who can run it directly via `! <command>` in the prompt.
+Raw `git` and `gh` are denied by the permission model. If a command
+is not available through the wrappers, explain the situation to the
+human who can run it directly via `! <command>` in the prompt.
 
 ## Validation
 

--- a/actions/ci/security/semgrep/action.yml
+++ b/actions/ci/security/semgrep/action.yml
@@ -54,6 +54,34 @@ runs:
 
         semgrep scan $config_args --sarif --output semgrep-results.sarif
 
+    - name: Fail on Semgrep findings
+      shell: bash
+      run: |
+        sarif_file="semgrep-results.sarif"
+
+        if [ ! -f "$sarif_file" ]; then
+          echo "::error::SARIF file not found: $sarif_file"
+          exit 1
+        fi
+
+        count=$(jq \
+          '[.runs[]?.results[]?
+            | select(.level == "warning" or .level == "error")]
+          | length' \
+          "$sarif_file")
+
+        if [ "$count" -gt 0 ]; then
+          echo "::error::Semgrep found $count finding(s) at warning level or above"
+          jq -r \
+            '.runs[]?.results[]?
+              | select(.level == "warning" or .level == "error")
+              | "  \(.level): \(.ruleId) — \(.message.text)"' \
+            "$sarif_file"
+          exit 1
+        fi
+
+        echo "No Semgrep findings at warning level or above."
+
     - name: Upload SARIF
       if: always()
       uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
# Pull Request

## Summary

- Add SARIF warning-level enforcement to the Semgrep action

## Issue Linkage

- Ref #586

## Notes

- Semgrep writes findings to a SARIF file and uploads it to GHAS, but GHAS only fails CI on error-level alerts by default — warning-level findings appear as annotations without blocking merges.

This adds a post-scan step that reads the SARIF output and exits non-zero when any warning-or-above findings are present, matching the enforcement pattern added to CodeQL in PR #564.

Trivy was evaluated but does not need this change: its existing `exit-code` input (default `"1"`) on the `trivy convert --format sarif` step already gates CI on findings matching the configured severity filter.

Also aligns the CLAUDE.md shell command policy paragraph with the current vergil-tooling template to pass the `local.claude_md` repo config audit check.