### PR TITLE
refactor(registry-publish): replace case-statement command derivation with vrg-ecosystem-resolve

### DIFF
--- a/actions/cd/release/registry-publish/action.yml
+++ b/actions/cd/release/registry-publish/action.yml
@@ -78,44 +78,14 @@ runs:
         INPUT_BUILD_COMMAND: ${{ inputs.build-command }}
         INPUT_PUBLISH_COMMAND: ${{ inputs.publish-command }}
       run: |
-        build="$INPUT_BUILD_COMMAND"
-        if [ -z "$build" ]; then
-          case "$INPUT_LANGUAGE" in
-            python) build="uv build" ;;
-            rust)   build="cargo build --release" ;;
-            ruby)   build="gem build *.gemspec" ;;
-            java)   build="./mvnw -B package -DskipTests" ;;
-            go)     build="go build ./..." ;;
-            *)
-              echo "::error::unrecognized language '${INPUT_LANGUAGE}' — cannot derive build command"
-              exit 1
-              ;;
-          esac
-        fi
-        echo "build=$build" >> "$GITHUB_OUTPUT"
+        vrg-ecosystem-resolve "$INPUT_LANGUAGE"
 
-        publish="$INPUT_PUBLISH_COMMAND"
-        if [ -z "$publish" ]; then
-          case "$INPUT_LANGUAGE" in
-            python) publish="uv publish dist/*" ;;
-            rust)   publish="cargo publish" ;;
-            ruby)   publish="gem push *.gem" ;;
-            java)   publish="./mvnw -B deploy -DskipTests" ;;
-            go)     publish="" ;;
-            *)
-              echo "::error::unrecognized language '${INPUT_LANGUAGE}' — cannot derive publish command"
-              exit 1
-              ;;
-          esac
+        if [ -n "$INPUT_BUILD_COMMAND" ]; then
+          echo "build=$INPUT_BUILD_COMMAND" >> "$GITHUB_OUTPUT"
         fi
-        echo "publish=$publish" >> "$GITHUB_OUTPUT"
-
-        case "$INPUT_LANGUAGE" in
-          rust) echo "credential-secret=CARGO_REGISTRY_TOKEN" >> "$GITHUB_OUTPUT" ;;
-          ruby) echo "credential-secret=RUBYGEMS_API_KEY" >> "$GITHUB_OUTPUT" ;;
-          java) echo "credential-secret=CENTRAL_TOKEN" >> "$GITHUB_OUTPUT" ;;
-          *)    echo "credential-secret=" >> "$GITHUB_OUTPUT" ;;
-        esac
+        if [ -n "$INPUT_PUBLISH_COMMAND" ]; then
+          echo "publish=$INPUT_PUBLISH_COMMAND" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Configure Maven credentials
       if: inputs.language == 'java'


### PR DESCRIPTION
# Pull Request

## Summary

- Replace three duplicated case blocks with a single vrg-ecosystem-resolve call

## Issue Linkage

- Ref #600

## Notes

- The tool writes shell-compatible strings directly to GITHUB_OUTPUT with the correct key names (build, publish, credential-secret). User overrides append after the tool call. 36 lines removed, 6 added.