### PR TITLE
docs(ci-security): document the actions: read caller contract and rollout policy

### DIFF
--- a/docs/site/docs/ci-gates/required-checks.md
+++ b/docs/site/docs/ci-gates/required-checks.md
@@ -89,6 +89,7 @@ security-and-standards:
   permissions:
     contents: read
     security-events: write
+    actions: read
 ```
 
 Using a job-level `if` on a single flag (e.g., `if: inputs.run-security !=

--- a/docs/site/docs/development/contributing.md
+++ b/docs/site/docs/development/contributing.md
@@ -27,6 +27,36 @@
 - **Environment variables for sensitive data** — Use `env` blocks rather than
   inline interpolation for values that might contain special characters.
 
+## Reusable workflow caller contract
+
+The `permissions:` blocks of a `workflow_call` workflow — workflow-level
+and job-level alike — are **requests against the caller**, not grants.
+GitHub validates at workflow startup that the calling job's effective
+permissions cover every requested scope; a caller that does not is
+rejected with `startup_failure` before any job runs, and no checks are
+registered on the PR.
+
+Treat any **addition** to a `permissions:` block in a `workflow_call`
+workflow as a breaking change to the caller contract:
+
+- It requires a coordinated consumer rollout: every consumer must add the
+  grant to its calling job **before** the rolling tag is promoted to a
+  release containing the new request. Grants are backward-compatible
+  (callers may grant more than a called workflow requests), so consumer
+  patches can always land first.
+- Call the new requirement out prominently in the release notes, under a
+  **Breaking change** heading.
+- Removing or narrowing a request is non-breaking and needs no rollout.
+
+Incident [#698](https://github.com/vergil-project/vergil-actions/issues/698)
+is the cautionary tale: v2.1.3 added `actions: read` to `ci-security.yml`'s
+request and broke every consumer of `@v2.1` at the moment of promote.
+Follow-ups
+[#699](https://github.com/vergil-project/vergil-actions/issues/699)
+(consumer-refresh release stage) and
+[#700](https://github.com/vergil-project/vergil-actions/issues/700)
+(release-gate permissions diff) track automating this policy.
+
 ## Testing via self-referencing CI
 
 This repository tests its own actions by using local path references in the CI

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -67,6 +67,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     with:
       language: python
 ```

--- a/docs/site/docs/workflows/ci-security.md
+++ b/docs/site/docs/workflows/ci-security.md
@@ -29,6 +29,22 @@ repositories do not need it, but reusable-workflow jobs can only downgrade
 caller permissions, so the caller must grant it for the workflow-level
 grant to take effect.
 
+### Upgrading from v2.1.2 or earlier
+
+v2.1.3 added `actions: read` to this workflow's `permissions:` request.
+GitHub validates the request against the calling job's **effective**
+permissions at startup, so a caller whose `security:` job carries an
+explicit `permissions:` block (the standard posture) must add
+`actions: read` to that job-level block — the job block fully replaces
+any workflow-level block in the caller, so a workflow-level grant alone
+is not sufficient. Callers without the grant fail with `startup_failure`
+and no registered checks.
+
+The grant is backward-compatible with earlier releases, so it can merge
+before the workflow pin moves to v2.1.3. See
+[#698](https://github.com/vergil-project/vergil-actions/issues/698) for
+the incident that motivated this note.
+
 ## Jobs and check names
 
 | Job | Check name | Condition |

--- a/docs/site/docs/workflows/index.md
+++ b/docs/site/docs/workflows/index.md
@@ -57,9 +57,16 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      actions: read
     with:
       language: python
 ```
+
+A called workflow's own `permissions:` blocks are **requests against the
+caller**: GitHub validates at workflow startup that the calling job's
+effective permissions cover every requested scope, and rejects the run with
+`startup_failure` if they do not. See each workflow's page for the scopes
+it requests.
 
 ## Container image prefix
 

--- a/releases/v2.1.3.md
+++ b/releases/v2.1.3.md
@@ -1,6 +1,25 @@
 
 # Release 2.1.3 (2026-06-06)
 
+## Breaking change — ci-security.yml callers must grant `actions: read`
+
+This release adds `actions: read` to the `permissions:` request of the
+reusable `ci-security.yml` workflow. GitHub validates that request against
+the calling job's permissions at workflow startup, so **every caller must
+add `actions: read` to the `permissions:` block of the job that calls
+`ci-security.yml` before consuming this release**. Callers without the
+grant fail at startup, with no checks registered:
+
+> The workflow is requesting 'actions: read', but is only allowed
+> 'actions: none'.
+
+The grant is backward-compatible with v2.1.2 (callers may grant more than
+a called workflow requests), so consumers can land it before upgrading.
+The `v2.1` rolling tag was rolled back to v2.1.2 when this release first
+broke consumers, and is re-promoted once all consumers carry the grant.
+Full incident analysis and rollout plan:
+[#698](https://github.com/vergil-project/vergil-actions/issues/698).
+
 ## Bug fixes
 
 - **grant actions: read and add upload-sarif artifact fallback (#694)**


### PR DESCRIPTION
# Pull Request

## Summary

- Breaking-change callout for v2.1.3, migration note, caller-contract policy, and the caller examples cc01d533 missed.

## Issue Linkage

- Ref #698

## Notes

- >-