### PR TITLE
fix(release): separate language and container-suffix inputs in cd-release.yml

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -4,9 +4,13 @@ on:
   workflow_call:
     inputs:
       language:
-        description: Primary language (matches container image suffix).
+        description: Programming language ecosystem (go, java, python, ruby, rust). Omit for non-language projects.
         type: string
-        default: "base"
+        default: ""
+      container-suffix:
+        description: Container image suffix (e.g. python, base). Defaults to language, then "base".
+        type: string
+        default: ""
       container-tag:
         description: Container image tag (e.g. 3.14, 1.26).
         type: string
@@ -61,7 +65,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-${{ inputs.language }}:${{ inputs.container-tag }}
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || inputs.language || 'base' }}:${{ inputs.container-tag }}
     defaults:
       run:
         shell: bash

--- a/actions/cd/release/validate-inputs/action.yml
+++ b/actions/cd/release/validate-inputs/action.yml
@@ -5,14 +5,17 @@ description: >-
 
 inputs:
   language:
-    description: Primary language string.
-    required: true
+    description: Programming language (go, java, python, ruby, rust). Empty for non-language projects.
+    required: false
+    default: ""
   container-tag:
-    description: Dev container image tag.
-    required: true
+    description: Container image tag.
+    required: false
+    default: ""
   registry-publish:
     description: Whether publishing is enabled.
-    required: true
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -24,7 +27,11 @@ runs:
         INPUT_CONTAINER_TAG: ${{ inputs.container-tag }}
         INPUT_REGISTRY_PUBLISH: ${{ inputs.registry-publish }}
       run: |
-        args=("$INPUT_LANGUAGE")
+        args=()
+
+        if [ -n "$INPUT_LANGUAGE" ]; then
+          args+=("$INPUT_LANGUAGE")
+        fi
 
         if [ -n "$INPUT_CONTAINER_TAG" ]; then
           args+=(--container-tag "$INPUT_CONTAINER_TAG")


### PR DESCRIPTION
# Pull Request

## Summary

- Add dedicated container-suffix input to cd-release.yml so non-language projects no longer misuse language: base

## Issue Linkage

- Ref #653

## Notes

- Adds container-suffix input that CI workflows already have. Container image line falls back through container-suffix, language, then base. Validate-inputs action treats language as optional. Backward compatible: consumers passing language: base still work via the lenient positional CLI path. Cross-repo context: vergil-project/vergil-tooling#1272, vergil-tooling v2.0.69.