### PR TITLE
fix(ci): run codeql job in container image

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -64,6 +64,7 @@ jobs:
     name: codeql
     if: ${{ inputs.run-security && inputs.run-codeql }}
     runs-on: ubuntu-latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
# Pull Request

## Summary

- Add container directive to codeql job so it runs in our standard image instead of a bare runner, fixing uv: command not found failures

## Issue Linkage

- Ref #636

## Notes

- -