### PR TITLE
refactor(codeql): replace inline SARIF evaluation with vrg-sarif-evaluate

### DIFF
--- a/actions/ci/security/codeql/action.yml
+++ b/actions/ci/security/codeql/action.yml
@@ -32,30 +32,4 @@ runs:
 
     - name: Fail on CodeQL findings
       shell: bash
-      run: |
-        sarif_dir="${{ runner.temp }}/codeql-sarif"
-
-        shopt -s nullglob
-        sarif_files=("$sarif_dir"/*.sarif)
-        if [ "${#sarif_files[@]}" -eq 0 ]; then
-          echo "::error::No SARIF files found in $sarif_dir"
-          exit 1
-        fi
-
-        count=$(jq --slurp \
-          '[.[].runs[]?.results[]?
-            | select(.level == "warning" or .level == "error")]
-          | length' \
-          "${sarif_files[@]}")
-
-        if [ "$count" -gt 0 ]; then
-          echo "::error::CodeQL found $count finding(s) at warning level or above"
-          jq --slurp -r \
-            '.[].runs[]?.results[]?
-              | select(.level == "warning" or .level == "error")
-              | "  \(.level): \(.ruleId) — \(.message.text)"' \
-            "${sarif_files[@]}"
-          exit 1
-        fi
-
-        echo "No CodeQL findings at warning level or above."
+      run: vrg-sarif-evaluate "${{ runner.temp }}/codeql-sarif"


### PR DESCRIPTION
# Pull Request

## Summary

- Replace jq-based SARIF evaluation with vrg-sarif-evaluate CLI tool

## Issue Linkage

- Ref #598

## Notes

- Removes 27 lines of inline shell (nullglob glob expansion, jq --slurp pipeline, count-based gating) and replaces with a single vrg-sarif-evaluate call. The tool handles directory-mode SARIF parsing, severity filtering, structured annotations, and job summaries.