### PR TITLE
feat(cd): harvest, attest, and attach CI evidence (warning mode)

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -43,6 +43,15 @@ on:
         description: Files to attach to release ($VERSION placeholder).
         type: string
         default: ""
+      evidence-enforce:
+        description: >-
+          CI-evidence gate fatality. false (default) = WARNING mode: the
+          evidence step never aborts the release. true = ENFORCING mode:
+          incomplete evidence fails the release (spec §9.2). Promotion to
+          enforcing is a single human-gated flip of this one default (Task
+          T11) — it also flips the step's continue-on-error automatically.
+        type: boolean
+        default: false
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -73,6 +82,11 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # Required so the CI-evidence harvest can list and download the release
+      # PR's ci-evidence-* artifacts from its (separate) CI run (spec §5.2).
+      # The consuming repo's cd.yml must grant this scope too — a reusable
+      # workflow's permissions are capped by the caller.
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -106,6 +120,33 @@ jobs:
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # Evidence-first (spec §9): the CI-evidence gate runs before build/publish
+      # and tag-and-release so that, once enforcing, nothing publishes without
+      # complete attested evidence. Ships in WARNING mode — continue-on-error
+      # tracks the evidence-enforce flag so a rare attest failure (a composite
+      # `uses:` step that the composite's own shell wrapper cannot catch) still
+      # never aborts the release. Promotion (T11) flips evidence-enforce alone.
+      - name: Resolve SBOM path for evidence
+        id: evidence_sbom
+        if: >-
+          steps.tag_check.outputs.exists == 'false' &&
+          inputs.sbom-output-file != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SBOM_OUTPUT_FILE: ${{ inputs.sbom-output-file }}
+        run: |
+          echo "path=${SBOM_OUTPUT_FILE//\$VERSION/$VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Harvest, attest, and attach CI evidence
+        if: steps.tag_check.outputs.exists == 'false'
+        continue-on-error: ${{ !inputs.evidence-enforce }}
+        uses: ./actions/cd/release/ci-evidence
+        with:
+          version: ${{ steps.version.outputs.version }}
+          tag: ${{ steps.version.outputs.tag }}
+          enforce: ${{ inputs.evidence-enforce }}
+          sbom-file: ${{ steps.evidence_sbom.outputs.path }}
 
       - name: Resolve release artifacts
         if: >-

