### PR TITLE
feat(actions): export NODE_PATH in the build-command step for CI resolution parity

### DIFF
--- a/actions/shared/setup/build-command/install.sh
+++ b/actions/shared/setup/build-command/install.sh
@@ -19,3 +19,15 @@ fi
 
 echo "Running [container].build-command: ${script}"
 bash -c "${script}"
+
+# CI parity (epic vergil-project/.github#291): expose NODE_PATH so a node library
+# baked out-of-workspace by the build-command (npm install -g …) resolves via
+# CommonJS require in the subsequent test steps — mirroring the local dev-image
+# NODE_PATH injection (vergil-project/vergil-tooling#2781). Use `npm root -g`
+# (= /usr/lib/node_modules on the vergil base images) so local and CI use the
+# identical value. Guarded on CI context ($GITHUB_ENV) and npm presence, so a
+# non-CI or non-node run is a clean no-op. NODE_PATH is honoured by require only;
+# ESM import ignores it (documented limitation).
+if [ -n "${GITHUB_ENV:-}" ] && command -v npm >/dev/null 2>&1; then
+  echo "NODE_PATH=$(npm root -g)" >>"${GITHUB_ENV}"
+fi

--- a/actions/shared/setup/build-command/tests/install.test.sh
+++ b/actions/shared/setup/build-command/tests/install.test.sh
@@ -45,6 +45,21 @@ EOF
   chmod +x "${bin}/vrg-container-build-command"
 }
 
+# make_npm_stub <bin> <root> — write a stub `npm` whose `npm root -g` prints
+# <root>, so install.sh's NODE_PATH export resolves to a known value.
+make_npm_stub() {
+  local bin="$1" root="$2"
+
+  cat >"${bin}/npm" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "root" ] && [ "\${2:-}" = "-g" ]; then
+  printf '%s\n' "${root}"
+fi
+EOF
+
+  chmod +x "${bin}/npm"
+}
+
 # ---------------------------------------------------------------------------
 # Case 1: a declared command is executed — the emitted script touches a marker
 # file; install.sh runs it via bash -c and exits 0.
@@ -141,9 +156,82 @@ case_no_command_skip() {
   pass_case "${name}"
 }
 
+# ---------------------------------------------------------------------------
+# Case 4: a declared command ran and CI context is present — install.sh appends
+# `NODE_PATH=<npm root -g>` to $GITHUB_ENV so later CI test steps resolve a
+# baked node library (CI parity with the local dev image, vergil-tooling#2781).
+# ---------------------------------------------------------------------------
+case_node_path_exported() {
+  local name="node-path-exported"
+  local dir bin marker github_env node_root out rc
+  dir="$(mktemp -d)"
+  bin="${dir}/bin"
+  marker="${dir}/marker"
+  github_env="${dir}/github_env"
+  node_root="/usr/lib/node_modules"
+  mkdir -p "${bin}"
+  : >"${github_env}"
+  make_stub "${bin}" "  echo \"touch '${marker}'\""
+  make_npm_stub "${bin}" "${node_root}"
+
+  set +e
+  out="$(PATH="${bin}:${PATH}" GITHUB_ENV="${github_env}" bash "${install_sh}" 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 0 ]; then
+    rm -rf "${dir}"
+    fail_case "${name}" "expected exit 0, got ${rc}; output: ${out}"
+    return
+  fi
+  if ! grep -qx "NODE_PATH=${node_root}" "${github_env}"; then
+    rm -rf "${dir}"
+    fail_case "${name}" "expected NODE_PATH=${node_root} in GITHUB_ENV; got: $(cat "${github_env}")"
+    return
+  fi
+  rm -rf "${dir}"
+  pass_case "${name}"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: no command declared — install.sh skips before the NODE_PATH block, so
+# nothing is appended to $GITHUB_ENV even with a stub npm on PATH.
+# ---------------------------------------------------------------------------
+case_node_path_skip_no_command() {
+  local name="node-path-skip-no-command"
+  local dir bin github_env out rc
+  dir="$(mktemp -d)"
+  bin="${dir}/bin"
+  github_env="${dir}/github_env"
+  mkdir -p "${bin}"
+  : >"${github_env}"
+  make_stub "${bin}" '  :'
+  make_npm_stub "${bin}" "/usr/lib/node_modules"
+
+  set +e
+  out="$(PATH="${bin}:${PATH}" GITHUB_ENV="${github_env}" bash "${install_sh}" 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -ne 0 ]; then
+    rm -rf "${dir}"
+    fail_case "${name}" "expected exit 0, got ${rc}; output: ${out}"
+    return
+  fi
+  if [ -s "${github_env}" ]; then
+    rm -rf "${dir}"
+    fail_case "${name}" "expected empty GITHUB_ENV on skip; got: $(cat "${github_env}")"
+    return
+  fi
+  rm -rf "${dir}"
+  pass_case "${name}"
+}
+
 case_declared_runs
 case_fail_closed_no_retry
 case_no_command_skip
+case_node_path_exported
+case_node_path_skip_no_command
 
 printf '\n%d passed, %d failed\n' "${pass}" "${fail}"
 [ "${fail}" -eq 0 ]

--- a/docs/site/docs/actions/shared-setup-build-command.md
+++ b/docs/site/docs/actions/shared-setup-build-command.md
@@ -35,6 +35,20 @@ The action runs a single step, `install.sh`, which:
    `No [container].build-command declared; skipping.` and exits `0`. The step is
    a no-op for repositories that need no build step.
 3. Otherwise it runs the command via `bash -c`.
+4. After the command runs, it exports `NODE_PATH` (the npm global root, from
+   `npm root -g`) to `$GITHUB_ENV` so the subsequent CI test steps can resolve a
+   node library the build-command baked out-of-workspace (e.g. `npm install -g
+   <lib>`). This mirrors the `NODE_PATH` the local dev image injects
+   ([vergil-tooling#2781](https://github.com/vergil-project/vergil-tooling/pull/2781)),
+   so a baked library resolves identically **locally and in CI** — the local/CI
+   drift this epic exists to prevent. The export is guarded on CI context
+   (`$GITHUB_ENV` present) and `npm` being installed, so it is a clean no-op on a
+   non-CI or non-node run.
+
+   > **`require`-only caveat.** `NODE_PATH` is honoured by CommonJS `require`
+   > resolution only; ESM `import` ignores it. A baked library consumed via
+   > `import` will not resolve through `NODE_PATH` — this is a documented Node
+   > limitation, not an action bug.
 
 ### Fail-closed, no retry
 


### PR DESCRIPTION
# Pull Request

## Summary

- After the declared [container].build-command runs, the build-command action exports NODE_PATH (npm global root) to $GITHUB_ENV so a node library baked out-of-workspace resolves via require in the subsequent CI test steps.

## Issue Linkage

- Closes #824

## Notes

- Mirrors the local dev-image NODE_PATH injection in vergil-project/vergil-tooling#2781 so baked-library resolution is identical locally and in CI (epic vergil-project/.github#291). Guarded on $GITHUB_ENV + npm presence (clean no-op otherwise); step stays fail-closed and retry-free. NODE_PATH is require-only — ESM import ignores it (documented caveat). The install.test.sh harness (run manually; not in vrg-validate) gained two cases and passes 5/5. Needs a vergil-actions release before consumers' CI picks it up.