### PR TITLE
fix(version-bump): gate follows release-model instead of run-release wiring

### DIFF
--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -9,6 +9,11 @@ on:
       run-release:
         type: boolean
         default: true
+        description: >-
+          Deprecated — the gate now follows release-model in vergil.toml.
+          Passing false still suppresses the gate for backwards
+          compatibility but emits a deprecation warning. Tracked for
+          removal in #688.
       container-suffix:
         type: string
         required: false
@@ -31,7 +36,6 @@ on:
 jobs:
   version-bump:
     name: version-bump
-    if: ${{ inputs.run-release }}
     runs-on: ubuntu-latest
     container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-${{ inputs.container-suffix || 'base' }}:${{ inputs.container-tag || 'latest' }}
     steps:
@@ -40,10 +44,43 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect release model
+        id: release-model
+        shell: bash
+        # Self-guard so the gate follows repo configuration (#675): a repo
+        # with release-model = "none" has nothing to version-bump, so the
+        # gate steps do not run and the job passes without caller wiring.
+        env:
+          RUN_RELEASE: ${{ inputs.run-release }}
+        run: |
+          if [ "$RUN_RELEASE" = "false" ]; then
+            msg='run-release is deprecated: the version-bump gate now'
+            msg="$msg follows release-model in vergil.toml. Remove"
+            msg="$msg run-release from the calling workflow (see"
+            msg="$msg vergil-actions#688)."
+            echo "::warning::$msg"
+            echo "releases=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          model=$(/usr/local/bin/python3 -c "
+          import tomllib, pathlib
+          path = pathlib.Path('vergil.toml')
+          cfg = tomllib.loads(path.read_text()) if path.is_file() else {}
+          print(cfg.get('project', {}).get('release-model', ''))
+          ")
+          if [ "$model" = "none" ]; then
+            echo "release-model is \"none\"; nothing to version-bump." >&2
+            echo "releases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "releases=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install vergil-tooling
+        if: steps.release-model.outputs.releases == 'true'
         uses: ./actions/shared/setup/vergil
 
       - name: Verify version bump
+        if: steps.release-model.outputs.releases == 'true'
         uses: ./actions/ci/version-bump/version-divergence
         with:
           head-version-command: vrg-version show

--- a/docs/site/docs/workflows/ci-version-bump.md
+++ b/docs/site/docs/workflows/ci-version-bump.md
@@ -2,12 +2,17 @@
 
 Version divergence gate workflow.
 
+The gate follows the consuming repo's configuration: the job reads
+`release-model` from `vergil.toml` and, when it is `"none"`, passes
+without running the gate. Non-releasing repos need no caller wiring to
+stay green.
+
 ## Inputs
 
 | Input | Type | Required | Default | Description |
 | ------- | ------ | ---------- | --------- | ------------- |
 | `language` | string | yes | — | Primary language of the repository |
-| `run-release` | boolean | no | `true` | Run the version-bump verification job |
+| `run-release` | boolean | no | `true` | **Deprecated** — the gate follows `release-model` in `vergil.toml`. Passing `false` still suppresses the gate but emits a deprecation warning. Tracked for removal in [#688](https://github.com/vergil-project/vergil-actions/issues/688) |
 | `container-suffix` | string | no | `base` | Container image name suffix (e.g. `python`, `base`) |
 | `container-tag` | string | no | `latest` | Container image tag (e.g. `3.14`, `1.26`) |
 
@@ -15,7 +20,7 @@ Version divergence gate workflow.
 
 | Job | Check name | Condition |
 | ----- | ------------ | ----------- |
-| `version-bump` | `CI Version Bump / version-bump` | `run-release` is true |
+| `version-bump` | `CI Version Bump / version-bump` | Always runs; the gate steps run only when `release-model` is not `none` |
 
 ## Usage
 
@@ -27,13 +32,13 @@ jobs:
       language: python
 ```
 
-To skip version gates (e.g., for infrastructure repos that don't version):
+Repos that don't release (e.g., infrastructure or documentation repos)
+declare it in `vergil.toml` instead of passing `run-release: false`:
 
-```yaml
-jobs:
-  version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
-    with:
-      language: shell
-      run-release: false
+```toml
+[project]
+release-model = "none"
 ```
+
+The version-bump job then passes without running the gate, and the
+tooling-derived required-check set omits it entirely.


### PR DESCRIPTION
# Pull Request

## Summary

- ci-version-bump.yml self-guards on vergil.toml release-model so non-releasing repos pass without run-release:false; the input is deprecated with a warning, removal tracked in #688

## Issue Linkage

- Ref #675

## Notes

- Follow-up issue #688 filed for removing the deprecated run-release input once consumer templates are refreshed.