### PR TITLE
docs(actions): document build-command step at parity with system-packages

### DIFF
--- a/docs/site/docs/actions/index.md
+++ b/docs/site/docs/actions/index.md
@@ -31,3 +31,7 @@ definition and optional supporting scripts.
 - **[shared/setup/system-packages](shared-setup-system-packages.md)** — Installs
   a repository's declared `[container].system-packages` on CI test jobs
   (test-runtime only; auto-wired into `ci-test`).
+- **[shared/setup/build-command](shared-setup-build-command.md)** — Runs a
+  repository's declared `[container].build-command` on CI test jobs
+  (test-runtime only; auto-wired into `ci-test`; fail-closed with no retry;
+  exports `NODE_PATH` so a baked out-of-workspace node library resolves).

--- a/docs/site/docs/actions/shared-setup-system-packages.md
+++ b/docs/site/docs/actions/shared-setup-system-packages.md
@@ -72,5 +72,7 @@ step and how the step behaves.
 
 - [`ci-test` reusable workflow](../workflows/ci-test.md) — installs declared
   system packages on test jobs only.
+- [`shared/setup/build-command`](shared-setup-build-command.md) — the sibling
+  build step (fail-closed, no retry) that runs immediately after this one.
 - [Repository Configuration](../configuration.md) — repository-level GitHub
   configuration overview.

--- a/docs/site/docs/configuration.md
+++ b/docs/site/docs/configuration.md
@@ -101,6 +101,21 @@ action), so tests run against the same system dependencies as the local dev
 container. The key's schema and semantics are documented on the vergil-tooling
 side: [`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/).
 
+## Container build command
+
+A repository can declare a build step under `[container].build-command` in its
+`vergil.toml`. On CI, the [`ci-test`](workflows/ci-test.md) workflow runs that
+command on its **test jobs** (via the
+[`shared/setup/build-command`](actions/shared-setup-build-command.md) action,
+after the system-packages install and before the tests), so tests run against
+the same build output as the local dev container. The step **fails closed with
+no retry** — a failing build command fails the test job immediately rather than
+being retried. After it runs, the action exports `NODE_PATH` so a node library
+the build baked out-of-workspace resolves; note that `NODE_PATH` is honoured by
+CommonJS `require` only and ignored by ESM `import`. The key's schema and
+semantics are documented on the vergil-tooling side:
+[`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/).
+
 ## GitHub Project integration
 
 The `add-to-project` workflow automatically adds new issues to a GitHub Project

--- a/docs/site/docs/workflows/ci-test.md
+++ b/docs/site/docs/workflows/ci-test.md
@@ -46,6 +46,35 @@ behavior, and the
 [`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/)
 on the vergil-tooling side for the `[container].system-packages` key itself.
 
+## Build command
+
+After the system-packages install, each `unit` job runs the command the
+repository declares under `[container].build-command` in its `vergil.toml`, via
+the [`shared/setup/build-command`](../actions/shared-setup-build-command.md)
+action. Like the system-packages install, this runs on **test jobs only** — lint
+and typecheck jobs do not exercise the code and are deliberately excluded — and
+it runs after the packages are installed, before the tests.
+
+The step is a no-op when a repository declares no build command. When it does
+declare one, the step **fails closed with no retry**: an arbitrary build command
+that fails is a real failure, not a transient one, so — in deliberate contrast
+to the system-packages install's bounded retry — a non-zero exit fails the test
+job immediately rather than being retried and masking a genuine break.
+
+After the command runs, the action exports `NODE_PATH` (the npm global root,
+from `npm root -g`) so subsequent test steps can resolve a node library the
+build baked out-of-workspace (e.g. `npm install -g <lib>`).
+
+> **`require`-only caveat.** `NODE_PATH` is honoured by CommonJS `require`
+> resolution only; ESM `import` ignores it. A baked library consumed via
+> `import` will not resolve through `NODE_PATH` — a documented Node limitation,
+> not an action bug.
+
+See the [action reference](../actions/shared-setup-build-command.md) for the
+full behavior, and the
+[`container-config` reference](https://vergil-project.github.io/vergil-tooling/reference/container-config/)
+on the vergil-tooling side for the `[container].build-command` key itself.
+
 ## Extension points
 
 The `unit` job provides a version matrix scaffold. Consuming repositories


### PR DESCRIPTION
# Pull Request

## Summary

- Document the shared/setup/build-command CI step across the vergil-actions site docs (actions index, ci-test workflow, configuration) at parity with the existing system-packages coverage.

## Issue Linkage

- Closes #829

## Notes

- Docs-only, four files: actions/index.md (new Shared bullet), workflows/ci-test.md (new Build command section), configuration.md (new Container build command section), and a back-link added to shared-setup-system-packages.md Related. The dedicated action page shared-setup-build-command.md was already complete and left unchanged. mkdocs.yml needs no nav change. Validation green.