### PR TITLE
fix(cd): resolve v2.0.21 breaking changes in release and trivy workflows

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -75,15 +75,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install vergil-tooling
+        uses: ./actions/shared/setup/vergil
+
       - name: Validate inputs
         uses: ./actions/cd/release/validate-inputs
         with:
           language: ${{ inputs.language }}
           container-tag: ${{ inputs.container-tag }}
           registry-publish: ${{ inputs.registry-publish }}
-
-      - name: Install vergil-tooling
-        uses: ./actions/shared/setup/vergil
 
       - name: Extract version
         id: version

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -41,6 +41,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Ensure vergil-tooling is available
+      if: inputs.scan-type == 'fs' || inputs.scan-type == 'image'
+      shell: bash
+      run: |
+        if command -v vrg-trivy-scan &>/dev/null; then
+          exit 0
+        fi
+        TAG=$(python3 -c "
+        import tomllib, pathlib
+        cfg = tomllib.loads(pathlib.Path('vergil.toml').read_text())
+        print(cfg['dependencies']['vergil'])
+        ")
+        if [ -z "${TAG:-}" ]; then
+          echo "::error::vergil.toml not found or missing vergil version"
+          exit 1
+        fi
+        uv tool install "vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@${TAG}"
+
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'
       shell: bash


### PR DESCRIPTION
# Pull Request

## Summary

- Move vergil-tooling install before input validation in cd-release.yml, and make the trivy composite action self-contained by installing vergil-tooling when not already on PATH

## Issue Linkage

- Ref #631

## Notes

- Issue 3 (cd-docs deploy primary-language fallback) was already fixed on develop in commit fa46ed75