### PR TITLE
fix(cd-docs): fully-qualify the nested cd-docs reusable ref

### DIFF
--- a/.github/workflows/cd-docs-refresh.yml
+++ b/.github/workflows/cd-docs-refresh.yml
@@ -32,7 +32,10 @@ permissions:
 
 jobs:
   refresh:
-    uses: ./.github/workflows/cd-docs.yml
+    # Fully-qualified so this nested reusable resolves when cd-docs-refresh is
+    # called cross-repo (a relative ./ ref does not); @develop is frozen to the
+    # release tag by vrg-freeze-refs at release time.
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@develop
     permissions:
       contents: write
     with:


### PR DESCRIPTION
# Pull Request

## Summary

- cd-docs-refresh.yml nested cd-docs.yml via a relative ./ ref, which does not resolve when the reusable workflow is called cross-repo (startup failure: 'workflow was not found') and is never frozen; change it to a fully-qualified @develop ref that the release freeze pins to the tag.

## Issue Linkage

- Closes #751

## Notes

- Under the vergil-actions ad-hoc epic (vergil-project/.github#102). Fixes the daily cd-docs-refresh failure in org docs repos — needs a v2.1.X release to reach them, then a workflow_dispatch on docs confirms it end-to-end. Companion systemic fix: vergil-tooling#2177 (freeze relative workflow refs).