### PR TITLE
fix(trivy): skip pip's vendored SBOM in fs/image vuln scans

### DIFF
--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -119,11 +119,11 @@ runs:
           "$TRIVY_IMAGE" \
           -c '
             set -e
-            # Skip pip's vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
-            # pip 26.x ships it to describe pip's vendored dependencies; Trivy
+            # Skip the pip-vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
+            # pip 26.x ships it to describe the packages pip vendors; Trivy
             # would otherwise ingest it and report those vendored packages
             # (e.g. setuptools, msgpack) as findings, though they are pip
-            # internals, not the scan target's attack surface. See #796.
+            # internals, not part of the scan target attack surface. See #796.
             trivy fs \
               --scanners "$SCANNERS" \
               --severity "$SEVERITY" \
@@ -183,11 +183,11 @@ runs:
           "$TRIVY_IMAGE" \
           -c '
             set -e
-            # Skip pip's vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
-            # pip 26.x ships it to describe pip's vendored dependencies; Trivy
+            # Skip the pip-vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
+            # pip 26.x ships it to describe the packages pip vendors; Trivy
             # would otherwise ingest it and report those vendored packages
             # (e.g. setuptools, msgpack) as findings, though they are pip
-            # internals, not the scan target's attack surface. See #796.
+            # internals, not part of the scan target attack surface. See #796.
             trivy image \
               --scanners "$SCANNERS" \
               --severity "$SEVERITY" \

--- a/actions/shared/security/trivy/action.yml
+++ b/actions/shared/security/trivy/action.yml
@@ -119,12 +119,18 @@ runs:
           "$TRIVY_IMAGE" \
           -c '
             set -e
+            # Skip pip's vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
+            # pip 26.x ships it to describe pip's vendored dependencies; Trivy
+            # would otherwise ingest it and report those vendored packages
+            # (e.g. setuptools, msgpack) as findings, though they are pip
+            # internals, not the scan target's attack surface. See #796.
             trivy fs \
               --scanners "$SCANNERS" \
               --severity "$SEVERITY" \
               --exit-code 0 \
               --format json \
               --output /tmp/trivy-raw.json \
+              --skip-files "**/pip/_vendor/bom.cdx.json" \
               $TRIVYIGNORE_ARGS \
               "$SCAN_REF"
             trivy convert \
@@ -177,12 +183,18 @@ runs:
           "$TRIVY_IMAGE" \
           -c '
             set -e
+            # Skip pip's vendored CycloneDX SBOM (pip/_vendor/bom.cdx.json).
+            # pip 26.x ships it to describe pip's vendored dependencies; Trivy
+            # would otherwise ingest it and report those vendored packages
+            # (e.g. setuptools, msgpack) as findings, though they are pip
+            # internals, not the scan target's attack surface. See #796.
             trivy image \
               --scanners "$SCANNERS" \
               --severity "$SEVERITY" \
               --exit-code 0 \
               --format json \
               --output /tmp/trivy-raw.json \
+              --skip-files "**/pip/_vendor/bom.cdx.json" \
               $TRIVYIGNORE_ARGS \
               "$SCAN_REF"
             trivy convert \

--- a/docs/site/docs/actions/shared-security-trivy.md
+++ b/docs/site/docs/actions/shared-security-trivy.md
@@ -45,6 +45,13 @@ session that scans once to JSON, then converts to both table output (stdout) and
 SARIF (file). The `trivy convert` step operates on cached JSON with no re-scan
 or extra DB download.
 
+The `fs` and `image` vuln scans skip pip's vendored CycloneDX SBOM
+(`**/pip/_vendor/bom.cdx.json`, shipped by pip 26.x). Trivy would otherwise
+ingest that SBOM and report pip's **vendored** dependencies (e.g. `setuptools`,
+`msgpack`) as findings even though they are pip internals, not the scan target's
+attack surface. The `sbom` mode does **not** skip it — an SBOM should describe
+everything present.
+
 ### Filesystem scan (`fs`)
 
 1. Runs `trivy fs` inside the Trivy Docker container against the specified


### PR DESCRIPTION
# Pull Request

## Summary

- Add --skip-files '**/pip/_vendor/bom.cdx.json' to the shared trivy action's fs and image scans so Trivy stops reporting pip's vendored dependencies (setuptools, msgpack, ...) as findings fleet-wide.

## Issue Linkage

- Closes #796

## Notes

- Root cause: pip 26.x ships pip/_vendor/bom.cdx.json (a CycloneDX SBOM of pip's vendored deps); Trivy ingests it and flags those internals as image/fs CVEs. Fix skips that one file in the fs and image vuln scans; sbom-generation mode intentionally left untouched. Verified against the real vergil-containers prod-base image on Trivy 0.71.0 (action default) and 0.72.0 — clears the setuptools/msgpack false positives, all other findings still report. Doc updated. Once merged + tagged, vergil-containers can drop its per-image rm workaround (vergil-containers#481).