### PR TITLE
fix(cd): split cd-release evidence into pre-publish gate + post-release attach

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -121,12 +121,20 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Evidence-first (spec §9): the CI-evidence gate runs before build/publish
-      # and tag-and-release so that, once enforcing, nothing publishes without
-      # complete attested evidence. Ships in WARNING mode — continue-on-error
-      # tracks the evidence-enforce flag so a rare attest failure (a composite
-      # `uses:` step that the composite's own shell wrapper cannot catch) still
-      # never aborts the release. Promotion (T11) flips evidence-enforce alone.
+      # Evidence-first (spec §9), split in two so the bundle is both gated before
+      # publish AND self-contained + attachable after it:
+      #   * GATE (here, pre-publish) — resolve the release PR, harvest the
+      #     required gate evidence, and validate completeness. Once enforcing,
+      #     incomplete evidence fails the release here, before anything is built,
+      #     tagged, or released.
+      #   * ATTACH (below, after tag-and-release) — assemble the complete bundle
+      #     (now including the built SBOM), attest it, and upload it to the
+      #     Release that now exists as the upload target.
+      # Both steps ship in WARNING mode: continue-on-error tracks the
+      # evidence-enforce flag so even a failure the composite's shell wrapper
+      # cannot catch (a `uses:` attest step) never aborts the release. Promotion
+      # to enforcing (T11) is a single flip of the evidence-enforce default — it
+      # flips both steps' fatality and both continue-on-error guards at once.
       - name: Resolve SBOM path for evidence
         id: evidence_sbom
         if: >-
@@ -138,15 +146,13 @@ jobs:
         run: |
           echo "path=${SBOM_OUTPUT_FILE//\$VERSION/$VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Harvest, attest, and attach CI evidence
+      - name: CI evidence gate (pre-publish)
         if: steps.tag_check.outputs.exists == 'false'
         continue-on-error: ${{ !inputs.evidence-enforce }}
-        uses: ./actions/cd/release/ci-evidence
+        uses: ./actions/cd/release/ci-evidence-gate
         with:
           version: ${{ steps.version.outputs.version }}
-          tag: ${{ steps.version.outputs.tag }}
           enforce: ${{ inputs.evidence-enforce }}
-          sbom-file: ${{ steps.evidence_sbom.outputs.path }}
 
       - name: Resolve release artifacts
         if: >-
@@ -185,6 +191,20 @@ jobs:
         with:
           version: ${{ steps.version.outputs.version }}
           release-artifacts: ${{ steps.resolved.outputs.release-artifacts }}
+
+      # Post-publish attach (spec §9): the Release now exists (upload target) and
+      # the SBOM has been built by registry-publish (bundle content), so the
+      # bundle the pre-publish gate could only validate can now be assembled in
+      # full, attested, and attached. Same WARNING-mode contract as the gate.
+      - name: Attach CI evidence bundle (post-release)
+        if: steps.tag_check.outputs.exists == 'false'
+        continue-on-error: ${{ !inputs.evidence-enforce }}
+        uses: ./actions/cd/release/ci-evidence-attach
+        with:
+          version: ${{ steps.version.outputs.version }}
+          tag: ${{ steps.version.outputs.tag }}
+          enforce: ${{ inputs.evidence-enforce }}
+          sbom-file: ${{ steps.evidence_sbom.outputs.path }}
 
       - name: Verify tag is resolvable from remote
         if: steps.tag_check.outputs.exists == 'false'

--- a/actions/cd/release/ci-evidence-attach/action.yml
+++ b/actions/cd/release/ci-evidence-attach/action.yml
@@ -1,12 +1,15 @@
-name: CI evidence bundle
+name: CI evidence attach
 description: >-
