### PR TITLE
refactor(version-divergence): replace inline comparison with vrg-version-divergence

### DIFF
--- a/actions/ci/version-bump/version-divergence/action.yml
+++ b/actions/ci/version-bump/version-divergence/action.yml
@@ -16,10 +16,10 @@ inputs:
 outputs:
   head-version:
     description: The version extracted from the PR branch.
-    value: ${{ steps.compare.outputs.head-version }}
+    value: ${{ steps.compare.outputs.head_version }}
   main-version:
     description: The version extracted from the main branch.
-    value: ${{ steps.compare.outputs.main-version }}
+    value: ${{ steps.compare.outputs.main_version }}
   diverged:
     description: "'true' if versions differ, 'false' otherwise."
     value: ${{ steps.compare.outputs.diverged }}
@@ -43,23 +43,10 @@ runs:
       shell: bash
       run: |
         head_version=$(${{ inputs.head-version-command }})
-
-        if ! main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || [ -z "$main_version" ]; then
-          echo "head-version=$head_version" >> "$GITHUB_OUTPUT"
-          echo "main-version=" >> "$GITHUB_OUTPUT"
+        main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || main_version=""
+        if vrg-version-divergence "$head_version" ${main_version:+"$main_version"}; then
           echo "diverged=true" >> "$GITHUB_OUTPUT"
-          echo "OK: no version found on main (no prior release). Skipping divergence check."
-          exit 0
-        fi
-
-        echo "head-version=$head_version" >> "$GITHUB_OUTPUT"
-        echo "main-version=$main_version" >> "$GITHUB_OUTPUT"
-
-        if [ "$main_version" = "$head_version" ]; then
+        else
           echo "diverged=false" >> "$GITHUB_OUTPUT"
-          echo "FAIL: PR version ($head_version) must differ from main ($main_version)."
           exit 1
         fi
-
-        echo "diverged=true" >> "$GITHUB_OUTPUT"
-        echo "OK: PR version ($head_version) differs from main ($main_version)."


### PR DESCRIPTION
# Pull Request

## Summary

- Replace 22 lines of version comparison shell with a single call to vrg-version-divergence from vergil-tooling

## Issue Linkage

- Ref #605

## Notes

- The tool handles version comparison logic, error messages, and job summaries. The action retains version extraction via user-provided commands and maps the exit code to the diverged boolean output.