### PR TITLE
fix(ci-security): grant actions: read and add upload-sarif artifact fallback

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -21,6 +21,15 @@ on:
           Disable for languages CodeQL does not support (e.g. shell).
         type: boolean
         default: true
+      upload-sarif:
+        description: >-
+          Upload scanner SARIF results to GitHub code scanning.
+          Disable on private repos without GitHub Advanced Security:
+          Trivy and Semgrep results are preserved as build artifacts
+          instead, and the CodeQL job is skipped entirely (CodeQL
+          cannot run on private repos without GHAS).
+        type: boolean
+        default: true
       container-suffix:
         type: string
         required: false
@@ -40,9 +49,13 @@ on:
         description: >-
           Container image name prefix (prod or dev). Defaults to "prod".
 
+# actions: read is required by codeql-action/upload-sarif on private
+# repos (it reads the workflow run via the Actions API); public repos
+# do not need it, which is why the gap was invisible there. See #693.
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 jobs:
   standards:
@@ -62,7 +75,10 @@ jobs:
 
   codeql:
     name: codeql
-    if: ${{ inputs.run-security && inputs.run-codeql }}
+    # upload-sarif gates this job entirely: CodeQL requires GitHub code
+    # scanning, which on private repos requires GHAS. upload-sarif: false
+    # signals code scanning is unavailable, so CodeQL cannot run at all.
+    if: ${{ inputs.run-security && inputs.run-codeql && inputs.upload-sarif }}
     runs-on: ubuntu-latest
     # No container: CodeQL autobuild for compiled languages (go, java, rust)
     # needs the language toolchain on PATH. The prod-base image has none, and
@@ -73,6 +89,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -92,6 +109,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -100,6 +118,7 @@ jobs:
         uses: ./actions/shared/security/trivy
         with:
           scan-type: fs
+          upload-sarif: ${{ inputs.upload-sarif }}
 
   semgrep:
     name: semgrep
@@ -109,6 +128,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -120,3 +140,4 @@ jobs:
         uses: ./actions/ci/security/semgrep
         with:
           language: ${{ inputs.language }}
+          upload-sarif: ${{ inputs.upload-sarif }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,6 +30,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     with:
       language: shell
       run-codeql: false

--- a/actions/ci/security/semgrep/action.yml
+++ b/actions/ci/security/semgrep/action.yml
@@ -17,6 +17,13 @@ inputs:
       "p/owasp-top-ten").
     required: false
     default: ""
+  upload-sarif:
+    description: >-
+      Upload SARIF results to GitHub code scanning. Set to "false" on
+      private repos without GitHub Advanced Security; results are
+      attached as a build artifact instead.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -46,8 +53,16 @@ runs:
         vrg-semgrep-scan "${args[@]}"
 
     - name: Upload SARIF
-      if: always()
+      if: inputs.upload-sarif == 'true' && always()
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: semgrep-results.sarif
         category: semgrep
+
+    - name: Attach SARIF as build artifact
+      if: inputs.upload-sarif != 'true' && always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: semgrep-sarif
+        path: semgrep-results.sarif
+        if-no-files-found: warn

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -46,6 +46,13 @@ inputs:
       Docker image to use for Trivy. Override to pin a specific version.
     required: false
     default: "aquasec/trivy:0.70.0"
+  upload-sarif:
+    description: >-
+      Upload SARIF results to GitHub code scanning. Set to "false" on
+      private repos without GitHub Advanced Security; results are
+      attached as a build artifact instead.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -101,7 +108,7 @@ runs:
           '
 
     - name: Upload SARIF (filesystem scan)
-      if: inputs.scan-type == 'fs' && always()
+      if: inputs.scan-type == 'fs' && inputs.upload-sarif == 'true' && always()
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.output-file }}
@@ -159,11 +166,21 @@ runs:
           '
 
     - name: Upload SARIF (image scan)
-      if: inputs.scan-type == 'image' && always()
+      if: inputs.scan-type == 'image' && inputs.upload-sarif == 'true' && always()
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.output-file }}
         category: ${{ inputs.sarif-category || 'trivy-image' }}
