### PR TITLE
fix(trivy): replace Docker orchestration with vrg-trivy-scan

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -83,12 +83,16 @@ jobs:
     name: trivy
     if: ${{ inputs.run-security }}
     runs-on: ubuntu-latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
       contents: read
       security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install vergil-tooling
+        uses: ./actions/shared/setup/vergil
 
       - name: Run Trivy vulnerability scan
         uses: ./actions/shared/security/trivy

--- a/actions/cd/release/registry-publish/action.yml
+++ b/actions/cd/release/registry-publish/action.yml
@@ -139,7 +139,7 @@ runs:
 
     - name: Generate SBOM
       if: inputs.sbom-output-file != ''
-      uses: vergil-project/vergil-actions/actions/shared/security/trivy@develop
+      uses: ./actions/shared/security/trivy
       with:
         scan-type: sbom
         output-file: ${{ steps.resolve.outputs.sbom-output-file }}

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -1,8 +1,8 @@
 name: Trivy security scan
 description: >-
   Runs Trivy vulnerability scanning, SBOM generation, or container image
-  scanning. The calling workflow must grant security-events: write permission
-  when scan-type is "fs" or "image".
+  scanning via vrg-trivy-scan. The calling workflow must grant
+  security-events: write permission when scan-type is "fs" or "image".
 
 inputs:
   scan-type:
@@ -22,10 +22,6 @@ inputs:
     description: Exit code when vulnerabilities are found (0 = advisory only).
     required: false
     default: "1"
-  scanners:
-    description: Comma-separated Trivy scanners to enable.
-    required: false
-    default: "vuln"
   output-file:
     description: Output file path for SARIF or SBOM results.
     required: false
@@ -38,14 +34,9 @@ inputs:
     required: false
     default: ""
   trivyignores:
-    description: Comma-separated list of .trivyignore file paths.
+    description: Path to .trivyignore file for suppressing violations.
     required: false
     default: ""
-  trivy-image:
-    description: >-
-      Docker image to use for Trivy. Override to pin a specific version.
-    required: false
-    default: "aquasec/trivy:0.70.0"
 
 runs:
   using: composite
@@ -54,51 +45,25 @@ runs:
       if: inputs.scan-type == 'fs'
       shell: bash
       env:
-        TRIVY_IMAGE: ${{ inputs.trivy-image }}
         SCAN_REF: ${{ inputs.scan-ref }}
-        SCANNERS: ${{ inputs.scanners }}
         SEVERITY: ${{ inputs.severity }}
         EXIT_CODE: ${{ inputs.exit-code }}
         OUTPUT_FILE: ${{ inputs.output-file }}
         TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
