### PR TITLE
fix(docs): pass GH_TOKEN to the docs stage step so evidence links resolve

### DIFF
--- a/actions/shared/docs/stage/action.yml
+++ b/actions/shared/docs/stage/action.yml
@@ -26,6 +26,11 @@ runs:
       working-directory: ${{ github.workspace }}
       env:
         MKDOCS_CONFIG: ${{ inputs.mkdocs-config }}
+        # vrg-docs-stage links each release page to its CI-evidence bundle via
+        # `gh release view`, which needs an authenticated gh. Both docs
+        # workflows grant the permission (ci-docs: contents:read; cd-docs:
+        # contents:write); wire the token so gh is authenticated. Issue #770.
+        GH_TOKEN: ${{ github.token }}
       run: |
         vrg-docs-stage --docs-dir "$(dirname "$MKDOCS_CONFIG")/docs"
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add GH_TOKEN: ${{ github.token }} to the 'Stage changelog and release notes' step's env block so vrg-docs-stage can authenticate gh for its 'gh release view' evidence lookups.

## Issue Linkage

- Closes #770

## Notes

- One-line env addition (plus an explanatory comment) in actions/shared/docs/stage/action.yml. Both docs workflows already grant the required contents permission (ci-docs: read, cd-docs: write), so the token is all that was missing. Verified the sibling nav-patch step (vrg-docs-patch-nav) makes no gh calls and needs no token. vrg-docs-stage stays strict. Must be released to the 2.1 tag before the T6 docs-stage change can pass CI.