### PR TITLE
chore(settings): point plugin marketplace at main (single released channel)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "main"
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Switches vergil-actions's vergil-marketplace registration to ref main per the single released-channel distribution model (epic #45).

## Issue Linkage

- Ref #711

## Notes

- One-line .claude/settings.json change (marketplace ref -> main). Warns-but-passes on the #1974 audit bridge until the full sweep completes. Ref vergil-project/.github#45.