-        TRIVYIGNORE_ARGS=""
+        args=(--type filesystem --target "$SCAN_REF" --output-dir .)
+        args+=(--severity "$SEVERITY")
         if [ -n "$TRIVYIGNORES" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
+          args+=(--trivyignore "$TRIVYIGNORES")
         fi
-        docker run --rm \
-          -v "$GITHUB_WORKSPACE:/workspace" \
-          -w /workspace \
-          -e SCANNERS \
-          -e SEVERITY \
-          -e EXIT_CODE \
-          -e OUTPUT_FILE \
-          -e SCAN_REF \
-          -e TRIVYIGNORE_ARGS \
-          --entrypoint sh \
-          "$TRIVY_IMAGE" \
-          -c '
-            set -e
-            trivy fs \
-              --scanners "$SCANNERS" \
-              --severity "$SEVERITY" \
-              --exit-code 0 \
-              --format json \
-              --output /tmp/trivy-raw.json \
-              $TRIVYIGNORE_ARGS \
-              "$SCAN_REF"
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format table \
-              --exit-code 0 \
-              /tmp/trivy-raw.json
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format sarif \
-              --exit-code "$EXIT_CODE" \
-              --output "/workspace/$OUTPUT_FILE" \
-              /tmp/trivy-raw.json
-          '
+        vrg-trivy-scan "${args[@]}" || rc=$?
+        if [ -f trivy-results.sarif ] && [ "$OUTPUT_FILE" != "trivy-results.sarif" ]; then
+          mv trivy-results.sarif "$OUTPUT_FILE"
+        fi
+        if [ "${rc:-0}" -eq 1 ] && [ "$EXIT_CODE" = "0" ]; then
+          exit 0
+        fi
+        exit "${rc:-0}"
 
     - name: Upload SARIF (filesystem scan)
       if: inputs.scan-type == 'fs' && always()
@@ -111,52 +76,25 @@ runs:
       if: inputs.scan-type == 'image'
       shell: bash
       env:
-        TRIVY_IMAGE: ${{ inputs.trivy-image }}
         SCAN_REF: ${{ inputs.scan-ref }}
-        SCANNERS: ${{ inputs.scanners }}
         SEVERITY: ${{ inputs.severity }}
         EXIT_CODE: ${{ inputs.exit-code }}
         OUTPUT_FILE: ${{ inputs.output-file }}
         TRIVYIGNORES: ${{ inputs.trivyignores }}
       run: |
-        TRIVYIGNORE_ARGS=""
+        args=(--type image --target "$SCAN_REF" --output-dir .)
+        args+=(--severity "$SEVERITY")
         if [ -n "$TRIVYIGNORES" ]; then
-          TRIVYIGNORE_ARGS="--ignorefile $TRIVYIGNORES"
+          args+=(--trivyignore "$TRIVYIGNORES")
         fi
-        docker run --rm \
-          -v "$GITHUB_WORKSPACE:/workspace" \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          -w /workspace \
-          -e SCANNERS \
-          -e SEVERITY \
-          -e EXIT_CODE \
-          -e OUTPUT_FILE \
-          -e SCAN_REF \
-          -e TRIVYIGNORE_ARGS \
-          --entrypoint sh \
-          "$TRIVY_IMAGE" \
-          -c '
-            set -e
-            trivy image \
-              --scanners "$SCANNERS" \
-              --severity "$SEVERITY" \
-              --exit-code 0 \
-              --format json \
-              --output /tmp/trivy-raw.json \
-              $TRIVYIGNORE_ARGS \
-              "$SCAN_REF"
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format table \
-              --exit-code 0 \
-              /tmp/trivy-raw.json
-            trivy convert \
-              --severity "$SEVERITY" \
-              --format sarif \
-              --exit-code "$EXIT_CODE" \
-              --output "/workspace/$OUTPUT_FILE" \
-              /tmp/trivy-raw.json
-          '
+        vrg-trivy-scan "${args[@]}" || rc=$?
+        if [ -f trivy-results.sarif ] && [ "$OUTPUT_FILE" != "trivy-results.sarif" ]; then
+          mv trivy-results.sarif "$OUTPUT_FILE"
+        fi
+        if [ "${rc:-0}" -eq 1 ] && [ "$EXIT_CODE" = "0" ]; then
+          exit 0
+        fi
+        exit "${rc:-0}"
 
     - name: Upload SARIF (image scan)
       if: inputs.scan-type == 'image' && always()
@@ -169,15 +107,6 @@ runs:
       if: inputs.scan-type == 'sbom'
       shell: bash
       env:
-        TRIVY_IMAGE: ${{ inputs.trivy-image }}
         OUTPUT_FILE: ${{ inputs.output-file }}
         SCAN_REF: ${{ inputs.scan-ref }}
-      run: |
-        docker run --rm \
-          -v "$GITHUB_WORKSPACE:/workspace" \
-          -w /workspace \
-          "$TRIVY_IMAGE" \
-          fs \
-          --format cyclonedx \
-          --output "/workspace/$OUTPUT_FILE" \
-          "$SCAN_REF"
+      run: trivy fs --format cyclonedx --output "$OUTPUT_FILE" "$SCAN_REF"


### PR DESCRIPTION
# Pull Request

## Summary

- Replace docker run wrapping with vrg-trivy-scan direct invocation, run trivy job in container, convert registry-publish ref to local path

## Issue Linkage

- Ref #607

## Notes

- Dependencies: vergil-tooling#1246 (merged), vergil-docker#268 (dev images available). Removes trivy-image and scanners inputs. SBOM generation uses direct trivy CLI.