### PR TITLE
refactor(standards-compliance): remove redundant auto-close check

### DIFF
--- a/actions/ci/security/standards-compliance/action.yml
+++ b/actions/ci/security/standards-compliance/action.yml
@@ -16,18 +16,3 @@ runs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: vrg-pr-issue-linkage
-
-    - name: Reject auto-close linkage keywords
-      if: github.event_name == 'pull_request'
-      shell: bash
-      run: |
-        PR_BODY=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
-        AUTOCLOSE_RE='^\s*[-*]?\s*(Fixes|Closes|Resolves):?\s+'
-        AUTOCLOSE_RE+='([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#[0-9]+'
-        if echo "$PR_BODY" | grep -qEi "$AUTOCLOSE_RE"; then
-          echo "::error::PR body contains auto-close linkage (Fixes/Closes/Resolves)."
-          echo "Use 'Ref #N' instead. Auto-close keywords cause issues to close"
-          echo "before finalization is complete. The vrg-finalize-repo workflow"
-          echo "handles issue closure at the right time."
-          exit 1
-        fi


### PR DESCRIPTION
# Pull Request

## Summary

- Remove duplicate auto-close keyword check already handled by vrg-pr-issue-linkage

## Issue Linkage

- Ref #604

## Notes

- The vrg-pr-issue-linkage tool validates both issue linkage and auto-close keyword rejection in one call. The shell step with jq extraction and grep regex was a redundant duplicate. 15 lines removed.