### PR TITLE
Remove invalid primary-language from vergil.toml

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -3,7 +3,6 @@ repository-type = "library"
 versioning-scheme = "semver"
 branching-model = "library-release"
 release-model = "tagged-release"
-primary-language = "shell"
 [ci]
 versions = ["latest"]
 integration-tests = false


### PR DESCRIPTION
# Pull Request

## Summary

- Remove primary-language = shell from vergil.toml; shell is no longer a valid value

## Issue Linkage

- Ref #608

## Notes

- -