### PR TITLE
docs(site): explicit CD secrets and semgrep rule-exclusion docs

### DIFF
--- a/docs/site/docs/actions/ci-security-semgrep.md
+++ b/docs/site/docs/actions/ci-security-semgrep.md
@@ -54,6 +54,28 @@ rulesets.
    `upload-sarif` is `false`, the SARIF file is attached to the workflow run
    as a build artifact (`semgrep-sarif`) instead.
 
+## Rule exclusions
+
+The underlying `vrg-semgrep-scan` supports a repeatable `--exclude-rule
+<full-rule-id>` flag that drops individual findings by their full Semgrep rule
+ID. Caller-supplied `--exclude-rule` values are **added on top of** the fleet
+`DEFAULT_EXCLUDED_RULES` — they never replace the defaults, so the fleet
+baseline always applies.
+
+### Fleet default: `github-actions-mutable-action-tag`
+
+`github-actions-mutable-action-tag` is currently exempted fleet-wide (it lives
+in `DEFAULT_EXCLUDED_RULES`). This rule flags third-party actions pinned to a
+mutable tag (e.g. `@v4`) rather than a full commit SHA. The exemption is
+**temporary**, pending backlog
+[vergil-project/.github#194](https://github.com/vergil-project/.github/issues/194)
+— once pin-advancement tooling exists to keep SHA pins current, third-party
+action SHAs will be pinned and the exemption lifted.
+
+Our own `vergil-project/vergil-actions/…@v2.1` references are a **permanent**
+exception: they track our controlled release line and are never SHA-pinned, so
+the rule does not apply to them regardless of the backlog above.
+
 ## Examples
 
 ### Python Semgrep scan

--- a/docs/site/docs/getting-started.md
+++ b/docs/site/docs/getting-started.md
@@ -96,7 +96,33 @@ jobs:
     uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     with:
       language: python
-    secrets: inherit
+    # Python publishes via OIDC trusted publishing — no secret to pass.
+```
+
+### Release publishing secrets
+
+Callers must forward only the publishing credentials the target ecosystem
+needs, never a blanket `secrets: inherit`. The generated `cd.yml` emits an
+explicit `secrets:` block (or none at all) matching the language:
+
+| Ecosystem | Secrets to forward |
+| --------- | ------------------ |
+| `python` | None — OIDC trusted publishing (requires `id-token: write`) |
+| `go` | None |
+| `rust` | `CARGO_REGISTRY_TOKEN` |
+| `ruby` | `RUBYGEMS_API_KEY` |
+| `java` | `CENTRAL_USERNAME`, `CENTRAL_TOKEN`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE` |
+
+For example, a Rust release job forwards a single least-privilege secret:
+
+```yaml
+  release:
+    if: github.ref == 'refs/heads/main'
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
+    with:
+      language: rust
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 ```
 
 See [Reusable Workflows](workflows/index.md) for the full list and


### PR DESCRIPTION
# Pull Request

## Summary

- Document vrg-semgrep-scan's --exclude-rule flag with the additive DEFAULT_EXCLUDED_RULES baseline and the mutable-action-tag exemption, plus per-ecosystem least-privilege CD publishing secrets replacing blanket secrets: inherit.

## Issue Linkage

- Closes #787

## Notes

- Two doc files under docs/site. Semgrep doc (ci-security-semgrep.md) gains a Rule exclusions section: repeatable --exclude-rule adds ON TOP of the fleet DEFAULT_EXCLUDED_RULES; github-actions-mutable-action-tag exempted fleet-wide pending backlog vergil-project/.github#194, with our own @v2.1 refs a permanent exception. getting-started.md CD example drops secrets: inherit (python uses OIDC) and gains a Release publishing secrets subsection enumerating rust=CARGO_REGISTRY_TOKEN, ruby=RUBYGEMS_API_KEY, java=CENTRAL_USERNAME/CENTRAL_TOKEN/GPG_PRIVATE_KEY/GPG_PASSPHRASE, python/go=none. No dedicated cd-release.yml doc page exists; getting-started.md is the canonical consumer-facing CD example so the enumeration landed there. vrg-validate green.