### PR TITLE
fix(trivy): pull from GHCR mirror with retry; bump to 0.71.0

### DIFF
--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -43,9 +43,12 @@ inputs:
     default: ""
   trivy-image:
     description: >-
-      Docker image to use for Trivy. Override to pin a specific version.
+      Docker image to use for Trivy. Defaults to the GitHub Container
+      Registry mirror (ghcr.io/aquasecurity/trivy) rather than Docker Hub
+      to avoid Docker Hub's anonymous pull rate limits and transient
+      registry timeouts. Override to pin a specific version or registry.
     required: false
-    default: "aquasec/trivy:0.70.0"
+    default: "ghcr.io/aquasecurity/trivy:0.71.0"
   upload-sarif:
     description: >-
       Upload SARIF results to GitHub code scanning. Set to "false" on
@@ -57,6 +60,36 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Pull Trivy image (with retry)
+      if: >-
+        inputs.scan-type == 'fs' || inputs.scan-type == 'image' ||
+        inputs.scan-type == 'sbom'
+      shell: bash
+      env:
+        TRIVY_IMAGE: ${{ inputs.trivy-image }}
+      run: |
+        # Pull the Trivy image up front with bounded retry/backoff so a
+        # transient registry hiccup (timeout, rate limit) does not fail the
+        # whole scan. Subsequent `docker run` steps reuse this local image
+        # and so do not trigger their own pulls. See issue #705.
+        set -euo pipefail
+        max_attempts=3
+        attempt=1
+        while true; do
+          if docker pull "$TRIVY_IMAGE"; then
+            echo "Pulled $TRIVY_IMAGE"
+            break
+          fi
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "::error::Failed to pull $TRIVY_IMAGE after $max_attempts attempts" >&2
+            exit 1
+          fi
+          backoff=$((attempt * 10))
+          echo "::warning::Pull of $TRIVY_IMAGE failed (attempt $attempt/$max_attempts); retrying in ${backoff}s" >&2
+          sleep "$backoff"
+          attempt=$((attempt + 1))
+        done
+
     - name: Run Trivy filesystem scan
       if: inputs.scan-type == 'fs'
       shell: bash


### PR DESCRIPTION
# Pull Request

## Summary

- Default the shared Trivy action to the GHCR mirror (ghcr.io/aquasecurity/trivy:0.71.0) and add a bounded pull-with-backoff step, so transient Docker Hub timeouts and anonymous rate limits no longer turn the security/trivy check red.

## Issue Linkage

- Ref #705

## Notes

- Registry change is the primary fix: GHCR sidesteps Docker Hub's anonymous pull limits and needs no Hub-token secret in consuming repos. The retry step is a registry-agnostic backstop and runs once up front; the three scan steps reuse the local image. The secondary upload-sarif 'Requires authentication' symptom from the issue is already addressed in ci-security.yml via 'actions: read' (#693) — no change needed here. Final acceptance criterion (green on a consuming repo's CI) requires a downstream PR after this lands and is tagged.