--- a/actions/cd/release/ci-evidence/action.yml
+++ b/actions/cd/release/ci-evidence/action.yml
@@ -1,0 +1,129 @@
+name: CI evidence bundle
+description: >-
+  Harvest, validate, attest, and attach the CI evidence bundle for a release.
+  Runs FIRST in cd-release (evidence-first) so that, once enforcing, no package,
+  tag, or Release is created without complete attested evidence. Ships in
+  WARNING mode: with enforce=false any failure or timeout is non-fatal and the
+  release always proceeds. Promotion to enforcing (enforce=true) is a single
+  human-gated flag flip — the step's position and steps are identical in both
+  modes. See epic vergil-project/.github#140 spec §9, §9.2, §10.
+
+inputs:
+  version:
+    description: Semver version string (e.g. 2.1.129).
+    required: true
+  tag:
+    description: Release tag the bundle is attached to (e.g. v2.1.129).
+    required: true
+  enforce:
+    description: >-
+      Fatality mode. "false" (default, WARNING) — any bundle/attest/upload
+      failure or timeout emits a loud warning and the job succeeds; the release
+      is never aborted. "true" (ENFORCING) — a non-zero vrg-ci-evidence exit
+      (substantive incompleteness) fails the job, gating publish.
+    required: false
+    default: "false"
+  timeout-minutes:
+    description: >-
+      Upper bound (minutes) on the harvest+bundle step. Composite steps cannot
+      use the step-level timeout-minutes key, so the bound is enforced with the
+      coreutils `timeout` command; a timeout is treated as a bundle failure
+      (non-fatal in warning mode, fatal in enforcing mode).
+    required: false
+    default: "15"
+  sbom-file:
+    description: >-
+      Path to an already-built SBOM in the CD workspace. Included in the bundle
+      when present so the bundle is self-contained; silently skipped when empty
+      or not yet materialized at this point in the pipeline.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Harvest and bundle CI evidence
+      id: bundle
+      shell: bash
+      env:
+        ENFORCE: ${{ inputs.enforce }}
+        TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        MERGE_SHA: ${{ github.sha }}
+        VERSION: ${{ inputs.version }}
+        SBOM_FILE: ${{ inputs.sbom-file }}
+      run: |
+        # Non-fatal by construction: capture the exit code explicitly instead of
+        # letting `set -e` (GitHub's default for composite bash) abort the step,
+        # so warning mode can convert any failure into a ::warning:: and exit 0.
+        set +e
+        generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+        sbom_args=()
+        if [ -n "$SBOM_FILE" ]; then
+          if [ -f "$SBOM_FILE" ]; then
+            sbom_args+=(--sbom-file "$SBOM_FILE")
+          else
+            echo "::notice::SBOM $SBOM_FILE not present yet; bundling without it"
+          fi
+        fi
+
+        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence bundle \
+          --repo "$REPO" \
+          --version "$VERSION" \
+          --merge-sha "$MERGE_SHA" \
+          --generated-at "$generated_at" \
+          --out-dir evidence-out \
+          "${sbom_args[@]}"
+        rc=$?
+
+        if [ "$rc" -eq 0 ]; then
+          echo "bundled=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "bundled=false" >> "$GITHUB_OUTPUT"
+        if [ "$rc" -eq 124 ]; then
+          reason="timed out after ${TIMEOUT_MINUTES}m"
+        else
+          reason="failed (exit $rc)"
+        fi
+
+        if [ "$ENFORCE" = "true" ]; then
+          echo "::error::CI evidence bundling $reason — enforcing mode: failing the release" >&2
+          exit "$rc"
+        fi
+        echo "::warning::CI evidence bundling $reason — warning mode: release proceeds without a complete evidence bundle" >&2
+        exit 0
+
+    - name: Attest evidence bundle provenance
+      if: steps.bundle.outputs.bundled == 'true'
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-path: evidence-out/*.tar.gz
+
+    - name: Attach evidence bundle to release
+      if: steps.bundle.outputs.bundled == 'true'
+      shell: bash
+      env:
+        ENFORCE: ${{ inputs.enforce }}
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set +e
+        gh release upload "$TAG" \
+          evidence-out/*.tar.gz \
+          evidence-out/*-manifest.json \
+          --clobber
+        rc=$?
+
+        if [ "$rc" -eq 0 ]; then
+          exit 0
+        fi
+        if [ "$ENFORCE" = "true" ]; then
+          echo "::error::Attaching CI evidence bundle to release $TAG failed (exit $rc) — enforcing mode" >&2
+          exit "$rc"
+        fi
+        echo "::warning::Attaching CI evidence bundle to release $TAG failed (exit $rc) — warning mode: release proceeds" >&2
+        exit 0


### PR DESCRIPTION
# Pull Request

## Summary

- Add the actions/cd/release/ci-evidence composite and wire it as the first publish step of cd-release.yml, shipping the CI-evidence gate in non-fatal, timeout-bounded warning mode with build-provenance attestation.

## Issue Linkage

- Closes #769

## Notes

- Task T9 of epic vergil-project/.github#140 (spec §9, §9.2, §5.2, §10).

WHAT
- New composite actions/cd/release/ci-evidence/action.yml: vrg-ci-evidence bundle -> actions/attest-build-provenance over the bundle digest -> gh release upload <tag> *.tar.gz *-manifest.json --clobber. Inputs: enforce (default false), timeout-minutes (default 15), version, tag, sbom-file.
- cd-release.yml: added evidence-enforce workflow input (boolean, default false); added actions: read to the release job permissions (spec §5.2); inserted the evidence step FIRST among publish steps (after tag_check, before build/publish and tag-and-release), gated on a new tag.

WARNING-MODE WRAPPER MECHANISM (verify this reasoning)
- Composite steps support neither continue-on-error nor timeout-minutes, so: (1) the bundle+upload steps are bash steps that set +e (GitHub's default composite shell is -eo pipefail), capture rc explicitly, and in warning mode convert any failure/timeout into ::warning:: and exit 0 -> these steps can never fail the job; (2) timeout is enforced with the coreutils timeout command (rc 124 handled); (3) the attest step is a uses: step a composite cannot wrap, so the call-site continue-on-error: ${{ !inputs.evidence-enforce }} absorbs a rare attest-service failure. Net: warning mode NEVER aborts the release. In enforcing mode, continue-on-error is false and a non-zero vrg-ci-evidence exit fails the job.
- Promotion to enforcing (Task T11) is a single-flag flip: evidence-enforce false -> true drives both enforce (composite fatality) and continue-on-error. Step position/code identical in both modes.

ASSUMPTIONS / THINGS TO NOTE
- SBOM path: passed best-effort. sbom-file is resolved from the sbom-output-file input ($VERSION expanded) and included only if the file exists; at the evidence-first position the SBOM is generated later (registry-publish), so early warning-mode bundles typically omit it. Non-fatal; to be reconciled during bake-in.
- Ordering nuance: gh release upload runs at evidence-first position, before tag-and-release creates the Release, so the upload will warn until ordering is reconciled during live verification. This is the deferred live check the issue calls out and is exactly what warning mode absorbs.
- Companion change (separate repo, out of scope here): vergil-tooling's cd.yml must grant actions: read to the job calling cd-release, since a reusable workflow's permissions are capped by the caller.
- Live warning-mode verification (a real bundle attached to a release, plus an induced evidence failure that warns without aborting) happens on the next vergil-tooling release once vrg-ci-evidence is in a released tag — safe because warning mode is non-fatal.

VERIFICATION
- vrg-container-run -- vrg-validate green (actionlint, yamllint, markdownlint). Workflow YAML has no unit-test surface.