### PR TITLE
fix(ci): revert internal refs to @develop, replace trivy shell with vrg-trivy-scan

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Run pre-deploy command
         if: inputs.pre-deploy-command != ''
@@ -45,7 +45,7 @@ jobs:
         run: eval "$PRE_DEPLOY_COMMAND"
 
       - name: Deploy docs
-        uses: vergil-project/vergil-actions/actions/cd/docs/deploy@v2.0
+        uses: vergil-project/vergil-actions/actions/cd/docs/deploy@develop
         with:
           version-command: vrg-version show --major-minor
           mkdocs-config: ${{ inputs.mkdocs-config || 'docs/site/mkdocs.yml' }}

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Run pre-deploy command
         if: inputs.pre-deploy-command != ''
@@ -45,7 +45,7 @@ jobs:
         run: eval "$PRE_DEPLOY_COMMAND"
 
       - name: Deploy docs
-        uses: vergil-project/vergil-actions/actions/cd/docs/deploy@develop
+        uses: ./actions/cd/docs/deploy
         with:
           version-command: vrg-version show --major-minor
           mkdocs-config: ${{ inputs.mkdocs-config || 'docs/site/mkdocs.yml' }}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -76,14 +76,14 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
-        uses: vergil-project/vergil-actions/actions/cd/release/validate-inputs@develop
+        uses: ./actions/cd/release/validate-inputs
         with:
           language: ${{ inputs.language }}
           container-tag: ${{ inputs.container-tag }}
           registry-publish: ${{ inputs.registry-publish }}
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Extract version
         id: version
@@ -116,7 +116,7 @@ jobs:
         if: >-
           contains(fromJSON('["python","java","ruby","rust","go"]'), inputs.language) &&
           steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/registry-publish@develop
