### PR TITLE
feat(ci): wire CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER into ci-audit workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -231,6 +231,11 @@ jobs:
       versions: '["clang-20", "clang-19", "gcc-14", "gcc-13"]'
       container-tag: '20'
       container-suffix: cpp-clang
+    # Explicit-secret chain (never `secrets: inherit`): forward the ConanCenter
+    # provider token so `conan audit` can authenticate. Optional — omit it and
+    # the cpp audit command skips the conan gate with a notice.
+    secrets:
+      CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
 
   quality:
     uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -29,6 +29,16 @@ on:
         default: prod
         description: >-
           Container image name prefix (prod or dev). Defaults to "prod".
+    secrets:
+      CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER:
+        required: false
+        description: >-
+          ConanCenter provider token for `conan audit`. Only meaningful for
+          cpp repos; other ecosystems ignore it. Optional — callers without
+          the org/repo secret configured leave it unset, in which case the
+          cpp audit command degrades to a notice-and-skip for the conan gate
+          (see the audit step below). Passed explicitly by the caller — never
+          via `secrets: inherit` (epics vergil-project/.github#189, #197).
 
 jobs:
   # Resolve the per-version job matrix (version label + container image),
@@ -73,7 +83,19 @@ jobs:
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen
 
+      # The job runs INSIDE the language container, so this step-level env:
+      # lands inside the container directly — no [container].env-prefixes
+      # passthrough is needed as it would be for a host->container hop. The
+      # token is only consumed by the cpp `conan audit` path; other ecosystems
+      # ignore it. When the caller leaves the secret unset (repos without it),
+      # this expands to an empty string and the cpp audit command skips the
+      # conan gate with a notice rather than failing auth — a per-language
+      # decision that lives in vrg-validate, not here, because only it knows
+      # whether the current run actually uses conan. A workflow-level skip is
+      # deliberately avoided: it would wrongly skip python/go audits too.
       - name: Run dependency audit
+        env:
+          CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
         run: vrg-validate --check audit
 
   evidence:

--- a/docs/site/docs/workflows/ci-audit.md
+++ b/docs/site/docs/workflows/ci-audit.md
@@ -10,6 +10,12 @@ Dependency audit workflow.
 | `versions` | string | yes | — | JSON array of language versions (e.g., `'["3.12", "3.13"]'`) |
 | `container-suffix` | string | no | `<language>` | Container image name suffix (e.g. `python`, `base`) |
 
+## Secrets
+
+| Secret | Required | Description |
+| -------- | ---------- | ------------- |
+| `CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER` | no | ConanCenter provider token for `conan audit`. Only meaningful for cpp repos; other ecosystems ignore it. Pass it explicitly via the caller's `secrets:` block — never `secrets: inherit`. When unset, the cpp audit command skips the conan gate with a notice instead of failing auth. |
+
 ## Jobs and check names
 
 | Job | Check name | Description |
@@ -25,6 +31,22 @@ jobs:
     with:
       language: python
       versions: '["3.12", "3.13", "3.14"]'
+```
+
+For cpp repos, forward the ConanCenter provider token through the explicit-secret
+chain so `conan audit` can authenticate:
+
+```yaml
+jobs:
+  audit:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-audit.yml@v2.1
+    with:
+      language: cpp
+      versions: '["clang-20", "gcc-14"]'
+      container-tag: '20'
+      container-suffix: cpp-clang
+    secrets:
+      CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
 ```
 
 ## Extension points


### PR DESCRIPTION
# Pull Request

## Summary

- Declare the ConanCenter provider token as an optional workflow_call secret in ci-audit.yml and inject it into the dependency-audit step's env so conan audit can authenticate inside the container, threaded via the explicit-secret chain (never secrets: inherit).

## Issue Linkage

- Closes #802

## Notes

- Core change is ci-audit.yml: added a workflow_call secrets block with CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER (required: false) and injected it as step-level env on the Run dependency audit step. No composite action is in the audit path, so the token lands directly on the step env, and since the job runs inside the language container no env-prefix passthrough is needed. Token-absent handling: the run-once audit step covers all languages, so a workflow-level skip would wrongly skip python/go audits; instead the env expands to empty when unset and graceful skip-with-notice for the cpp conan gate is left to vrg-validate (the only place that knows whether a run uses conan). Docs updated: workflows README C++ example and ci-audit docs page show the caller-side secrets passing. Validation green (actionlint, yamllint, markdownlint).