### PR TITLE
feat(ci): emit ci-evidence-<gate> artifacts from gate workflows

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -51,3 +51,23 @@ jobs:
 
       - name: Run dependency audit
         run: vrg-validate --check audit
+
+  evidence:
+    name: evidence
+    # Runs only after every matrix audit job succeeds, so the artifact's
+    # presence is itself proof the audit gate passed. Report files (audit /
+    # license JSON) are collected when the audit command emits them; until then
+    # the artifact carries evidence.json alone.
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Emit ci-evidence-audit artifact
+        uses: ./actions/ci/evidence/emit
+        with:
+          gate: audit
+          files: |
+            pip-audit.json
+            licenses.json

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -85,3 +85,20 @@ jobs:
 
       - name: Run typecheck
         run: vrg-validate --check typecheck
+
+  evidence:
+    name: evidence
+    # Runs only after the common, lint, and typecheck jobs all succeed, so the
+    # artifact's presence is itself proof the quality gate passed. Lint and
+    # typecheck report to stdout and emit no files today; the artifact carries
+    # evidence.json alone, which is sufficient for completeness.
+    needs: [common, lint, typecheck]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Emit ci-evidence-quality artifact
+        uses: ./actions/ci/evidence/emit
+        with:
+          gate: quality

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -92,6 +92,17 @@ jobs:
         with:
           language: ${{ inputs.language }}
 
+      # Upload the CodeQL SARIF as an evidence partial UNCONDITIONALLY —
+      # independent of the code-scanning upload — so the release harvester
+      # reads artifacts only and never touches the code-scanning API (spec §7).
+      - name: Upload CodeQL SARIF evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-security-part-codeql
+          path: ${{ runner.temp }}/codeql-sarif
+          if-no-files-found: warn
+
   trivy:
     name: trivy
     if: ${{ inputs.run-security }}
@@ -109,6 +120,16 @@ jobs:
         with:
           scan-type: fs
           upload-sarif: ${{ inputs.upload-sarif }}
+
+      # Upload the Trivy SARIF as an evidence partial UNCONDITIONALLY, whether
+      # or not it was also pushed to code scanning (spec §7).
+      - name: Upload Trivy SARIF evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-security-part-trivy
+          path: trivy-results.sarif
+          if-no-files-found: warn
 
   semgrep:
     name: semgrep
@@ -131,3 +152,47 @@ jobs:
         with:
           language: ${{ inputs.language }}
           upload-sarif: ${{ inputs.upload-sarif }}
