### PR TITLE
fix(docs): handle missing primary-language in vergil.toml

### DIFF
--- a/actions/cd/docs/deploy/action.yml
+++ b/actions/cd/docs/deploy/action.yml
@@ -55,7 +55,7 @@ runs:
           lang=$(/usr/local/bin/python3 -c "
           import tomllib, pathlib
           cfg = tomllib.loads(pathlib.Path('vergil.toml').read_text())
-          print(cfg['project']['primary-language'])
+          print(cfg.get('project', {}).get('primary-language', ''))
           ")
           if [ "$lang" = "python" ]; then
             echo "cmd=uv run mike" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Pull Request

## Summary

- Fix KeyError crash in docs deploy when primary-language is absent from vergil.toml

## Issue Linkage

- Ref #617

## Notes

- One-line fix: use .get() with empty-string fallback instead of bare subscript. The key was removed in PR #609 but the deploy action still assumed it existed.