### PR TITLE
chore(gitignore): ignore .vergil/ tooling state dir (#730)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ build/
 
 # Parallel AI agent worktrees (see CLAUDE.md)
 .worktrees/
+
+# Vergil tooling scratch dir
+.vergil/


### PR DESCRIPTION
# Pull Request

## Summary

- Add .vergil/ to .gitignore so the untracked tooling state dir (pr-workflow.json, vrg-validate/finalize logs) no longer marks every worktree dirty, aligning vergil-actions with the rest of the fleet.

## Issue Linkage

- Ref #730

## Notes

- One-line .gitignore addition. Fixes the untracked .vergil/ that made git status --porcelain report worktrees dirty, tripping the removable gate in vrg-worktree-status/vrg-finalize-pr so merged worktrees were never reaped. Fleet-wide drift guard is tracked in vergil-tooling Ref #1577. Parent Ref #710.