-  Harvest, validate, attest, and attach the CI evidence bundle for a release.
-  Runs FIRST in cd-release (evidence-first) so that, once enforcing, no package,
-  tag, or Release is created without complete attested evidence. Ships in
-  WARNING mode: with enforce=false any failure or timeout is non-fatal and the
-  release always proceeds. Promotion to enforcing (enforce=true) is a single
-  human-gated flag flip — the step's position and steps are identical in both
-  modes. See epic vergil-project/.github#140 spec §9, §9.2, §10.
+  Post-publish CI-evidence attach: assemble the complete evidence bundle — now
+  including the already-built SBOM — attest it to the pipeline and released
+  commit, and attach it to the GitHub Release that tag-and-release just created.
+  Runs AFTER tag-and-release (spec §9): the pre-publish completeness gate is done
+  by ci-evidence-gate, and by this point both the Release (upload target) and the
+  SBOM (bundle content) exist. Ships in WARNING mode: with enforce=false any
+  failure or timeout is non-fatal and the release always proceeds. Promotion to
+  enforcing (enforce=true) is a single human-gated flag flip — the step's
+  position and steps are identical in both modes. See epic
+  vergil-project/.github#140 spec §9, §9.2, §10.
 
 inputs:
   version:
@@ -20,7 +23,7 @@ inputs:
       Fatality mode. "false" (default, WARNING) — any bundle/attest/upload
       failure or timeout emits a loud warning and the job succeeds; the release
       is never aborted. "true" (ENFORCING) — a non-zero vrg-ci-evidence exit
-      (substantive incompleteness) fails the job, gating publish.
+      (substantive incompleteness) or a failed attach fails the job.
     required: false
     default: "false"
   timeout-minutes:
@@ -33,9 +36,9 @@ inputs:
     default: "15"
   sbom-file:
     description: >-
-      Path to an already-built SBOM in the CD workspace. Included in the bundle
-      when present so the bundle is self-contained; silently skipped when empty
-      or not yet materialized at this point in the pipeline.
+      Path to the SBOM built earlier in the CD job (by registry-publish).
+      Included in the bundle when present so the bundle is self-contained;
+      silently skipped when empty or not materialized.
     required: false
     default: ""
 
@@ -65,7 +68,7 @@ runs:
           if [ -f "$SBOM_FILE" ]; then
             sbom_args+=(--sbom-file "$SBOM_FILE")
           else
-            echo "::notice::SBOM $SBOM_FILE not present yet; bundling without it"
+            echo "::notice::SBOM $SBOM_FILE not present; bundling without it"
           fi
         fi
 

