### PR TITLE
docs: document CI system-packages setup step

### DIFF
--- a/docs/site/docs/actions/index.md
+++ b/docs/site/docs/actions/index.md
@@ -28,3 +28,6 @@ definition and optional supporting scripts.
 
 - **[shared/security/trivy](shared-security-trivy.md)** — Runs Trivy
   vulnerability scanning, SBOM generation, or container image scanning.
+- **[shared/setup/system-packages](shared-setup-system-packages.md)** — Installs
+  a repository's declared `[container].system-packages` on CI test jobs
+  (test-runtime only; auto-wired into `ci-test`).

--- a/docs/site/docs/actions/shared-setup-system-packages.md
+++ b/docs/site/docs/actions/shared-setup-system-packages.md
@@ -1,0 +1,76 @@
+# shared/setup/system-packages
+
+Installs the Debian packages a repository declares under
+`[container].system-packages` in its `vergil.toml`, so that CI test jobs run
+against the same system dependencies as the local dev container.
+
+This action is **wired automatically** into the [`ci-test`](../workflows/ci-test.md)
+reusable workflow — consuming repositories do not add it themselves. It is
+documented here for operators who need to understand what the step does and why
+a test job might fail inside it.
+
+## Usage
+
+```yaml
+- uses: vergil-project/vergil-actions/actions/shared/setup/system-packages@v2.1
+```
+
+The action takes no inputs. It requires `vergil-tooling` to be on `PATH`
+(installed by the preceding `shared/setup/vergil` step in the `ci-test`
+workflow), because it reads the package list through
+`vrg-container-system-packages`.
+
+## Inputs
+
+None.
+
+## Behavior
+
+The action runs a single step, `install.sh`, which:
+
+1. Reads the apt install snippet from `vrg-container-system-packages
+   --install-script`. This is the **single speller** shared with the local
+   dev-container cache build, so CI and the dev container install the exact
+   same packages the same way — there is no second place a package list is
+   spelled out.
+2. If the repository declares no `[container].system-packages`, the script
+   prints `No [container].system-packages declared; skipping.` and exits `0`.
+   The step is a no-op for repositories that need no extra system packages.
+3. Otherwise it runs the install snippet with a **bounded retry** (3 attempts
+   by default, with a delay between attempts) so a transient apt mirror flake
+   does not fail the job.
+4. **Fail-closed on a missing candidate.** If a declared package genuinely has
+   no install candidate, the retries are exhausted and the step exits non-zero
+   with the speller's own "not installable" message — naming the offending
+   package and the platform — still visible in the log. Nothing is silently
+   skipped: an unresolvable package fails the test job rather than letting the
+   tests run against a missing dependency.
+
+The retry and fail-closed logic lives in `install.sh` (not inline YAML) so it
+is unit-testable; see `actions/shared/setup/system-packages/tests/install.test.sh`.
+
+### Test-runtime scope only
+
+This action installs **test-runtime** dependencies. It is wired only onto jobs
+that execute the repository's tests — never onto lint or typecheck jobs, which
+do not exercise the code and so do not need its system dependencies. See the
+[`ci-test` workflow reference](../workflows/ci-test.md) for where it sits in the
+job graph.
+
+## Configuration
+
+The package list is declared by the consuming repository in its `vergil.toml`
+under `[container].system-packages`. That key — its schema, semantics, and the
+dev-container side of its effect — is documented on the vergil-tooling side:
+
+- [`container-config` reference (`system-packages`)](https://vergil-project.github.io/vergil-tooling/reference/container-config/)
+
+This page covers only the vergil-actions CI side: which jobs run the install
+step and how the step behaves.
+
+## Related
+
+- [`ci-test` reusable workflow](../workflows/ci-test.md) — installs declared
+  system packages on test jobs only.
+- [Repository Configuration](../configuration.md) — repository-level GitHub
+  configuration overview.

--- a/docs/site/docs/configuration.md
+++ b/docs/site/docs/configuration.md
@@ -91,6 +91,16 @@ gh secret set APP_PRIVATE_KEY --repo vergil-project/<repo> --body "$(cat <path-t
 the `APP_PRIVATE_KEY` secret in all library repositories, then revoke the old
 key.
 
+## Container system packages
+
+A repository can declare extra Debian packages under `[container].system-packages`
+in its `vergil.toml`. On CI, the [`ci-test`](workflows/ci-test.md) workflow
+installs those packages on its **test jobs** (via the
+[`shared/setup/system-packages`](actions/shared-setup-system-packages.md)
+action), so tests run against the same system dependencies as the local dev
+container. The key's schema and semantics are documented on the vergil-tooling
+side: [`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/).
+
 ## GitHub Project integration
 
 The `add-to-project` workflow automatically adds new issues to a GitHub Project

--- a/docs/site/docs/workflows/ci-test.md
+++ b/docs/site/docs/workflows/ci-test.md
@@ -27,6 +27,25 @@ jobs:
       versions: '["3.12", "3.13", "3.14"]'
 ```
 
+## System packages
+
+Each `unit` job installs the system packages the repository declares under
+`[container].system-packages` in its `vergil.toml`, via the
+[`shared/setup/system-packages`](../actions/shared-setup-system-packages.md)
+action. This runs on **test jobs only** — lint and typecheck jobs do not
+exercise the code and are deliberately excluded, so the packages are installed
+exactly where the tests need them and nowhere else.
+
+The install is a no-op when a repository declares no system packages. When it
+does declare them, the step installs with a bounded retry (to absorb transient
+apt mirror flakes) and **fails closed** if a declared package has no install
+candidate — the offending package and platform are named in the log and the
+test job fails rather than running against a missing dependency. See the
+[action reference](../actions/shared-setup-system-packages.md) for the full
+behavior, and the
+[`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/)
+on the vergil-tooling side for the `[container].system-packages` key itself.
+
 ## Extension points
 
 The `unit` job provides a version matrix scaffold. Consuming repositories

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
           - cd/docs/deploy: actions/cd-docs-deploy.md
       - Shared:
           - shared/security/trivy: actions/shared-security-trivy.md
+          - shared/setup/system-packages: actions/shared-setup-system-packages.md
   - Reusable Workflows:
       - Overview: workflows/index.md
       - ci-docs: workflows/ci-docs.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add operator-facing docs for the shared/setup/system-packages composite action and its auto-wiring into the ci-test workflow's test jobs.

## Issue Linkage

- Closes #812

## Notes

- Adds docs/site/docs/actions/shared-setup-system-packages.md (new Action Reference page: behavior, single-speller apt install via vrg-container-system-packages --install-script, bounded retry, fail-closed on missing candidate, test-runtime-only scope) and registers it in the mkdocs nav and actions/index.md. Updates workflows/ci-test.md (system-packages installed on test jobs only; lint/typecheck excluded) and configuration.md (cross-reference pointer to the key's CI effect). Cross-links the consuming-repo key docs in vergil-tooling rather than restating them; this is the vergil-actions operator-side companion to vergil-tooling#2724. Refs epic 272; action #808 (issue #807). Note: strict mkdocs build has two PRE-EXISTING nav warnings (changelog.md, releases/index.md generated at release/deploy time) unrelated to this change; my new page and links produced zero warnings.