### PR TITLE
refactor(validate-inputs): replace inline validation with vrg-release-validate-inputs

### DIFF
--- a/actions/cd/release/validate-inputs/action.yml
+++ b/actions/cd/release/validate-inputs/action.yml
@@ -24,30 +24,14 @@ runs:
         INPUT_CONTAINER_TAG: ${{ inputs.container-tag }}
         INPUT_REGISTRY_PUBLISH: ${{ inputs.registry-publish }}
       run: |
-        supported_languages="python java ruby rust go"
+        args=("$INPUT_LANGUAGE")
 
-        if [ "$INPUT_LANGUAGE" != "base" ] && \
-           [ "$INPUT_CONTAINER_TAG" = "latest" ]; then
-          echo "::error::language '${INPUT_LANGUAGE}' requires an explicit container-tag (language-specific images do not publish a :latest tag)"
-          exit 1
-        fi
-
-        if [ "$INPUT_REGISTRY_PUBLISH" = "true" ] && \
-           [ "$INPUT_LANGUAGE" = "base" ]; then
-          echo "::error::registry-publish requires a language to derive ecosystem build/publish commands"
-          exit 1
+        if [ -n "$INPUT_CONTAINER_TAG" ]; then
+          args+=(--container-tag "$INPUT_CONTAINER_TAG")
         fi
 
         if [ "$INPUT_REGISTRY_PUBLISH" = "true" ]; then
-          found=0
-          for lang in $supported_languages; do
-            if [ "$INPUT_LANGUAGE" = "$lang" ]; then
-              found=1
-              break
-            fi
-          done
-          if [ "$found" -eq 0 ]; then
-            echo "::error::unsupported language '${INPUT_LANGUAGE}' for registry publishing (supported: ${supported_languages})"
-            exit 1
-          fi
+          args+=(--registry-publish)
         fi
+
+        vrg-release-validate-inputs "${args[@]}"


### PR DESCRIPTION
# Pull Request

## Summary

- Replace inline shell validation with vrg-release-validate-inputs CLI tool

## Issue Linkage

- Ref #601

## Notes

- Removes 22 lines of shell (interdependent conditionals, loop-based language lookup, duplicated supported-languages list) and replaces with a single vrg-release-validate-inputs call. The tool shares the canonical language list with vrg-ecosystem-resolve.