### PR TITLE
feat(ci): TypeScript support in reusable workflows

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -99,7 +99,14 @@ jobs:
     container: ${{ matrix.image }}
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.matrix.outputs.all) }}
+        # TYPECHECK cardinality is per-language. Matrix languages whose
+        # typecheck runs per Node/compiler version (e.g. C++) consume `all`;
+        # TypeScript runs a single canonical `tsc --noEmit` once (spec §3.6), so
+        # it consumes the collapsed `once` output — emitting one
+        # `quality / typecheck / <primary>` job that matches the single run-once
+        # gate github_config.desired_ci_gates_ruleset keys to ci.versions[0]
+        # (Cardinality.ONCE). This is the inverse of C++'s per-version typecheck.
+        include: ${{ fromJSON(inputs.language == 'typescript' && needs.matrix.outputs.once || needs.matrix.outputs.all) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -151,11 +151,17 @@ jobs:
         uses: ./actions/ci/security/semgrep
         with:
           language: ${{ inputs.language }}
-          # C++ has no single `p/<language>` ruleset — its coverage is split
-          # across the C and C++ registries, so wire both explicitly (epic
-          # vergil-project/.github#207 §4). Other languages resolve their
-          # ruleset from the language input alone.
-          extra-config: ${{ inputs.language == 'cpp' && 'p/c p/cpp' || '' }}
+          # Some languages need their Semgrep ruleset wired explicitly because
+          # vrg-semgrep-scan does not resolve one from the language name alone:
+          #   cpp        — no single `p/<language>` ruleset; coverage is split
+          #                across the C and C++ registries (epic
+          #                vergil-project/.github#207 §4), so wire both.
+          #   typescript — the `typescript` primary-language name has no
+          #                registry entry in vrg-semgrep-scan, so wire the
+          #                `p/typescript` JS/TS ruleset (epic
+          #                vergil-project/.github#284 T7).
+          # Other languages resolve their ruleset from the language input alone.
+          extra-config: ${{ inputs.language == 'cpp' && 'p/c p/cpp' || inputs.language == 'typescript' && 'p/typescript' || '' }}
           upload-sarif: ${{ inputs.upload-sarif }}
 
       # Upload the Semgrep SARIF as an evidence partial UNCONDITIONALLY, whether

--- a/actions/ci/matrix/action.yml
+++ b/actions/ci/matrix/action.yml
@@ -6,20 +6,24 @@ description: >-
 
   Two behaviors are folded in:
 
-    1. C++ compiler-family image routing. C++ carries its compiler family on
-       the version token (`clang-20`, `gcc-14`) rather than a separate suffix,
-       so the token is split into family + numeric tag and routed to the
-       matching image — `clang-20` -> `prod-cpp-clang:20`,
-       `gcc-14` -> `prod-cpp-gcc:14` (epic vergil-project/.github#207 §6).
-       Every other language keeps the single-suffix scheme
-       `<prefix>-<suffix>:<version>`.
+    1. Version-token image routing. C++ carries its compiler family on the
+       version token (`clang-20`, `gcc-14`) rather than a separate suffix, so
+       the token is split into family + numeric tag and routed to the matching
+       image — `clang-20` -> `prod-cpp-clang:20`, `gcc-14` -> `prod-cpp-gcc:14`
+       (epic vergil-project/.github#207 §6). TypeScript carries its Node major
+       on the version token (`node-24`): the `ts-node` runtime family rides the
+       suffix and the numeric part is the tag — `node-24` -> `prod-ts-node:24`
+       (epic vergil-project/.github#284). Every other language keeps the
+       single-suffix scheme `<prefix>-<suffix>:<version>`.
 
     2. Per-kind cardinality. The `once` output collapses the matrix to the
-       primary (first) version for C++ so run-once kinds (LINT, AUDIT) emit a
-       single job/gate instead of one per compiler x version — matching the
-       run-once gates that `github_config.desired_ci_gates_ruleset` emits. For
-       every other language `once` equals `all`, so their run-once kinds stay
-       per-version exactly as before.
+       primary (first) version for the matrix languages that declare run-once
+       kinds (C++, TypeScript) so those kinds emit a single job/gate instead of
+       one per version — matching the run-once gates that
+       `github_config.desired_ci_gates_ruleset` emits. For C++ the run-once
+       kinds are LINT and AUDIT; for TypeScript they are LINT, AUDIT, and
+       TYPECHECK (one canonical `tsc`). For every other language `once` equals
+       `all`, so their run-once kinds stay per-version exactly as before.
 
 inputs:
   language:
@@ -34,8 +38,10 @@ inputs:
     default: prod
   container-suffix:
     description: >-
-      Container image name suffix for non-C++ languages (e.g. python, go,
-      base). Ignored for C++, whose suffix is derived from the version token.
+      Container image name suffix for single-suffix languages (e.g. python, go,
+      base) and for TypeScript (`ts-node`, with the Node major taken from the
+      version token as the tag). Ignored for C++, whose suffix is derived
+      entirely from the version token.
     required: false
     default: ""
 
@@ -48,8 +54,9 @@ outputs:
   once:
     description: >-
       JSON array of {version, image} objects collapsed to the primary version
-      for C++, else identical to `all`. Consumed by run-once kinds (LINT,
-      AUDIT).
+      for the matrix languages with run-once kinds (C++, TypeScript), else
+      identical to `all`. Consumed by run-once kinds (LINT, AUDIT; and, for
+      TypeScript, TYPECHECK).
     value: ${{ steps.resolve.outputs.once }}
 
 runs:
@@ -63,39 +70,4 @@ runs:
         VERSIONS: ${{ inputs.versions }}
         PREFIX: ${{ inputs.container-prefix }}
         SUFFIX: ${{ inputs.container-suffix }}
-      run: |
-        set -euo pipefail
-
-        registry="ghcr.io/vergil-project"
-        prefix="${PREFIX:-prod}"
-
-        all=$(jq -cn \
-          --argjson versions "$VERSIONS" \
-          --arg lang "$LANGUAGE" \
-          --arg prefix "$prefix" \
-          --arg suffix "$SUFFIX" \
-          --arg reg "$registry" '
-          $versions | map(
-            if $lang == "cpp" then
-              (. | split("-")) as $p
-              | { version: .,
-                  image: ($reg + "/" + $prefix + "-cpp-" + $p[0]
-                          + ":" + ($p[1:] | join("-"))) }
-            else
-              (if $suffix == "" then $lang else $suffix end) as $sfx
-              | { version: ., image: ($reg + "/" + $prefix + "-" + $sfx + ":" + .) }
-            end)')
-
-        if [ "$LANGUAGE" = "cpp" ]; then
-          once=$(printf '%s' "$all" | jq -c '.[:1]')
-        else
-          once="$all"
-        fi
-
-        {
-          echo "all=$all"
-          echo "once=$once"
-        } >> "$GITHUB_OUTPUT"
-
-        echo "Resolved matrix (all): $all"
-        echo "Resolved matrix (once): $once"
+      run: bash "${GITHUB_ACTION_PATH}/resolve.sh"

--- a/actions/ci/matrix/resolve.sh
+++ b/actions/ci/matrix/resolve.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Resolve the per-version CI job matrix for a reusable CI workflow.
+#
+# Emits two JSON arrays of {version, image} objects to $GITHUB_OUTPUT:
+#
+#   all  — one entry per configured version. Consumed by per-version kinds
+#          (TEST always; TYPECHECK for languages whose typecheck is per-version,
+#          e.g. C++).
+#   once — the matrix collapsed to the primary (first) version for languages
+#          that carry run-once kinds (C++, TypeScript), else identical to `all`.
+#          Consumed by run-once kinds (LINT, AUDIT; and TYPECHECK for
+#          TypeScript). This mirrors github_config.desired_ci_gates_ruleset,
+#          which keys a run-once kind's single gate to ci.versions[0].
+#
+# Image routing by language:
+#
+#   cpp         — the compiler family rides the version token (`clang-20`,
+#                 `gcc-14`): split into family + numeric tag →
+#                 `<prefix>-cpp-<family>:<tag>` (epic vergil-project/.github#207
+#                 §6). e.g. clang-20 -> prod-cpp-clang:20.
+#   typescript  — the Node major rides the version token (`node-24`): the
+#                 `ts-node` runtime family rides the image *suffix* and the
+#                 numeric part is the tag → `<prefix>-<suffix>:<tag>` (epic
+#                 vergil-project/.github#284). e.g. node-24 (suffix ts-node) ->
+#                 prod-ts-node:24. This matches repo_init's _container_suffix
+#                 (`ts-node`) / _container_tag (the Node major) on the tooling
+#                 side.
+#   everything  — the single-suffix scheme `<prefix>-<suffix>:<version>`, with
+#   else          the language name used as the suffix when none is given.
+#
+# The logic lives here (not inline in action.yml) so it is unit-testable
+# (tests/resolve.test.sh).
+#
+# Inputs (env): LANGUAGE, VERSIONS (JSON array string), PREFIX, SUFFIX.
+set -euo pipefail
+
+registry="ghcr.io/vergil-project"
+prefix="${PREFIX:-prod}"
+
+all=$(jq -cn \
+  --argjson versions "$VERSIONS" \
+  --arg lang "$LANGUAGE" \
+  --arg prefix "$prefix" \
+  --arg suffix "$SUFFIX" \
+  --arg reg "$registry" '
+  $versions | map(
+    if $lang == "cpp" then
+      (. | split("-")) as $p
+      | { version: .,
+          image: ($reg + "/" + $prefix + "-cpp-" + $p[0]
+                  + ":" + ($p[1:] | join("-"))) }
+    elif $lang == "typescript" then
+      # The Node major rides the tag; the `ts-node` family rides the suffix.
+      # node-24 (suffix ts-node) -> prod-ts-node:24. Fall back to `ts-<family>`
+      # when no suffix is supplied so the runtime family is still explicit.
+      (. | split("-")) as $p
+      | (if $suffix == "" then ("ts-" + $p[0]) else $suffix end) as $sfx
+      | { version: .,
+          image: ($reg + "/" + $prefix + "-" + $sfx
+                  + ":" + ($p[1:] | join("-"))) }
+    else
+      (if $suffix == "" then $lang else $suffix end) as $sfx
+      | { version: ., image: ($reg + "/" + $prefix + "-" + $sfx + ":" + .) }
+    end)')
+
+# Run-once kinds collapse to the primary (first) version for matrix languages
+# that declare them (C++, TypeScript), so LINT/AUDIT (and TypeScript's TYPECHECK)
+# emit a single job/gate instead of one per version — matching the run-once
+# gates github_config.desired_ci_gates_ruleset keys to ci.versions[0]. Every
+# other language keeps `once` == `all`, so its gates are byte-identical to the
+# pre-cardinality behavior.
+case "$LANGUAGE" in
+  cpp | typescript) once=$(printf '%s' "$all" | jq -c '.[:1]') ;;
+  *) once="$all" ;;
+esac
+
+{
+  echo "all=$all"
+  echo "once=$once"
+} >> "$GITHUB_OUTPUT"
+
+echo "Resolved matrix (all): $all"
+echo "Resolved matrix (once): $once"

--- a/actions/ci/matrix/tests/resolve.test.sh
+++ b/actions/ci/matrix/tests/resolve.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Behavioural test for resolve.sh — the CI matrix resolver's image routing and
+# per-kind cardinality collapse.
+#
+# This repo declares `language = shell` (vergil.toml), which runs no test gate,
+# so this is a self-contained, framework-free, developer-runnable harness: run
+# it directly with `bash resolve.test.sh`. It needs only `jq` on PATH (the same
+# dependency resolve.sh has).
+#
+# Each case runs resolve.sh with a GITHUB_OUTPUT temp file and the input env,
+# then asserts the resolved `all` / `once` JSON against expected values.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+resolve_sh="${here}/../resolve.sh"
+
+pass=0
+fail=0
+
+fail_case() {
+  printf 'not ok - %s: %s\n' "$1" "$2" >&2
+  fail=$((fail + 1))
+}
+
+pass_case() {
+  printf 'ok - %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+# run_resolve <language> <versions-json> <prefix> <suffix>
+# Echoes: "<all-json>\t<once-json>" read back from the GITHUB_OUTPUT file.
+run_resolve() {
+  local out all once
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" \
+    LANGUAGE="$1" VERSIONS="$2" PREFIX="$3" SUFFIX="$4" \
+    bash "$resolve_sh" >/dev/null
+  all="$(sed -n 's/^all=//p' "$out")"
+  once="$(sed -n 's/^once=//p' "$out")"
+  rm -f "$out"
+  printf '%s\t%s' "$all" "$once"
+}
+
+# assert_json <name> <actual> <expected>  (compares as JSON, order-sensitive)
+assert_json() {
+  local name="$1" actual="$2" expected="$3"
+  if jq -e --argjson a "$actual" --argjson e "$expected" -n '$a == $e' >/dev/null; then
+    return 0
+  fi
+  fail_case "$name" "expected $expected, got $actual"
+  return 1
+}
+
+reg="ghcr.io/vergil-project"
+
+# ---------------------------------------------------------------------------
+# Case 1: TypeScript — node-<major> tokens route to prod-ts-node:<major>, and
+# TYPECHECK/LINT/AUDIT collapse to the primary (node-24) via `once`.
+# ---------------------------------------------------------------------------
+case_typescript() {
+  local name="typescript-node-routing" res all once
+  res="$(run_resolve typescript '["node-24","node-22"]' prod ts-node)"
+  all="${res%$'\t'*}"
+  once="${res#*$'\t'}"
+  assert_json "$name (all)" "$all" "$(cat <<EOF
+[{"version":"node-24","image":"$reg/prod-ts-node:24"},
+ {"version":"node-22","image":"$reg/prod-ts-node:22"}]
+EOF
+)" || return
+  assert_json "$name (once)" "$once" \
+    "[{\"version\":\"node-24\",\"image\":\"$reg/prod-ts-node:24\"}]" || return
+  pass_case "$name"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: TypeScript with an empty suffix falls back to the `ts-<family>`
+# runtime family derived from the version token.
+# ---------------------------------------------------------------------------
+case_typescript_empty_suffix() {
+  local name="typescript-empty-suffix-fallback" res all
+  res="$(run_resolve typescript '["node-24"]' prod '')"
+  all="${res%$'\t'*}"
+  assert_json "$name" "$all" \
+    "[{\"version\":\"node-24\",\"image\":\"$reg/prod-ts-node:24\"}]" || return
+  pass_case "$name"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: TypeScript honours the dev prefix.
+# ---------------------------------------------------------------------------
+case_typescript_dev_prefix() {
+  local name="typescript-dev-prefix" res all
+  res="$(run_resolve typescript '["node-22"]' dev ts-node)"
+  all="${res%$'\t'*}"
+  assert_json "$name" "$all" \
+    "[{\"version\":\"node-22\",\"image\":\"$reg/dev-ts-node:22\"}]" || return
+  pass_case "$name"
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: C++ regression — compiler-family routing and the once-collapse are
+# unchanged by the TypeScript addition.
+# ---------------------------------------------------------------------------
+case_cpp_regression() {
+  local name="cpp-regression" res all once
+  res="$(run_resolve cpp '["clang-20","gcc-14"]' prod '')"
+  all="${res%$'\t'*}"
+  once="${res#*$'\t'}"
+  assert_json "$name (all)" "$all" "$(cat <<EOF
+[{"version":"clang-20","image":"$reg/prod-cpp-clang:20"},
+ {"version":"gcc-14","image":"$reg/prod-cpp-gcc:14"}]
+EOF
+)" || return
+  assert_json "$name (once)" "$once" \
+    "[{\"version\":\"clang-20\",\"image\":\"$reg/prod-cpp-clang:20\"}]" || return
+  pass_case "$name"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: Single-suffix language (python) — no token split, and once == all
+# (no run-once collapse).
+# ---------------------------------------------------------------------------
+case_python_regression() {
+  local name="python-regression" res all once
+  res="$(run_resolve python '["3.12","3.13"]' prod python)"
+  all="${res%$'\t'*}"
+  once="${res#*$'\t'}"
+  assert_json "$name (all)" "$all" "$(cat <<EOF
+[{"version":"3.12","image":"$reg/prod-python:3.12"},
+ {"version":"3.13","image":"$reg/prod-python:3.13"}]
+EOF
+)" || return
+  assert_json "$name (once==all)" "$once" "$all" || return
+  pass_case "$name"
+}
+
+case_typescript
+case_typescript_empty_suffix
+case_typescript_dev_prefix
+case_cpp_regression
+case_python_regression
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/actions/ci/security/codeql/action.yml
+++ b/actions/ci/security/codeql/action.yml
@@ -3,9 +3,18 @@ description: >-
   Runs GitHub CodeQL static analysis (init + analyze) for a single language.
   The calling workflow must grant security-events: write permission.
 
+  The `language` input is the repo's primary-language name (carried end-to-end
+  for container resolution). A few primary-language names are not valid CodeQL
+  analysis languages, so this action maps them via resolve-language.sh before
+  handing them to codeql-action: typescript -> javascript-typescript, cpp ->
+  c-cpp (epic vergil-project/.github#284 §6 point 8a). Every other language
+  passes through unchanged.
+
 inputs:
   language:
-    description: CodeQL language to analyze (e.g. "python", "javascript").
+    description: >-
+      The repo's primary-language name (e.g. "python", "typescript", "cpp").
+      Mapped to the CodeQL analysis-language identifier by resolve-language.sh.
     required: true
   queries:
     description: Query suite to run.
@@ -15,10 +24,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Resolve CodeQL analysis language
+      id: map
+      shell: bash
+      env:
+        LANGUAGE: ${{ inputs.language }}
+      run: bash "${GITHUB_ACTION_PATH}/resolve-language.sh"
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
-        languages: ${{ inputs.language }}
+        languages: ${{ steps.map.outputs.codeql_language }}
         queries: ${{ inputs.queries }}
 
     - name: Autobuild
@@ -27,7 +43,7 @@ runs:
     - name: Run CodeQL analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{ inputs.language }}"
+        category: "/language:${{ steps.map.outputs.codeql_language }}"
         output: ${{ runner.temp }}/codeql-sarif
 
     - name: Fail on CodeQL findings

--- a/actions/ci/security/codeql/resolve-language.sh
+++ b/actions/ci/security/codeql/resolve-language.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Map a repo's primary-language name to the CodeQL analysis-language identifier.
+#
+# The reusable CI workflows carry the primary-language (e.g. `typescript`)
+# end-to-end for container resolution, but a few primary-language names are not
+# valid CodeQL analysis languages and must be translated for the codeql-action
+# `languages:` input (epic vergil-project/.github#284 §6 point 8a):
+#
+#   typescript -> javascript-typescript   (bare `typescript` is not a CodeQL
+#                                          analysis language; JS and TS are one
+#                                          combined CodeQL language)
+#   cpp        -> c-cpp                    (`c-cpp` is the current canonical
+#                                          identifier; the legacy `cpp` alias is
+#                                          deprecated)
+#
+# Every other language is a valid CodeQL identifier already and passes through
+# unchanged. Both translations are routed through this one table so the mapping
+# has a single home and is unit-testable (tests/resolve-language.test.sh).
+#
+# Writes `codeql_language=<id>` to $GITHUB_OUTPUT (and echoes the resolution).
+#
+# Inputs (env): LANGUAGE — the repo's primary-language name.
+set -euo pipefail
+
+case "${LANGUAGE:?LANGUAGE is required}" in
+  typescript) codeql_language="javascript-typescript" ;;
+  cpp) codeql_language="c-cpp" ;;
+  *) codeql_language="$LANGUAGE" ;;
+esac
+
+echo "codeql_language=$codeql_language" >> "$GITHUB_OUTPUT"
+echo "Resolved CodeQL analysis language: $LANGUAGE -> $codeql_language"

--- a/actions/ci/security/codeql/tests/resolve-language.test.sh
+++ b/actions/ci/security/codeql/tests/resolve-language.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Behavioural test for resolve-language.sh — the primary-language ->
+# CodeQL-analysis-language mapping (epic vergil-project/.github#284 §6 point 8a).
+#
+# This repo declares `language = shell` (vergil.toml), which runs no test gate,
+# so this is a self-contained, framework-free, developer-runnable harness: run
+# it directly with `bash resolve-language.test.sh`.
+#
+# Each case runs resolve-language.sh with a GITHUB_OUTPUT temp file and asserts
+# the resolved `codeql_language`.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+resolve_sh="${here}/../resolve-language.sh"
+
+pass=0
+fail=0
+
+fail_case() {
+  printf 'not ok - %s: %s\n' "$1" "$2" >&2
+  fail=$((fail + 1))
+}
+
+pass_case() {
+  printf 'ok - %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+# assert_maps <name> <language> <expected-codeql-language>
+assert_maps() {
+  local name="$1" language="$2" expected="$3" out actual
+  out="$(mktemp)"
+  GITHUB_OUTPUT="$out" LANGUAGE="$language" bash "$resolve_sh" >/dev/null
+  actual="$(sed -n 's/^codeql_language=//p' "$out")"
+  rm -f "$out"
+  if [ "$actual" != "$expected" ]; then
+    fail_case "$name" "expected '$expected', got '$actual'"
+    return
+  fi
+  pass_case "$name"
+}
+
+# The pushback fix: bare `typescript` is not a valid CodeQL analysis language.
+assert_maps "typescript->javascript-typescript" typescript javascript-typescript
+# cpp routed through the same table to the current canonical identifier.
+assert_maps "cpp->c-cpp" cpp c-cpp
+# Valid CodeQL identifiers pass through unchanged.
+assert_maps "python passthrough" python python
+assert_maps "go passthrough" go go
+assert_maps "java passthrough" java java
+
+# Missing LANGUAGE fails closed (set -u / :? guard), never emitting a silent
+# empty mapping.
+case_missing_language() {
+  local name="missing-language-fails-closed" out rc
+  out="$(mktemp)"
+  set +e
+  # env -u LANGUAGE: the parent shell may export LANGUAGE as a GNU locale var;
+  # strip it so this exercises the genuinely-unset path.
+  env -u LANGUAGE GITHUB_OUTPUT="$out" bash "$resolve_sh" >/dev/null 2>&1
+  rc=$?
+  set -e
+  rm -f "$out"
+  if [ "$rc" -eq 0 ]; then
+    fail_case "$name" "expected non-zero exit when LANGUAGE is unset, got 0"
+    return
+  fi
+  pass_case "$name"
+}
+case_missing_language
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
# Pull Request

## Summary

- The reusable CI workflows accept language: typescript, resolving prod-ts-node:<major> images by version tag, mapping typescript to javascript-typescript for CodeQL, running TYPECHECK/LINT/AUDIT once and TEST per Node version, and wiring the p/typescript Semgrep ruleset.

## Issue Linkage

- Closes #814

## Notes

- Language input + image resolution: node-<major> version tokens route to prod-ts-node:<major> (ts-node suffix + numeric tag) via actions/ci/matrix/resolve.sh, mirroring the C++ token-routing precedent. CodeQL: one mapping table (actions/ci/security/codeql/resolve-language.sh) maps typescript -> javascript-typescript (bare typescript is not a valid CodeQL analysis language) and also cpp -> c-cpp (the current canonical identifier; the legacy cpp alias is deprecated), so both route through one place. Cardinality: TYPECHECK/LINT/AUDIT are ONCE (collapsed to the primary Node version via the matrix 'once' output; the typecheck job now consumes 'once' for TypeScript — the inverse of C++'s per-version typecheck), TEST is per Node version — matching desired_ci_gates_ruleset gate names quality/typecheck/node-24, quality/lint/node-24, audit/dependencies/node-24, test/unit/node-24, test/unit/node-22. Semgrep: extra-config wires p/typescript for TS repos (vrg-semgrep-scan has no typescript registry entry), alongside the existing cpp p/c p/cpp. Both resolver scripts have framework-free unit tests (11 cases total, all green); shellcheck clean; vrg-validate green. Note: cpp CodeQL category changes cpp -> c-cpp.