--- a/actions/cd/release/ci-evidence-gate/action.yml
+++ b/actions/cd/release/ci-evidence-gate/action.yml
@@ -1,0 +1,87 @@
+name: CI evidence gate
+description: >-
+  Pre-publish CI-evidence gate: resolve the release PR, harvest the required
+  gate evidence artifacts, and validate completeness — BEFORE anything is
+  published. Runs FIRST in cd-release (evidence-first, spec §9) so that, once
+  enforcing, no package, tag, or Release is created without complete evidence.
+  This step does NOT attest or attach anything: the GitHub Release does not yet
+  exist and the SBOM is not yet built at this point in the pipeline — the
+  ci-evidence-attach composite does that AFTER tag-and-release. Ships in WARNING
+  mode: with enforce=false any failure or timeout is non-fatal and the release
+  always proceeds. Promotion to enforcing (enforce=true) is a single human-gated
+  flag flip. See epic vergil-project/.github#140 spec §9, §9.2, §10.
+
+inputs:
+  version:
+    description: Semver version string (e.g. 2.1.129).
+    required: true
+  enforce:
+    description: >-
+      Fatality mode. "false" (default, WARNING) — an incomplete/failed harvest
+      emits a loud warning and the job succeeds; the release is never aborted.
+      "true" (ENFORCING) — a non-zero vrg-ci-evidence exit (substantive
+      incompleteness) fails the job here, before publish, gating the release
+      (spec §9.2).
+    required: false
+    default: "false"
+  timeout-minutes:
+    description: >-
+      Upper bound (minutes) on the harvest+validate step. Composite steps cannot
+      use the step-level timeout-minutes key, so the bound is enforced with the
+      coreutils `timeout` command; a timeout is treated as a gate failure
+      (non-fatal in warning mode, fatal in enforcing mode).
+    required: false
+    default: "15"
+
+runs:
+  using: composite
+  steps:
+    - name: Harvest and validate CI evidence (pre-publish gate)
+      id: gate
+      shell: bash
+      env:
+        ENFORCE: ${{ inputs.enforce }}
+        TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        MERGE_SHA: ${{ github.sha }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        # Non-fatal by construction: capture the exit code explicitly instead of
+        # letting `set -e` (GitHub's default for composite bash) abort the step,
+        # so warning mode can convert any failure into a ::warning:: and exit 0.
+        #
+        # `vrg-ci-evidence bundle` resolves the release PR, harvests the required
+        # gate artifacts, and validates completeness (raising a non-zero exit on
+        # a missing required gate). We run it here purely as the pre-publish
+        # completeness GATE — the tarball it assembles into the scratch out-dir
+        # is intentionally discarded: the SBOM is not built yet, so the complete,
+        # attested bundle is assembled and attached later by ci-evidence-attach.
+        # No --sbom-file is passed for the same reason.
+        set +e
+        generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence bundle \
+          --repo "$REPO" \
+          --version "$VERSION" \
+          --merge-sha "$MERGE_SHA" \
+          --generated-at "$generated_at" \
+          --out-dir evidence-gate
+        rc=$?
+
+        if [ "$rc" -eq 0 ]; then
+          exit 0
+        fi
+
+        if [ "$rc" -eq 124 ]; then
+          reason="timed out after ${TIMEOUT_MINUTES}m"
+        else
+          reason="failed (exit $rc)"
+        fi
+
+        if [ "$ENFORCE" = "true" ]; then
+          echo "::error::CI evidence gate $reason — enforcing mode: failing the release before publish" >&2
+          exit "$rc"
+        fi
+        echo "::warning::CI evidence gate $reason — warning mode: release proceeds without a validated evidence gate" >&2
+        exit 0


### PR DESCRIPTION
# Pull Request

## Summary

- Split the single cd-release CI-evidence step into a pre-publish completeness gate and a post-tag-and-release attach step so the bundle is both gated before publish and assembled (with the now-built SBOM), attested, and attached to the Release that actually exists.

## Issue Linkage

- Closes #776

## Notes

- Reshapes vergil-actions YAML only; reuses the existing vrg-ci-evidence bundle CLI unchanged (invoked in two phases per the merged T9 design).

Structure:
- ci-evidence-gate (pre-publish, unchanged position, before registry-publish/tag-and-release): runs 'vrg-ci-evidence bundle' with NO --sbom-file into a scratch out-dir purely for its harvest+validate_completeness side effect (the assembled tarball is discarded). No attest/upload.
- ci-evidence-attach (new, immediately after tag-and-release): runs 'vrg-ci-evidence bundle' WITH --sbom-file into evidence-out, then attest-build-provenance, then 'gh release upload --clobber' to the now-existing Release.

Enforce handling (identical in both steps): each shell step uses 'set +e' and captures the exit code; in warning mode (enforce=false) any non-zero/timeout becomes a ::warning:: and exits 0, in enforcing mode it re-exits the code and fails the job. Both call sites set 'continue-on-error: ${{ !inputs.evidence-enforce }}' so even the uses: attest step (which a composite shell wrapper cannot catch) cannot abort a warning-mode release. Promotion to enforcing (T11) remains a pure flip of the evidence-enforce default — it flips both steps' fatality and both continue-on-error guards at once; no restructuring.

Design note: with the current atomic 'bundle' CLI (temp-dir staging, no separate harvest/assemble phase), the two phases each re-run the full harvest rather than literally carrying raw harvested artifacts on disk between steps. The harvest is idempotent (fixed merge-sha/PR/CI run), so this is safe; a future vergil-tooling CLI split into harvest+assemble subcommands could carry artifacts and avoid the second harvest, but that is out of scope for this vergil-actions fix.

Verification: 'vrg-container-run -- vrg-validate' green (markdownlint/shellcheck/yamllint/actionlint). Workflow YAML has no unit-test surface. Live verification of a real attached bundle + 'gh attestation verify' happens once vrg-ci-evidence lands in a released vergil-tooling tag.