### PR TITLE
fix(cd): name release job "release / release" to match confirm-main gate

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   release:
-    name: "cd / release"
+    name: "release / release"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container: ghcr.io/vergil-project/prod-base:latest

--- a/docs/specs/2026-05-09-cicd-workflow-convention-design.md
+++ b/docs/specs/2026-05-09-cicd-workflow-convention-design.md
@@ -121,7 +121,7 @@ The change is caused by the `ci.yml` caller job key changing from
 
 | Workflow | Check name |
 |---|---|
-| `cd-release.yml` | `cd / release` |
+| `cd-release.yml` | `release / release` |
 | `cd-docs.yml` | `cd / docs` |
 
 ---


### PR DESCRIPTION
# Pull Request

## Summary

- Rename the CD release job from 'cd / release' to 'release / release' so vergil-tooling's hardened confirm-main gate (exact-match, #1853) matches, fixing the stall that half-applied the 2.1.6 release.

## Issue Linkage

- Ref #717

## Notes

- Only the inline release job's display name changes; its steps (freeze-refs + tag-and-release) are unchanged, and it now aligns with the sibling docs job's 'docs / docs'. The 2026-05-09 workflow-convention spec's CD-checks table is updated to match. Unblocks releases; the 2.1.7 bump that abandons stalled 2.1.6 follows in #718.