### PR TITLE
feat(workflows): add reusable ops-epic-rollup workflow

### DIFF
--- a/.github/workflows/ops-epic-rollup.yml
+++ b/.github/workflows/ops-epic-rollup.yml
@@ -1,0 +1,55 @@
+name: Ops — Epic Rollup
+
+on:
+  workflow_call:
+    inputs:
+      container-prefix:
+        type: string
+        required: false
+        default: prod
+        description: >-
+          Container image name prefix (prod or dev). Defaults to "prod".
+      epic-repo:
+        type: string
+        required: false
+        default: .github
+        description: >-
+          Repo within the caller's org that holds epics. The App token is
+          scoped to this repo so rollup can close the cross-repo parent epic.
+          Defaults to ".github".
+    secrets:
+      APP_CLIENT_ID:
+        required: true
+      APP_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  epic-rollup:
+    name: epic-rollup
+    runs-on: ubuntu-latest
+    container: ghcr.io/vergil-project/${{ inputs.container-prefix || 'prod' }}-base:latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ github.event.repository.name }}
+            ${{ inputs.epic-repo }}
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install vergil-tooling
+        uses: ./actions/shared/setup/vergil
+
+      - name: Roll up parent epic
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: vrg-epic-rollup --task "${{ github.repository }}#${{ github.event.issue.number }}"


### PR DESCRIPTION
# Pull Request

## Summary

- Adds ops-epic-rollup.yml, a reusable on: issues.closed workflow that runs vrg-epic-rollup to close a just-closed task's parent epic cross-repo, parameterizing the epic repo and App token so it works across all three orgs.

## Issue Linkage

- Ref #732

## Notes

- Mirrors the ops-github-config.yml App-token pattern (App token scoped to caller repo + epic-repo input, default .github; each org's thin caller passes its own APP_CLIENT_ID/APP_PRIVATE_KEY). Reads github.event.issue.number from the caller's issues.closed event and runs 'vrg-epic-rollup --task <repo>#<n>', which is a no-op unless the closed issue has an epic-labeled non-standing parent. Validation (actionlint et al.) passes green.

Dependencies: vrg-epic-rollup ships in vergil-tooling#2042 (on develop, not yet released); the thin caller is vergil-tooling#2052. Consumers must pin a vergil.toml version that includes vrg-epic-rollup.

Scope note: no site/README docs added — matches the ops-github-config.yml precedent, which carries no doc footprint. Flagging in case an Ops section in the workflows README is wanted as a follow-up.