### PR TITLE
fix(setup): install uv via setup-uv when not present on bare runners

### DIFF
--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -41,23 +41,22 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Ensure vergil-tooling is available
+    - name: Check vergil-tooling availability
+      id: check-tooling
       if: inputs.scan-type == 'fs' || inputs.scan-type == 'image'
       shell: bash
       run: |
         if command -v vrg-trivy-scan &>/dev/null; then
-          exit 0
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "available=false" >> "$GITHUB_OUTPUT"
         fi
-        TAG=$(python3 -c "
-        import tomllib, pathlib
-        cfg = tomllib.loads(pathlib.Path('vergil.toml').read_text())
-        print(cfg['dependencies']['vergil'])
-        ")
-        if [ -z "${TAG:-}" ]; then
-          echo "::error::vergil.toml not found or missing vergil version"
-          exit 1
-        fi
-        uv tool install "vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@${TAG}"
+
+    - name: Install vergil-tooling
+      if: >-
+        (inputs.scan-type == 'fs' || inputs.scan-type == 'image')
+        && steps.check-tooling.outputs.available == 'false'
+      uses: ./actions/shared/setup/vergil
 
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'

--- a/actions/shared/setup/vergil/action.yml
+++ b/actions/shared/setup/vergil/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Install uv
       if: steps.check-uv.outputs.found == 'false'
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
 
     - name: Install vergil-tooling
       shell: bash

--- a/actions/shared/setup/vergil/action.yml
+++ b/actions/shared/setup/vergil/action.yml
@@ -12,6 +12,20 @@ runs:
       shell: bash
       run: git config --global --add safe.directory "${GITHUB_WORKSPACE:-$(pwd)}"
 
+    - name: Check for uv
+      id: check-uv
+      shell: bash
+      run: |
+        if command -v uv &>/dev/null; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install uv
+      if: steps.check-uv.outputs.found == 'false'
+      uses: astral-sh/setup-uv@v8
+
     - name: Install vergil-tooling
       shell: bash
       run: |


### PR DESCRIPTION
# Pull Request

## Summary

- Add conditional uv installation to the setup action and remove duplicated install logic from the Trivy action

## Issue Linkage

- Ref #641

## Notes

- The setup action now checks for uv on PATH and installs it via astral-sh/setup-uv@v8 when absent. This handles bare ubuntu-latest runners (used by CD pipelines that need Docker socket access) without requiring consumers to manage the uv dependency.

The Trivy action's inline vergil-tooling install logic (tag read + uv tool install) is replaced with delegation to the setup action, establishing a single source of truth for the install path.