+
+    - name: Attach SARIF as build artifact
+      if: >-
+        (inputs.scan-type == 'fs' || inputs.scan-type == 'image') &&
+        inputs.upload-sarif != 'true' && always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.sarif-category || format('trivy-{0}', inputs.scan-type) }}-sarif
+        path: ${{ inputs.output-file }}
+        if-no-files-found: warn
 
     - name: Generate SBOM
       if: inputs.scan-type == 'sbom'

--- a/docs/site/docs/actions/ci-security-semgrep.md
+++ b/docs/site/docs/actions/ci-security-semgrep.md
@@ -18,10 +18,12 @@ rulesets.
 | ------ | ---------- | --------- | ------------- |
 | `language` | **Yes** | — | Language ruleset to enable (maps to `p/<language>`, e.g. `python`, `java`, `golang`). |
 | `extra-config` | No | `""` | Additional Semgrep config strings, space-separated (e.g. `p/owasp-top-ten`). |
+| `upload-sarif` | No | `true` | Upload SARIF to GitHub code scanning. Set to `false` on private repos without GHAS; results are attached as a build artifact instead. |
 
 ## Permissions
 
 - `security-events: write` (required for uploading SARIF results)
+- `actions: read` (required by the SARIF upload on **private** repositories)
 - `contents: read`
 
 ## Behavior
@@ -48,7 +50,9 @@ rulesets.
     - Any additional rulesets from `extra-config`
 4. **Upload SARIF** — Uploads the SARIF output file to GitHub code scanning
    using `github/codeql-action/upload-sarif@v4`, categorized as `semgrep`.
-   This step runs even if the scan finds issues (`if: always()`).
+   This step runs even if the scan finds issues (`if: always()`). When
+   `upload-sarif` is `false`, the SARIF file is attached to the workflow run
+   as a build artifact (`semgrep-sarif`) instead.
 
 ## Examples
 
@@ -81,6 +85,8 @@ jobs:
 ## GitHub configuration
 
 - **GitHub Advanced Security (GHAS)** — Must be enabled for SARIF upload.
+  On private repos without GHAS, set `upload-sarif: false` to preserve
+  results as a build artifact instead.
 - **Code scanning alerts** — Results appear in the repository's **Security >
   Code scanning alerts** tab alongside CodeQL results.
 

--- a/docs/site/docs/actions/shared-security-trivy.md
+++ b/docs/site/docs/actions/shared-security-trivy.md
@@ -28,11 +28,13 @@ Runs Trivy vulnerability scanning, SBOM generation, or container image scanning.
 | `sarif-category` | No | `""` | Category for SARIF upload. Use unique values when multiple matrix entries upload SARIF to avoid overwrites. Defaults to `trivy-fs` or `trivy-image` based on scan-type. |
 | `trivyignores` | No | `""` | Comma-separated list of `.trivyignore` file paths. |
 | `trivy-image` | No | `aquasec/trivy:0.70.0` | Docker image to use for Trivy. Override to pin a specific version. |
+| `upload-sarif` | No | `true` | Upload SARIF to GitHub code scanning. Set to `false` on private repos without GHAS; results are attached as a build artifact instead. |
 
 ## Permissions
 
 - `security-events: write` (required for SARIF upload when `scan-type` is `fs`
   or `image`)
+- `actions: read` (required by the SARIF upload on **private** repositories)
 - `contents: read`
 
 ## Behavior