+
+      # Upload the Semgrep SARIF as an evidence partial UNCONDITIONALLY, whether
+      # or not it was also pushed to code scanning (spec §7).
+      - name: Upload Semgrep SARIF evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-security-part-semgrep
+          path: semgrep-results.sarif
+          if-no-files-found: warn
+
+  evidence:
+    name: evidence
+    # Consolidate every scanner's SARIF partial into the single
+    # ci-evidence-security artifact the harvester expects. Runs once the
+    # scanners have settled: trivy and semgrep must have passed, and codeql
+    # must have passed or been legitimately skipped (no GHAS / run-codeql
+    # false). A failed scanner means the security gate failed, so no evidence
+    # is emitted and — per the publish invariant — nothing is released.
+    needs: [codeql, trivy, semgrep]
+    if: >-
+      ${{ always() && needs.trivy.result == 'success' &&
+      needs.semgrep.result == 'success' &&
+      (needs.codeql.result == 'success' || needs.codeql.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download scanner SARIF partials
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ci-evidence-security-part-*
+          path: security-sarif
+          merge-multiple: true
+
+      - name: Emit ci-evidence-security artifact
+        uses: ./actions/ci/evidence/emit
+        with:
+          gate: security
+          files: security-sarif/*.sarif

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -51,3 +51,23 @@ jobs:
 
       - name: Run unit tests
         run: vrg-validate --check test
+
+  evidence:
+    name: evidence
+    # Runs only after every matrix unit job succeeds, so the artifact's presence
+    # is itself proof the test gate passed. Report files (coverage.xml,
+    # junit.xml) are collected when the test command emits them; until then the
+    # artifact carries evidence.json alone, which is sufficient for completeness.
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Emit ci-evidence-test artifact
+        uses: ./actions/ci/evidence/emit
+        with:
+          gate: test
+          files: |
+            coverage.xml
+            junit.xml

--- a/actions/ci/evidence/emit/action.yml
+++ b/actions/ci/evidence/emit/action.yml
@@ -1,0 +1,97 @@
+name: Emit CI evidence artifact
+description: >-
+  Writes an evidence.json fragment and uploads a gate's report files as a
+  ci-evidence-<gate> workflow-run artifact, so the release-time harvester
+  (vrg-ci-evidence) can bundle durable, attested per-gate evidence. Additive
+  and harmless: the artifact is always produced (evidence.json is always
+  present) and missing report files are skipped, never fatal.
+
+inputs:
+  gate:
+    description: >-
+      Evidence gate name — one of "security", "test", "audit", "quality".
+      Determines the artifact name (ci-evidence-<gate>) and the evidence.json
+      "gate" field.
+    required: true
+  files:
+    description: >-
+      Newline- or space-separated list of report file paths or globs to include
+      in the artifact alongside evidence.json (e.g. SARIF, coverage XML, JUnit
+      XML). Entries that match no file are skipped — never fatal — so a gate
+      that does not yet emit report files still produces a valid artifact.
+    required: false
+    default: ""
+  tools:
+    description: >-
+      JSON array of tool descriptors for the evidence.json "tools" field
+      (e.g. '[{"name":"codeql","version":"2.17.0"}]'). Defaults to an empty
+      array; enrich as gates learn to report their tool versions.
+    required: false
+    default: "[]"
+  metrics:
+    description: >-
+      JSON object for the evidence.json "metrics" field (e.g. coverage percent,
+      finding counts). Defaults to an empty object.
+    required: false
+    default: "{}"
+
+runs:
+  using: composite
+  steps:
+    - name: Stage evidence fragment and report files
+      id: stage
+      shell: bash
+      env:
+        GATE: ${{ inputs.gate }}
+        FILES: ${{ inputs.files }}
+        TOOLS: ${{ inputs.tools }}
+        METRICS: ${{ inputs.metrics }}
+      run: |
+        set -euo pipefail
+
+        staging="${RUNNER_TEMP}/ci-evidence-${GATE}"
+        rm -rf "$staging"
+        mkdir -p "$staging"
+
+        # Collect report files. FILES may be newline- or space-separated and
+        # may contain globs; entries matching no file are silently skipped so a
+        # gate without report files still yields a valid (evidence.json-only)
+        # artifact.
+        collected=()
+        while IFS= read -r pattern; do
+          [ -z "$pattern" ] && continue
+          # Intentional word-splitting + globbing of the pattern.
+          # shellcheck disable=SC2086
+          for match in $pattern; do
+            if [ -f "$match" ]; then
+              cp "$match" "$staging/"
+              collected+=("$(basename "$match")")
+            fi
+          done
+        done <<< "${FILES//$'\t'/ }"
+
+        # Build the evidence.json "files" array from the collected basenames.
+        if [ "${#collected[@]}" -gt 0 ]; then
+          files_json="$(printf '%s\n' "${collected[@]}" | jq -R . | jq -cs .)"
+        else
+          files_json="[]"
+        fi
+
+        jq -n \
+          --arg gate "$GATE" \
+          --argjson tools "$TOOLS" \
+          --argjson metrics "$METRICS" \
+          --argjson files "$files_json" \
+          '{gate: $gate, tools: $tools, metrics: $metrics, files: $files}' \
+          > "$staging/evidence.json"
+
+        echo "staging=$staging" >> "$GITHUB_OUTPUT"
+        echo "Staged ci-evidence-${GATE}:"
+        ls -la "$staging"
+
+    - name: Upload evidence artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ci-evidence-${{ inputs.gate }}
+        path: ${{ steps.stage.outputs.staging }}
+        if-no-files-found: error


### PR DESCRIPTION
# Pull Request

## Summary

- Add a shared actions/ci/evidence/emit composite and wire it into the ci-test, ci-audit, ci-quality, and ci-security gate workflows so every required gate uploads a single ci-evidence-<gate> artifact (with security's SARIF captured unconditionally) for the release-time harvester.

## Issue Linkage

- Closes #762

## Notes

- Task T8 of epic vergil-project/.github#140. Design notes for review:

- One artifact per gate via a dedicated needs-gated 'evidence' job, because upload-artifact forbids same-name uploads across a gate's matrix/multi-job structure. The evidence job runs only after the gate's checks succeed, so the artifact's presence is itself proof the gate passed.
- Security consolidates: codeql/trivy/semgrep each upload their SARIF as an evidence partial UNCONDITIONALLY (independent of code-scanning upload), and a consolidation job merges the partials into the single ci-evidence-security. Harvester reads artifacts only, no code-scanning API (spec section 7).
- Verification is live-PR only (workflow YAML has no unit-test surface). vrg-validate (actionlint/yamllint) passes. On THIS repo's own CI only the quality and security gates run (language: shell), so this PR's run exercises ci-evidence-quality and ci-evidence-security directly; ci-evidence-test and ci-evidence-audit are only exercised by consumer repos (e.g. vergil-tooling).

Assumption flagged: vrg-validate's Python check commands do NOT currently write report files to disk (pytest has no --cov-report=xml/--junitxml; pip-audit has no --output). So test/audit/quality artifacts carry evidence.json alone today. The emit composite globs coverage.xml/junit.xml/pip-audit.json/licenses.json forward-compatibly; a companion vergil-tooling change to languages.py must add report-file emission to those check commands before those files appear in the bundle. Only the security SARIFs are real report files today.

Action versions: matched the repo's pins (actions/upload-artifact@v7, actions/checkout@v6) and used actions/download-artifact@v7 by the same convention; if v7 download does not exist at runtime it is a trivial version bump surfaced on the live run.