+        uses: ./actions/cd/release/registry-publish
         with:
           language: ${{ inputs.language }}
           version: ${{ steps.version.outputs.version }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@develop
+        uses: ./actions/cd/release/tag-and-release
         with:
           version: ${{ steps.version.outputs.version }}
           release-artifacts: ${{ steps.resolved.outputs.release-artifacts }}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
-        uses: vergil-project/vergil-actions/actions/cd/release/validate-inputs@v2.0
+        uses: vergil-project/vergil-actions/actions/cd/release/validate-inputs@develop
         with:
           language: ${{ inputs.language }}
           container-tag: ${{ inputs.container-tag }}
@@ -116,7 +116,7 @@ jobs:
         if: >-
           contains(fromJSON('["python","java","ruby","rust","go"]'), inputs.language) &&
           steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/registry-publish@v2.0
+        uses: vergil-project/vergil-actions/actions/cd/release/registry-publish@develop
         with:
           language: ${{ inputs.language }}
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -94,8 +94,10 @@ jobs:
 
       - name: Check if tag already exists
         id: tag_check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -143,8 +145,9 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         env:
           TAG: ${{ steps.version.outputs.tag }}
+          GITHUB_REPO: ${{ github.repository }}
         run: |
-          repo_url="https://github.com/${{ github.repository }}"
+          repo_url="https://github.com/${GITHUB_REPO}"
           tmp="$(mktemp -d)"
           if git clone --depth 1 --branch "$TAG" "$repo_url" "$tmp" 2>/dev/null; then
             rm -rf "$tmp"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,8 +51,10 @@ jobs:
 
       - name: Check if tag already exists
         id: tag_check
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: vergil-project/vergil-actions/actions/cd/release/tag-and-release@develop
+        uses: ./actions/cd/release/tag-and-release
         with:
           version: ${{ steps.version.outputs.version }}
 

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Run common quality checks
         run: vrg-validate --check common
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Install dependencies
         if: inputs.language == 'python'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Run common quality checks
         run: vrg-validate --check common
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Install dependencies
         if: inputs.language == 'python'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Validate standards
-        uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@v2.0
+        uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@develop
 
   codeql:
     name: codeql
@@ -71,8 +71,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install vergil-tooling
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+
       - name: Run CodeQL analysis
-        uses: vergil-project/vergil-actions/actions/ci/security/codeql@v2.0
+        uses: vergil-project/vergil-actions/actions/ci/security/codeql@develop
         with:
           language: ${{ inputs.language }}
 
@@ -87,8 +90,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install vergil-tooling
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+
       - name: Run Trivy vulnerability scan
-        uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/security/trivy@develop
         with:
           scan-type: fs
 
@@ -104,7 +110,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install vergil-tooling
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+
       - name: Run Semgrep SAST scan
-        uses: vergil-project/vergil-actions/actions/ci/security/semgrep@v2.0
+        uses: vergil-project/vergil-actions/actions/ci/security/semgrep@develop
         with:
           language: ${{ inputs.language }}

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Validate standards
-        uses: vergil-project/vergil-actions/actions/ci/security/standards-compliance@develop
+        uses: ./actions/ci/security/standards-compliance
 
   codeql:
     name: codeql
@@ -72,10 +72,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Run CodeQL analysis
-        uses: vergil-project/vergil-actions/actions/ci/security/codeql@develop
+        uses: ./actions/ci/security/codeql
         with:
           language: ${{ inputs.language }}
 
@@ -91,10 +91,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Run Trivy vulnerability scan
-        uses: vergil-project/vergil-actions/actions/shared/security/trivy@develop
+        uses: ./actions/shared/security/trivy
         with:
           scan-type: fs
 
@@ -111,9 +111,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Run Semgrep SAST scan
-        uses: vergil-project/vergil-actions/actions/ci/security/semgrep@develop
+        uses: ./actions/ci/security/semgrep
         with:
           language: ${{ inputs.language }}

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -83,16 +83,12 @@ jobs:
     name: trivy
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
-    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
       contents: read
       security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Install vergil-tooling
-        uses: ./actions/shared/setup/vergil
 
       - name: Run Trivy vulnerability scan
         uses: ./actions/shared/security/trivy

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -83,6 +83,7 @@ jobs:
     name: trivy
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Install dependencies
         if: inputs.language == 'python'

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -41,10 +41,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Verify version bump
-        uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@develop
+        uses: ./actions/ci/version-bump/version-divergence
         with:
           head-version-command: vrg-version show
           main-version-command: vrg-version show --ref origin/main

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -41,10 +41,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Verify version bump
-        uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@v2.0
+        uses: vergil-project/vergil-actions/actions/ci/version-bump/version-divergence@develop
         with:
           head-version-command: vrg-version show
           main-version-command: vrg-version show --ref origin/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       language: shell
       versions: '["latest"]'
+      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'
 
@@ -28,6 +29,7 @@ jobs:
     with:
       language: shell
       run-codeql: false
+      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'
 
@@ -35,5 +37,6 @@ jobs:
     uses: ./.github/workflows/ci-version-bump.yml
     with:
       language: shell
+      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'

--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
 
       - name: Audit GitHub configuration
         env:

--- a/.github/workflows/ops-github-config.yml
+++ b/.github/workflows/ops-github-config.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install vergil-tooling
-        uses: vergil-project/vergil-actions/actions/shared/setup/vergil@develop
+        uses: ./actions/shared/setup/vergil
 
       - name: Audit GitHub configuration
         env:

--- a/actions/cd/docs/deploy/action.yml
+++ b/actions/cd/docs/deploy/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       env:
-        INPUT_MIKE_COMMAND: ${{ steps.mike-cmd.outputs.cmd }}
+        INPUT_MIKE_COMMAND: ${{ inputs.mike-command }}
       run: |
         if [ -n "$INPUT_MIKE_COMMAND" ]; then
           echo "cmd=$INPUT_MIKE_COMMAND" >> "$GITHUB_OUTPUT"
@@ -68,9 +68,12 @@ runs:
       id: version
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        GIT_REF: ${{ github.ref }}
+        VERSION_COMMAND: ${{ inputs.version-command }}
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          VERSION=$(${{ inputs.version-command }})
+        if [ "$GIT_REF" = "refs/heads/main" ]; then
+          VERSION=$(eval "$VERSION_COMMAND")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "alias=latest" >> "$GITHUB_OUTPUT"
         else
@@ -81,36 +84,44 @@ runs:
     - name: Stage changelog and release notes
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        MKDOCS_CONFIG: ${{ inputs.mkdocs-config }}
       run: |
-        vrg-docs-stage --docs-dir "$(dirname "${{ inputs.mkdocs-config }}")/docs"
+        vrg-docs-stage --docs-dir "$(dirname "$MKDOCS_CONFIG")/docs"
 
     - name: Patch mkdocs nav with release versions
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        MKDOCS_CONFIG: ${{ inputs.mkdocs-config }}
       run: |
-        DOCS_DIR=$(dirname "${{ inputs.mkdocs-config }}")/docs
+        DOCS_DIR=$(dirname "$MKDOCS_CONFIG")/docs
         vrg-docs-patch-nav \
-          --mkdocs-yml "${{ inputs.mkdocs-config }}" \
+          --mkdocs-yml "$MKDOCS_CONFIG" \
           --releases-dir "$DOCS_DIR/releases"
 
     - name: Deploy docs
       shell: bash
       working-directory: ${{ github.workspace }}
+      env:
+        MIKE_CMD: ${{ steps.mike-cmd.outputs.cmd }}
+        MKDOCS_CONFIG: ${{ inputs.mkdocs-config }}
+        DOC_VERSION: ${{ steps.version.outputs.version }}
+        DOC_ALIAS: ${{ steps.version.outputs.alias }}
       run: |
-        if [ -n "${{ steps.version.outputs.alias }}" ]; then
-          ${{ steps.mike-cmd.outputs.cmd }} deploy \
-            -F ${{ inputs.mkdocs-config }} --push --update-aliases \
-            ${{ steps.version.outputs.version }} \
-            ${{ steps.version.outputs.alias }}
-          ${{ steps.mike-cmd.outputs.cmd }} set-default \
-            -F ${{ inputs.mkdocs-config }} --push latest
+        if [ -n "$DOC_ALIAS" ]; then
+          $MIKE_CMD deploy \
+            -F "$MKDOCS_CONFIG" --push --update-aliases \
+            "$DOC_VERSION" \
+            "$DOC_ALIAS"
+          $MIKE_CMD set-default \
+            -F "$MKDOCS_CONFIG" --push latest
         else
-          ${{ steps.mike-cmd.outputs.cmd }} deploy -F ${{ inputs.mkdocs-config }} --push ${{ steps.version.outputs.version }}
-          # Set dev as default if no default exists yet (pre-release repos)
-          CURRENT_DEFAULT=$(${{ steps.mike-cmd.outputs.cmd }} list \
-            -F ${{ inputs.mkdocs-config }} 2>/dev/null \
+          $MIKE_CMD deploy -F "$MKDOCS_CONFIG" --push "$DOC_VERSION"
+          CURRENT_DEFAULT=$($MIKE_CMD list \
+            -F "$MKDOCS_CONFIG" 2>/dev/null \
             | grep '\[default\]' || true)
           if [ -z "$CURRENT_DEFAULT" ]; then
-            ${{ steps.mike-cmd.outputs.cmd }} set-default -F ${{ inputs.mkdocs-config }} --push dev
+            $MIKE_CMD set-default -F "$MKDOCS_CONFIG" --push dev
           fi
         fi

--- a/actions/cd/release/tag-and-release/action.yml
+++ b/actions/cd/release/tag-and-release/action.yml
@@ -44,14 +44,19 @@ runs:
     - name: Compute tag name
       id: meta
       shell: bash
+      env:
+        TAG_PREFIX: ${{ inputs.tag-prefix }}
+        VERSION: ${{ inputs.version }}
       run: |
-        echo "tag=${{ inputs.tag-prefix }}${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+        echo "tag=${TAG_PREFIX}${VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Check if tag already exists
       id: check
       shell: bash
+      env:
+        TAG: ${{ steps.meta.outputs.tag }}
       run: |
-        if git rev-parse "${{ steps.meta.outputs.tag }}" >/dev/null 2>&1; then
+        if git rev-parse "$TAG" >/dev/null 2>&1; then
           echo "created=false" >> "$GITHUB_OUTPUT"
         else
           echo "created=true" >> "$GITHUB_OUTPUT"
@@ -67,18 +72,23 @@ runs:
     - name: Create annotated tag
       if: steps.check.outputs.created == 'true'
       shell: bash
+      env:
+        TAG: ${{ steps.meta.outputs.tag }}
+        VERSION: ${{ inputs.version }}
       run: |
-        git tag -a "${{ steps.meta.outputs.tag }}" \
-          -m "Release ${{ inputs.version }}"
-        git push origin "${{ steps.meta.outputs.tag }}"
+        git tag -a "$TAG" \
+          -m "Release $VERSION"
+        git push origin "$TAG"
 
     - name: Tag develop for changelog boundaries
       if: steps.check.outputs.created == 'true'
       shell: bash
+      env:
+        TAG: ${{ steps.meta.outputs.tag }}
       run: |
         git fetch origin develop
-        git tag "develop-${{ steps.meta.outputs.tag }}" origin/develop
-        git push origin "develop-${{ steps.meta.outputs.tag }}"
+        git tag "develop-$TAG" origin/develop
+        git push origin "develop-$TAG"
 
     - name: Create GitHub Release
       if: steps.check.outputs.created == 'true'
@@ -87,27 +97,28 @@ runs:
         GH_TOKEN: ${{ github.token }}
         INPUT_RELEASE_NOTES: ${{ inputs.release-notes }}
         INPUT_RELEASE_TITLE: ${{ inputs.release-title }}
+        INPUT_RELEASE_ARTIFACTS: ${{ inputs.release-artifacts }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        REPO_OWNER: ${{ github.repository_owner }}
+        TAG: ${{ steps.meta.outputs.tag }}
       run: |
-        repo_name="${{ github.event.repository.name }}"
-        owner="${{ github.repository_owner }}"
-
         title="$INPUT_RELEASE_TITLE"
         if [ -z "$title" ]; then
-          title="${repo_name} ${{ steps.meta.outputs.tag }}"
+          title="${REPO_NAME} ${TAG}"
         fi
 
         notes="$INPUT_RELEASE_NOTES"
         if [ -z "$notes" ]; then
-          notes="Documentation: https://${owner}.github.io/${repo_name}/"
+          notes="Documentation: https://${REPO_OWNER}.github.io/${REPO_NAME}/"
         fi
 
         release_args=(
-          "${{ steps.meta.outputs.tag }}"
+          "$TAG"
           --title "$title"
           --notes "$notes"
         )
-        if [ -n "${{ inputs.release-artifacts }}" ]; then
-          release_args+=( ${{ inputs.release-artifacts }} )
+        if [ -n "$INPUT_RELEASE_ARTIFACTS" ]; then
+          release_args+=( $INPUT_RELEASE_ARTIFACTS )
         fi
         gh release create "${release_args[@]}"
 

--- a/actions/ci/security/codeql/action.yml
+++ b/actions/ci/security/codeql/action.yml
@@ -32,4 +32,6 @@ runs:
 
     - name: Fail on CodeQL findings
       shell: bash
-      run: vrg-sarif-evaluate "${{ runner.temp }}/codeql-sarif"
+      env:
+        SARIF_DIR: ${{ runner.temp }}/codeql-sarif
+      run: vrg-sarif-evaluate "$SARIF_DIR"

--- a/actions/ci/version-bump/version-divergence/action.yml
+++ b/actions/ci/version-bump/version-divergence/action.yml
@@ -41,9 +41,12 @@ runs:
     - name: Compare versions
       id: compare
       shell: bash
+      env:
+        HEAD_VERSION_CMD: ${{ inputs.head-version-command }}
+        MAIN_VERSION_CMD: ${{ inputs.main-version-command }}
       run: |
-        head_version=$(${{ inputs.head-version-command }})
-        main_version=$(${{ inputs.main-version-command }} 2>/dev/null) || main_version=""
+        head_version=$(eval "$HEAD_VERSION_CMD")
+        main_version=$(eval "$MAIN_VERSION_CMD" 2>/dev/null) || main_version=""
         if vrg-version-divergence "$head_version" ${main_version:+"$main_version"}; then
           echo "diverged=true" >> "$GITHUB_OUTPUT"
         else

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -50,128 +50,28 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Run Trivy filesystem scan
-      if: inputs.scan-type == 'fs'
+    - name: Run Trivy vulnerability scan
+      if: inputs.scan-type == 'fs' || inputs.scan-type == 'image'
       shell: bash
       env:
-        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+        SCAN_TYPE: ${{ inputs.scan-type }}
         SCAN_REF: ${{ inputs.scan-ref }}
-        SCANNERS: ${{ inputs.scanners }}
         SEVERITY: ${{ inputs.severity }}
-        EXIT_CODE: ${{ inputs.exit-code }}
-        OUTPUT_FILE: ${{ inputs.output-file }}
         TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
-        TRIVYIGNORE_ARGS=""
+        type=$( [ "$SCAN_TYPE" = "fs" ] && echo "filesystem" || echo "image" )
+        args=(--type "$type" --target "$SCAN_REF" --output-dir "$RUNNER_TEMP/trivy" --severity "$SEVERITY")
         if [ -n "$TRIVYIGNORES" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
+          args+=(--trivyignore "$TRIVYIGNORES")
         fi
-        # Single docker session: scan once to JSON, then convert to both
-        # table (stdout, never gates) and SARIF (file, gates per input).
-        # `trivy convert` operates on the cached JSON — no re-scan, no
-        # extra DB download, no extra vuln matching.
-        docker run --rm \
-          -v "$GITHUB_WORKSPACE:/workspace" \
-          -w /workspace \
-          -e SCANNERS \
-          -e SEVERITY \
-          -e EXIT_CODE \
-          -e OUTPUT_FILE \
-          -e SCAN_REF \
-          -e TRIVYIGNORE_ARGS \
-          --entrypoint sh \
-          "$TRIVY_IMAGE" \
-          -c '
-            set -e
-            trivy fs \
-              --scanners "$SCANNERS" \
-              --severity "$SEVERITY" \
-              --exit-code 0 \
-              --format json \
-              --output /tmp/trivy-raw.json \
-              $TRIVYIGNORE_ARGS \
-              "$SCAN_REF"
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format table \
-              --exit-code 0 \
-              /tmp/trivy-raw.json
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format sarif \
-              --exit-code "$EXIT_CODE" \
-              --output "/workspace/$OUTPUT_FILE" \
-              /tmp/trivy-raw.json
-          '
+        vrg-trivy-scan "${args[@]}"
 
-    - name: Upload SARIF (filesystem scan)
-      if: inputs.scan-type == 'fs' && always()
+    - name: Upload SARIF
+      if: (inputs.scan-type == 'fs' || inputs.scan-type == 'image') && always()
       uses: github/codeql-action/upload-sarif@v4
       with:
-        sarif_file: ${{ inputs.output-file }}
-        category: ${{ inputs.sarif-category || 'trivy-fs' }}
-
-    - name: Run Trivy image scan
-      if: inputs.scan-type == 'image'
-      shell: bash
-      env:
-        TRIVY_IMAGE: ${{ inputs.trivy-image }}
-        SCAN_REF: ${{ inputs.scan-ref }}
-        SCANNERS: ${{ inputs.scanners }}
-        SEVERITY: ${{ inputs.severity }}
-        EXIT_CODE: ${{ inputs.exit-code }}
-        OUTPUT_FILE: ${{ inputs.output-file }}
-        TRIVYIGNORES: ${{ inputs.trivyignores }}
-      run: |
-        TRIVYIGNORE_ARGS=""
-        if [ -n "$TRIVYIGNORES" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
-        fi
-        # Single docker session: scan once to JSON, then convert to both
-        # table (stdout, never gates) and SARIF (file, gates per input).
-        # `trivy convert` operates on the cached JSON — no re-scan, no
-        # extra DB download, no extra vuln matching.
-        docker run --rm \
-          -v "$GITHUB_WORKSPACE:/workspace" \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          -w /workspace \
-          -e SCANNERS \
-          -e SEVERITY \
-          -e EXIT_CODE \
-          -e OUTPUT_FILE \
-          -e SCAN_REF \
-          -e TRIVYIGNORE_ARGS \
-          --entrypoint sh \
-          "$TRIVY_IMAGE" \
-          -c '
-            set -e
-            trivy image \
-              --scanners "$SCANNERS" \
-              --severity "$SEVERITY" \
-              --exit-code 0 \
-              --format json \
-              --output /tmp/trivy-raw.json \
-              $TRIVYIGNORE_ARGS \
-              "$SCAN_REF"
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format table \
-              --exit-code 0 \
-              /tmp/trivy-raw.json
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format sarif \
-              --exit-code "$EXIT_CODE" \
-              --output "/workspace/$OUTPUT_FILE" \
-              /tmp/trivy-raw.json
-          '
-
-    - name: Upload SARIF (image scan)
-      if: inputs.scan-type == 'image' && always()
-      uses: github/codeql-action/upload-sarif@v4
-      with:
-        sarif_file: ${{ inputs.output-file }}
-        category: ${{ inputs.sarif-category || 'trivy-image' }}
+        sarif_file: ${{ runner.temp }}/trivy/trivy-results.sarif
+        category: ${{ inputs.sarif-category || format('trivy-{0}', inputs.scan-type) }}
 
     - name: Generate SBOM
       if: inputs.scan-type == 'sbom'

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -168,12 +168,16 @@ runs:
     - name: Generate SBOM
       if: inputs.scan-type == 'sbom'
       shell: bash
+      env:
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        SCAN_REF: ${{ inputs.scan-ref }}
       run: |
         docker run --rm \
           -v "$GITHUB_WORKSPACE:/workspace" \
           -w /workspace \
-          "${{ inputs.trivy-image }}" \
+          "$TRIVY_IMAGE" \
           fs \
           --format cyclonedx \
-          --output "/workspace/${{ inputs.output-file }}" \
-          "${{ inputs.scan-ref }}"
+          --output "/workspace/$OUTPUT_FILE" \
+          "$SCAN_REF"

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -50,28 +50,120 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Run Trivy vulnerability scan
-      if: inputs.scan-type == 'fs' || inputs.scan-type == 'image'
+    - name: Run Trivy filesystem scan
+      if: inputs.scan-type == 'fs'
       shell: bash
       env:
-        SCAN_TYPE: ${{ inputs.scan-type }}
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
         SCAN_REF: ${{ inputs.scan-ref }}
+        SCANNERS: ${{ inputs.scanners }}
         SEVERITY: ${{ inputs.severity }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
         TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
-        type=$( [ "$SCAN_TYPE" = "fs" ] && echo "filesystem" || echo "image" )
-        args=(--type "$type" --target "$SCAN_REF" --output-dir "$RUNNER_TEMP/trivy" --severity "$SEVERITY")
+        TRIVYIGNORE_ARGS=""
         if [ -n "$TRIVYIGNORES" ]; then
-          args+=(--trivyignore "$TRIVYIGNORES")
+          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
         fi
-        vrg-trivy-scan "${args[@]}"
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE:/workspace" \
+          -w /workspace \
+          -e SCANNERS \
+          -e SEVERITY \
+          -e EXIT_CODE \
+          -e OUTPUT_FILE \
+          -e SCAN_REF \
+          -e TRIVYIGNORE_ARGS \
+          --entrypoint sh \
+          "$TRIVY_IMAGE" \
+          -c '
+            set -e
+            trivy fs \
+              --scanners "$SCANNERS" \
+              --severity "$SEVERITY" \
+              --exit-code 0 \
+              --format json \
+              --output /tmp/trivy-raw.json \
+              $TRIVYIGNORE_ARGS \
+              "$SCAN_REF"
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format table \
+              --exit-code 0 \
+              /tmp/trivy-raw.json
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format sarif \
+              --exit-code "$EXIT_CODE" \
+              --output "/workspace/$OUTPUT_FILE" \
+              /tmp/trivy-raw.json
+          '
 
-    - name: Upload SARIF
-      if: (inputs.scan-type == 'fs' || inputs.scan-type == 'image') && always()
+    - name: Upload SARIF (filesystem scan)
+      if: inputs.scan-type == 'fs' && always()
       uses: github/codeql-action/upload-sarif@v4
       with:
-        sarif_file: ${{ runner.temp }}/trivy/trivy-results.sarif
-        category: ${{ inputs.sarif-category || format('trivy-{0}', inputs.scan-type) }}
+        sarif_file: ${{ inputs.output-file }}
+        category: ${{ inputs.sarif-category || 'trivy-fs' }}
+
+    - name: Run Trivy image scan
+      if: inputs.scan-type == 'image'
+      shell: bash
+      env:
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+        SCAN_REF: ${{ inputs.scan-ref }}
+        SCANNERS: ${{ inputs.scanners }}
+        SEVERITY: ${{ inputs.severity }}
+        EXIT_CODE: ${{ inputs.exit-code }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        TRIVYIGNORES: ${{ inputs.trivyignores }}
+      run: |
+        TRIVYIGNORE_ARGS=""
+        if [ -n "$TRIVYIGNORES" ]; then
+          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
+        fi
+        docker run --rm \
+          -v "$GITHUB_WORKSPACE:/workspace" \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -w /workspace \
+          -e SCANNERS \
+          -e SEVERITY \
+          -e EXIT_CODE \
+          -e OUTPUT_FILE \
+          -e SCAN_REF \
+          -e TRIVYIGNORE_ARGS \
+          --entrypoint sh \
+          "$TRIVY_IMAGE" \
+          -c '
+            set -e
+            trivy image \
+              --scanners "$SCANNERS" \
+              --severity "$SEVERITY" \
+              --exit-code 0 \
+              --format json \
+              --output /tmp/trivy-raw.json \
+              $TRIVYIGNORE_ARGS \
+              "$SCAN_REF"
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format table \
+              --exit-code 0 \
+              /tmp/trivy-raw.json
+            trivy convert \
+              --severity "$SEVERITY" \
+              --format sarif \
+              --exit-code "$EXIT_CODE" \
+              --output "/workspace/$OUTPUT_FILE" \
+              /tmp/trivy-raw.json
+          '
+
+    - name: Upload SARIF (image scan)
+      if: inputs.scan-type == 'image' && always()
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: ${{ inputs.output-file }}
+        category: ${{ inputs.sarif-category || 'trivy-image' }}
 
     - name: Generate SBOM
       if: inputs.scan-type == 'sbom'


### PR DESCRIPTION
# Pull Request

## Summary

- Revert all 18 @v2.0 internal refs to @develop to restore self-referencing CI. Replace 80 lines of nested-shell-in-Docker trivy orchestration with vrg-trivy-scan. Add missing Install vergil-tooling steps to codeql, trivy, and semgrep jobs.

## Issue Linkage

- Ref #607

## Notes

- This PR is the moment of truth for all the action changes from PRs #611-#624. With @develop refs, CI will now actually test the current code for the first time. Expect potential failures that need patching. Also addresses #613.