@@ -110,9 +112,23 @@ jobs:
     sarif-category: "trivy-fs-${{ matrix.target }}"
 ```
 
+### Private repo without GHAS (artifact fallback)
+
+```yaml
+- uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.1
+  with:
+    scan-type: fs
+    upload-sarif: false
+```
+
+The scan still runs and still fails on findings; the SARIF file is attached
+to the workflow run as a build artifact (named after the SARIF category,
+e.g. `trivy-fs-sarif`) instead of being uploaded to code scanning.
+
 ## GitHub configuration
 
 - **GitHub Advanced Security (GHAS)** — Must be enabled for SARIF upload
-  (`fs` and `image` scan types).
+  (`fs` and `image` scan types). On private repos without GHAS, set
+  `upload-sarif: false` to preserve results as a build artifact instead.
 - **Code scanning alerts** — Results appear in **Security > Code scanning
   alerts** with categories `trivy-fs` or `trivy-image`.

--- a/docs/site/docs/ci-gates/security-scanning.md
+++ b/docs/site/docs/ci-gates/security-scanning.md
@@ -19,6 +19,13 @@ requires **GitHub Advanced Security (GHAS)**:
 - **Private repositories** — A GHAS license is required. Contact your GitHub
   administrator.
 
+On a private repository **without** GHAS, set `upload-sarif: false` on the
+[ci-security workflow](../workflows/ci-security.md): Trivy and Semgrep still
+run (and still fail on findings) but attach their SARIF results as build
+artifacts instead of uploading to code scanning, and the CodeQL job is
+skipped (CodeQL cannot run on private repos without GHAS at all). See
+[Private repos without GitHub Advanced Security](../workflows/ci-security.md#private-repos-without-github-advanced-security).
+
 ## Check names in the PR status area
 
 Each security scanner produces **two** check runs on a pull request:
@@ -119,12 +126,15 @@ the CI check. Set `exit-code: "0"` for advisory-only mode:
 
 ## Workflow permissions
 
-All security scanning jobs require the `security-events: write` permission:
+All security scanning jobs require the `security-events: write` permission,
+plus `actions: read`, which `codeql-action/upload-sarif` needs on **private**
+repositories (it reads the workflow run via the Actions API):
 
 ```yaml
 jobs:
   codeql:
     permissions:
       security-events: write
+      actions: read
       contents: read
 ```

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -10,6 +10,7 @@ Standards compliance and security scanning workflow.
 | `run-standards` | boolean | no | `true` | Run the standards-compliance job |
 | `run-security` | boolean | no | `true` | Run security scanner jobs (CodeQL, Semgrep, Trivy) |
 | `run-codeql` | boolean | no | `true` | Run CodeQL analysis (disable for unsupported languages like `shell`) |
+| `upload-sarif` | boolean | no | `true` | Upload scanner SARIF to GitHub code scanning (disable on private repos without GHAS; see below) |
 | `container-suffix` | string | no | `base` | Container image name suffix for the standards job |
 | `container-tag` | string | no | `latest` | Container image tag for the standards job |
 
@@ -19,14 +20,21 @@ Standards compliance and security scanning workflow.
 permissions:
   contents: read
   security-events: write
+  actions: read
 ```
+
+`actions: read` is required by `codeql-action/upload-sarif` on **private**
+repositories (it reads the workflow run via the Actions API). Public
+repositories do not need it, but reusable-workflow jobs can only downgrade
+caller permissions, so the caller must grant it for the workflow-level
+grant to take effect.
 
 ## Jobs and check names
 
 | Job | Check name | Condition |
 | ----- | ------------ | ----------- |
 | `standards` | `CI Security / standards` | `run-standards` is true |
-| `codeql` | `CI Security / codeql` | `run-security` and `run-codeql` are true |
+| `codeql` | `CI Security / codeql` | `run-security`, `run-codeql`, and `upload-sarif` are true |
 | `trivy` | `CI Security / trivy` | `run-security` is true |
 | `semgrep` | `CI Security / semgrep` | `run-security` is true |
 
@@ -39,6 +47,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     with:
       language: python
 ```
@@ -52,10 +61,43 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     with:
       language: shell
       run-codeql: false
 ```
+
+## Private repos without GitHub Advanced Security
+
+GitHub code scanning on private repositories requires GitHub Advanced
+Security (GHAS). On a private repo without GHAS, set `upload-sarif: false`:
+
+```yaml
+jobs:
+  security:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    with:
+      language: python
+      upload-sarif: false
+```
+
+With `upload-sarif: false`:
+
+- Trivy and Semgrep scans still run and still fail the job on findings;
+  their SARIF results are attached to the workflow run as build artifacts
+  (`trivy-fs-sarif`, `semgrep-sarif`) instead of being uploaded to code
+  scanning.
+- The `codeql` job is skipped entirely — CodeQL cannot run on private
+  repos without GHAS, regardless of the upload destination.
+
+The scans themselves do not require GHAS; only the code-scanning upload
+destination does. Failing CI because the reporting destination is
+unavailable, when the scan itself passed, is the wrong outcome — this
+input degrades the destination, not the scanning.
 
 ## Implementation notes
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions: read to SARIF-upload job permissions and an upload-sarif input that degrades to build artifacts on private repos without GHAS.

## Issue Linkage

- Ref #693

## Notes

- >-