### PR TITLE
refactor(setup): replace sed TOML parsing with python3 tomllib

### DIFF
--- a/actions/shared/setup/vergil/action.yml
+++ b/actions/shared/setup/vergil/action.yml
@@ -22,9 +22,13 @@ runs:
           exit 0
         fi
 
-        TAG=$(sed -n 's/^[[:space:]]*vergil[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' vergil.toml)
+        TAG=$(python3 -c "
+        import tomllib, pathlib
+        cfg = tomllib.loads(pathlib.Path('vergil.toml').read_text())
+        print(cfg['dependencies']['vergil'])
+        ")
         if [ -z "${TAG:-}" ]; then
-          echo "::error::vergil.toml not found or missing version tag"
+          echo "::error::vergil.toml not found or missing vergil version"
           exit 1
         fi
         uv tool install "vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@${TAG}"


### PR DESCRIPTION
# Pull Request

## Summary

- Replace fragile sed regex for vergil.toml version extraction with python3 tomllib stdlib module

## Issue Linkage

- Ref #606

## Notes

- The vrg-resolve-tooling-version tool exists in vergil-tooling but cannot be used here due to bootstrapping: this action installs vergil-tooling, so the tool is unavailable when the action runs. The inline python3 one-liner uses the stdlib tomllib module for proper TOML parsing without external dependencies.