### PR TITLE
refactor(cd-release): share one harvest across evidence gate and attach

### DIFF
--- a/actions/cd/release/ci-evidence-attach/action.yml
+++ b/actions/cd/release/ci-evidence-attach/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "false"
   timeout-minutes:
     description: >-
-      Upper bound (minutes) on the harvest+bundle step. Composite steps cannot
+      Upper bound (minutes) on the offline assemble step. Composite steps cannot
       use the step-level timeout-minutes key, so the bound is enforced with the
       coreutils `timeout` command; a timeout is treated as a bundle failure
       (non-fatal in warning mode, fatal in enforcing mode).
@@ -45,21 +45,26 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Harvest and bundle CI evidence
+    - name: Assemble CI evidence bundle
       id: bundle
       shell: bash
       env:
         ENFORCE: ${{ inputs.enforce }}
         TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
-        GH_TOKEN: ${{ github.token }}
-        REPO: ${{ github.repository }}
-        MERGE_SHA: ${{ github.sha }}
         VERSION: ${{ inputs.version }}
         SBOM_FILE: ${{ inputs.sbom-file }}
+        STAGING: ${{ github.workspace }}/.ci-evidence-staging
       run: |
         # Non-fatal by construction: capture the exit code explicitly instead of
         # letting `set -e` (GitHub's default for composite bash) abort the step,
         # so warning mode can convert any failure into a ::warning:: and exit 0.
+        #
+        # `vrg-ci-evidence assemble` is fully network-free: it reads the evidence
+        # and harvest-state.json that ci-evidence-gate already downloaded into the
+        # shared STAGING dir and produces the tarball + standalone manifest into
+        # evidence-out. The release's artifacts were downloaded exactly once, by
+        # the pre-publish gate's harvest. The SBOM, now built by registry-publish,
+        # is folded in here so the bundle is self-contained.
         set +e
         generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -72,10 +77,9 @@ runs:
           fi
         fi
 
-        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence bundle \
-          --repo "$REPO" \
+        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence assemble \
+          --staging "$STAGING" \
           --version "$VERSION" \
-          --merge-sha "$MERGE_SHA" \
           --generated-at "$generated_at" \
           --out-dir evidence-out \
           "${sbom_args[@]}"

--- a/actions/cd/release/ci-evidence-gate/action.yml
+++ b/actions/cd/release/ci-evidence-gate/action.yml
@@ -45,28 +45,27 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         MERGE_SHA: ${{ github.sha }}
-        VERSION: ${{ inputs.version }}
+        STAGING: ${{ github.workspace }}/.ci-evidence-staging
       run: |
         # Non-fatal by construction: capture the exit code explicitly instead of
         # letting `set -e` (GitHub's default for composite bash) abort the step,
         # so warning mode can convert any failure into a ::warning:: and exit 0.
         #
-        # `vrg-ci-evidence bundle` resolves the release PR, harvests the required
-        # gate artifacts, and validates completeness (raising a non-zero exit on
-        # a missing required gate). We run it here purely as the pre-publish
-        # completeness GATE — the tarball it assembles into the scratch out-dir
-        # is intentionally discarded: the SBOM is not built yet, so the complete,
-        # attested bundle is assembled and attached later by ci-evidence-attach.
-        # No --sbom-file is passed for the same reason.
+        # `vrg-ci-evidence harvest` resolves the release PR, downloads the required
+        # gate artifacts, and validates completeness (raising a non-zero exit on a
+        # missing required gate) — the pre-publish completeness GATE. It persists
+        # the downloaded evidence plus harvest-state.json into the shared STAGING
+        # dir on the job workspace; ci-evidence-attach later reads that SAME dir
+        # and assembles the tarball offline (network-free), so the release's
+        # artifacts are downloaded exactly once. The SBOM is not built yet, so no
+        # bundle is produced here.
         set +e
-        generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        mkdir -p "$STAGING"
 
-        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence bundle \
+        timeout "${TIMEOUT_MINUTES}m" vrg-ci-evidence harvest \
           --repo "$REPO" \
-          --version "$VERSION" \
           --merge-sha "$MERGE_SHA" \
-          --generated-at "$generated_at" \
-          --out-dir evidence-gate
+          --out-dir "$STAGING"
         rc=$?
 
         if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
# Pull Request

## Summary

- Rewire the cd-release ci-evidence gate to run vrg-ci-evidence harvest into a shared job-workspace staging dir and the ci-evidence-attach to run the network-free vrg-ci-evidence assemble over that same dir, so the release PR's artifacts are downloaded exactly once instead of twice.

## Issue Linkage

- Closes #781

## Notes

- Part 2 of the double-harvest fix; wires against the locked #2330 CLI split (vergil-tooling). Gate: bundle -> harvest --repo --merge-sha --out-dir ${{ github.workspace }}/.ci-evidence-staging (download + validate_completeness gate, persists harvest-state.json). Attach: bundle -> assemble --staging <same dir> --version --generated-at --out-dir evidence-out [--sbom-file], then unchanged attest + gh release upload. Shared staging works because both composites run in the same cd-release job so the workspace filesystem persists. Warning-mode wrappers and the enforce flag are byte-for-byte preserved in both steps (promotion stays a pure flip; no path aborts in warning mode). No caller change in cd-release.yml — staging path is internal to the composites. Verified with vrg-container-run -- vrg-validate (actionlint/yamllint/shellcheck green); workflow YAML has no unit-test surface. Live verification (one harvest, bundle attached) happens at bake time once #2330 ships in a released vergil-tooling 2.1 tag — warning mode absorbs the interim.