### PR TITLE
docs(tooling): replace vrg-docker-run, fix v1.4 pin and pre-installed claim

### DIFF
--- a/docs/development/environment-and-tooling.md
+++ b/docs/development/environment-and-tooling.md
@@ -7,6 +7,6 @@
 ## Host prerequisites
 
 Install the vergil-tooling host tool and ensure Docker is running. All
-other tools run inside the dev-base container via `vrg-docker-run`.
+other tools run inside the dev-base container via `vrg-container-run`.
 
 See [tooling-dependencies.md](tooling-dependencies.md).

--- a/docs/development/tooling-dependencies.md
+++ b/docs/development/tooling-dependencies.md
@@ -8,4 +8,4 @@
 
 All validation tools (actionlint, shellcheck, markdownlint, yamllint) are
 pre-installed in the `ghcr.io/vergil-project/dev-base:latest` container image
-and run via `vrg-docker-run`. No manual host installs needed.
+and run via `vrg-container-run`. No manual host installs needed.

--- a/docs/site/docs/development/environment-and-tooling.md
+++ b/docs/site/docs/development/environment-and-tooling.md
@@ -13,25 +13,27 @@ branches (`main`, `develop`).
 
 ## Host prerequisites
 
-Install the vergil-tooling host tool, which provides `vrg-docker-run`,
+Install the vergil-tooling host tool, which provides `vrg-container-run`,
 `vrg-commit`, `vrg-validate`, and other workflow commands:
 
 ```bash
-uv tool install 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v1.4'
+uv tool install 'vergil-tooling @ git+https://github.com/vergil-project/vergil-tooling@v2.1'
 ```
 
-Docker must be running for `vrg-docker-run` to work.
+Docker must be running for `vrg-container-run` to work.
 
 ## Validation and development tools
 
 All validation tools (actionlint, shellcheck, markdownlint, yamllint) and
 documentation tools (mkdocs-material, mike) are pre-installed in the
-`ghcr.io/vergil-project/dev-base:latest` container image. No manual host
-installs are needed — `vrg-docker-run` pulls and runs this image
-automatically.
+`ghcr.io/vergil-project/dev-base:latest` container image. vergil-tooling
+itself is not — on first use, `vrg-container-run` builds a per-branch
+cached image with vergil-tooling installed at the version pinned in
+`vergil.toml`, and rebuilds it when `vergil.toml` or the lockfiles
+change. No manual host installs are needed.
 
 ```bash
-vrg-docker-run -- vrg-validate             # Run all validation checks
-vrg-docker-run -- mkdocs serve -f docs/site/mkdocs.yml   # Preview docs locally
-vrg-docker-run -- mkdocs build -f docs/site/mkdocs.yml --strict  # Strict docs build
+vrg-container-run -- vrg-validate             # Run all validation checks
+vrg-container-run -- mkdocs serve -f docs/site/mkdocs.yml   # Preview docs locally
+vrg-container-run -- mkdocs build -f docs/site/mkdocs.yml --strict  # Strict docs build
 ```

--- a/docs/site/docs/development/validation.md
+++ b/docs/site/docs/development/validation.md
@@ -3,12 +3,16 @@
 ## Canonical command
 
 ```bash
-vrg-docker-run -- vrg-validate
+vrg-container-run -- vrg-validate
 ```
 
-This runs all validation inside the `ghcr.io/vergil-project/dev-base:latest`
-container, which has every required tool pre-installed. No manual host
-installs needed beyond the vergil-tooling host tool.
+This runs all validation inside a per-branch cached container image that
+`vrg-container-run` builds on first use from
+`ghcr.io/vergil-project/dev-base:latest`: vergil-tooling is installed into
+it at the version pinned in `vergil.toml` (`[dependencies] vergil`), and
+the cache is rebuilt automatically when `vergil.toml` or the lockfiles
+change. No manual host installs are needed beyond the vergil-tooling host
+tool.
 
 ## Architecture
 
@@ -19,7 +23,7 @@ shellcheck, yamllint, and actionlint.
 
 ## Tooling
 
-All validation tools are pre-installed in the dev-base container image:
+The static validation tools are baked into the dev-base container image:
 
 | Tool | Purpose |
 | --- | --- |
@@ -28,4 +32,6 @@ All validation tools are pre-installed in the dev-base container image:
 | `markdownlint` | Markdown formatting linter |
 | `yamllint` | YAML formatting linter |
 
-No host-level installs of these tools are required.
+`vrg-validate` itself is not baked in — it arrives via the dynamic
+vergil-tooling install described above. No host-level installs of any of
+these tools are required.

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -126,7 +126,7 @@ the overrides once the dev images have been validated and promoted to
 prod.
 
 For local validation using development containers, see the
-[`vrg-docker-run` documentation](https://vergil-project.github.io/vergil-tooling/reference/cli-tools-overview/#vrg-docker-run)
+[`vrg-container-run` documentation](https://vergil-project.github.io/vergil-tooling/reference/cli-tools-overview/#vrg-container-run)
 for instructions on specifying the container prefix.
 
 ## Reference freezing


### PR DESCRIPTION
# Pull Request

## Summary

- Replace all vrg-docker-run references with vrg-container-run (including the CLI-reference link anchor), bump the install snippet from v1.4 to the v2.1 pin, and rewrite the validation/environment pages to distinguish tools baked into the base image from the dynamically installed vergil-tooling.

## Issue Linkage

- Ref #686

## Notes

- >-