### PR TITLE
fix(setup): use pip to install uv on bare runners

### DIFF
--- a/actions/shared/setup/vergil/action.yml
+++ b/actions/shared/setup/vergil/action.yml
@@ -24,7 +24,8 @@ runs:
 
     - name: Install uv
       if: steps.check-uv.outputs.found == 'false'
-      uses: astral-sh/setup-uv@v7
+      shell: bash
+      run: pip install --break-system-packages uv
 
     - name: Install vergil-tooling
       shell: bash


### PR DESCRIPTION
# Pull Request

## Summary

- Replace astral-sh/setup-uv with pip install uv to break the circular dependency blocking releases

## Issue Linkage

- Ref #641

## Notes

- astral-sh/setup-uv requires allowlist and compliance changes that depend on this fix landing first. Using pip matches the Docker base image pattern and avoids the external action dependency. Issue #643 tracks the future upgrade to astral-sh/setup-uv.