### PR TITLE
feat(actions): add shared/setup/build-command CI step (fail-closed, no retry)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Install repo system packages
         uses: ./actions/shared/setup/system-packages
 
+      # Test-runtime dependency only (epic #291): run the declared
+      # [container].build-command after vergil-tooling + system-packages, before
+      # tests. Fail-closed, no retry.
+      - name: Run repo build-command
+        uses: ./actions/shared/setup/build-command
+
       - name: Install dependencies
         if: inputs.language == 'python'
         run: uv sync --group dev --frozen

--- a/actions/shared/setup/build-command/action.yml
+++ b/actions/shared/setup/build-command/action.yml
@@ -1,0 +1,12 @@
+name: Run repo build-command
+description: >-
+  Run the command a repo declares in [container].build-command, read through
+  vrg-container-build-command. Test-runtime dependency: runs only on jobs that
+  execute the repo's tests, after Install vergil-tooling. Fail-closed, no retry
+  (epic vergil-project/.github#291). Logic lives in install.sh (tests/install.test.sh).
+runs:
+  using: composite
+  steps:
+    - name: Run declared build-command
+      shell: bash
+      run: bash "${GITHUB_ACTION_PATH}/install.sh"

--- a/actions/shared/setup/build-command/install.sh
+++ b/actions/shared/setup/build-command/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Run the command a repo declares in [container].build-command.
+#
+# Reads it from `vrg-container-build-command --script` — the single speller
+# shared with the local dev-container cache build (epic vergil-project/.github#291).
+# Fail-closed and NOT retried: unlike apt (mirror flake), an arbitrary build
+# command that fails is a real failure, not a transient one.
+#
+# Test-runtime dependency: callers wire this onto jobs that execute the repo's
+# tests only, never lint/typecheck (spec §3.3). Runs after Install vergil-tooling.
+set -euo pipefail
+
+script="$(vrg-container-build-command --script)"
+if [ -z "${script}" ]; then
+  echo "No [container].build-command declared; skipping."
+  exit 0
+fi
+
+echo "Running [container].build-command: ${script}"
+bash -c "${script}"

--- a/actions/shared/setup/build-command/tests/install.test.sh
+++ b/actions/shared/setup/build-command/tests/install.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Behavioural test for install.sh — the build-command action's fail-closed core.
+#
+# This repo declares `language = shell` (vergil.toml), which runs no test gate,
+# and no action here ships a bats/shell harness, so there is no in-pipeline test
+# convention to match. This is therefore a self-contained, framework-free,
+# developer-runnable harness: run it directly with `bash install.test.sh`.
+#
+# Each case builds a temporary PATH holding a stub `vrg-container-build-command`
+# executable (so no real command is discovered), runs install.sh, and asserts
+# the exit code, output, and — crucially — that a failing command is run exactly
+# once (fail-closed, NO retry, unlike the system-packages sibling).
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_sh="${here}/../install.sh"
+
+pass=0
+fail=0
+
+fail_case() {
+  printf 'not ok - %s: %s\n' "$1" "$2" >&2
+  fail=$((fail + 1))
+}
+
+pass_case() {
+  printf 'ok - %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+# make_stub <bin> <script_body> — write a stub vrg-container-build-command that
+# emits <script_body> for the --script flag install.sh reads.
+make_stub() {
+  local bin="$1" script_body="$2"
+
+  cat >"${bin}/vrg-container-build-command" <<EOF
+#!/usr/bin/env bash
+# Only --script is used by install.sh.
+if [ "\${1:-}" = "--script" ]; then
+${script_body}
+fi
+EOF
+
+  chmod +x "${bin}/vrg-container-build-command"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: a declared command is executed — the emitted script touches a marker
+# file; install.sh runs it via bash -c and exits 0.
+# ---------------------------------------------------------------------------
+case_declared_runs() {
+  local name="declared-command-runs"
+  local dir bin marker out rc
+  dir="$(mktemp -d)"
+  bin="${dir}/bin"
+  marker="${dir}/marker"
+  mkdir -p "${bin}"
+  make_stub "${bin}" "  echo \"touch '${marker}'\""
+
+  set +e
+  out="$(PATH="${bin}:${PATH}" bash "${install_sh}" 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 0 ]; then
+    rm -rf "${dir}"
+    fail_case "${name}" "expected exit 0, got ${rc}; output: ${out}"
+    return
+  fi
+  if [ ! -e "${marker}" ]; then
+    rm -rf "${dir}"
+    fail_case "${name}" "declared command did not run (no marker); output: ${out}"
+    return
+  fi
+  rm -rf "${dir}"
+  pass_case "${name}"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: a failing command — install.sh exits non-zero AND runs the command
+# exactly once (NO retry). The command bumps a counter then exits 3; we assert
+# the counter is 1.
+# ---------------------------------------------------------------------------
+case_fail_closed_no_retry() {
+  local name="fail-closed-no-retry"
+  local dir bin counter out rc calls
+  dir="$(mktemp -d)"
+  bin="${dir}/bin"
+  counter="${dir}/calls"
+  mkdir -p "${bin}"
+  printf '0' >"${counter}"
+  # The emitted script records one invocation, then fails with exit 3.
+  make_stub "${bin}" \
+    "  echo \"n=\\\$(cat '${counter}'); printf '%s' \\\"\\\$((n + 1))\\\" >'${counter}'; exit 3\""
+
+  set +e
+  out="$(PATH="${bin}:${PATH}" bash "${install_sh}" 2>&1)"
+  rc=$?
+  set -e
+
+  calls="$(cat "${counter}")"
+  rm -rf "${dir}"
+  if [ "${rc}" -eq 0 ]; then
+    fail_case "${name}" "expected non-zero exit, got 0; output: ${out}"
+    return
+  fi
+  if [ "${calls}" -ne 1 ]; then
+    fail_case "${name}" "expected exactly 1 call (no retry), got ${calls}; output: ${out}"
+    return
+  fi
+  pass_case "${name}"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: no command declared — accessor prints nothing, install.sh skips.
+# ---------------------------------------------------------------------------
+case_no_command_skip() {
+  local name="no-command-skip"
+  local dir bin out rc
+  dir="$(mktemp -d)"
+  bin="${dir}/bin"
+  mkdir -p "${bin}"
+  # --script prints nothing when no build-command is declared.
+  make_stub "${bin}" '  :'
+
+  set +e
+  out="$(PATH="${bin}:${PATH}" bash "${install_sh}" 2>&1)"
+  rc=$?
+  set -e
+
+  rm -rf "${dir}"
+  if [ "${rc}" -ne 0 ]; then
+    fail_case "${name}" "expected exit 0, got ${rc}; output: ${out}"
+    return
+  fi
+  if ! printf '%s' "${out}" | grep -q "skipping"; then
+    fail_case "${name}" "expected a skip message; output: ${out}"
+    return
+  fi
+  pass_case "${name}"
+}
+
+case_declared_runs
+case_fail_closed_no_retry
+case_no_command_skip
+
+printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
+[ "${fail}" -eq 0 ]

--- a/docs/site/docs/actions/shared-setup-build-command.md
+++ b/docs/site/docs/actions/shared-setup-build-command.md
@@ -1,0 +1,78 @@
+# shared/setup/build-command
+
+Runs the command a repository declares under `[container].build-command` in its
+`vergil.toml`, so that CI test jobs perform the same build step as the local dev
+container before the tests run.
+
+This action is **wired automatically** into the [`ci-test`](../workflows/ci-test.md)
+reusable workflow — consuming repositories do not add it themselves. It is
+documented here for operators who need to understand what the step does and why
+a test job might fail inside it.
+
+## Usage
+
+```yaml
+- uses: vergil-project/vergil-actions/actions/shared/setup/build-command@v2.1
+```
+
+The action takes no inputs. It requires `vergil-tooling` to be on `PATH`
+(installed by the preceding `shared/setup/vergil` step in the `ci-test`
+workflow), because it reads the command through `vrg-container-build-command`.
+
+## Inputs
+
+None.
+
+## Behavior
+
+The action runs a single step, `install.sh`, which:
+
+1. Reads the command from `vrg-container-build-command --script`. This is the
+   **single speller** shared with the local dev-container cache build, so CI and
+   the dev container run the exact same build command — there is no second place
+   the command is spelled out.
+2. If the repository declares no `[container].build-command`, the script prints
+   `No [container].build-command declared; skipping.` and exits `0`. The step is
+   a no-op for repositories that need no build step.
+3. Otherwise it runs the command via `bash -c`.
+
+### Fail-closed, no retry
+
+Unlike the sibling [`shared/setup/system-packages`](shared-setup-system-packages.md)
+action — whose bounded retry absorbs a transient apt mirror flake — this action
+**does not retry**. An arbitrary build command that fails is a real failure, not
+a transient one, so retrying it would mask a genuine break. The step is
+**fail-closed**: if the command exits non-zero, the step exits non-zero and the
+test job fails. Nothing is silently skipped.
+
+The logic lives in `install.sh` (not inline YAML) so it is unit-testable; see
+`actions/shared/setup/build-command/tests/install.test.sh`.
+
+### Test-runtime scope only
+
+This action runs a **test-runtime** build step. It is wired only onto jobs that
+execute the repository's tests — never onto lint or typecheck jobs, which do not
+exercise the code and so do not need the build output. It runs after
+`Install vergil-tooling` and after the system-packages install, before the
+tests. See the [`ci-test` workflow reference](../workflows/ci-test.md) for where
+it sits in the job graph.
+
+## Configuration
+
+The command is declared by the consuming repository in its `vergil.toml` under
+`[container].build-command`. That key — its schema, semantics, and the
+dev-container side of its effect — is documented on the vergil-tooling side:
+
+- [`container-config` reference (`build-command`)](https://vergil-project.github.io/vergil-tooling/reference/container-config/)
+
+This page covers only the vergil-actions CI side: which jobs run the build step
+and how the step behaves.
+
+## Related
+
+- [`ci-test` reusable workflow](../workflows/ci-test.md) — runs the declared
+  build-command on test jobs only.
+- [`shared/setup/system-packages`](shared-setup-system-packages.md) — the
+  sibling install step (bounded retry) that runs immediately before this one.
+- [Repository Configuration](../configuration.md) — repository-level GitHub
+  configuration overview.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Shared:
           - shared/security/trivy: actions/shared-security-trivy.md
           - shared/setup/system-packages: actions/shared-setup-system-packages.md
+          - shared/setup/build-command: actions/shared-setup-build-command.md
   - Reusable Workflows:
       - Overview: workflows/index.md
       - ci-docs: workflows/ci-docs.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add a composite action that runs a repo's declared [container].build-command in CI (read via vrg-container-build-command), fail-closed with no retry, wired into ci-test.yml's unit job after system-packages.

## Issue Linkage

- Closes #819

## Notes

- Mirrors the shared/setup/system-packages sibling in structure; the deliberate difference is NO retry (an arbitrary build command failure is real, not a transient mirror flake). Logic in install.sh with a self-contained harness (tests/install.test.sh, 3 cases: runs / fail-closed-no-retry / skip) that passed 3/3; vrg-validate green and both new scripts shellcheck-clean. Push was correctly rejected because the commit touches .github/workflows/ci-test.yml (agent cannot push workflow files) — vrg-submit-pr will push at submit time.