### PR TITLE
feat(cd): promote CI evidence gate to enforcing

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -45,13 +45,16 @@ on:
         default: ""
       evidence-enforce:
         description: >-
-          CI-evidence gate fatality. false (default) = WARNING mode: the
-          evidence step never aborts the release. true = ENFORCING mode:
-          incomplete evidence fails the release (spec §9.2). Promotion to
-          enforcing is a single human-gated flip of this one default (Task
-          T11) — it also flips the step's continue-on-error automatically.
+          CI-evidence gate fatality. true (default) = ENFORCING mode: incomplete
+          or failed evidence fails the release before publish (the spec §9
+          publish invariant). false = WARNING mode: the evidence step emits a
+          loud warning and never aborts the release — a temporary per-repo
+          opt-out, not a permanent soft gate (spec §9.2). This one default drives
+          both composites' enforce input and the steps' continue-on-error.
+          Promoted from warning to enforcing after the T11 bake (epic
+          vergil-project/.github#140).
         type: boolean
-        default: false
+        default: true
     secrets:
       CARGO_REGISTRY_TOKEN:
         required: false
@@ -130,11 +133,14 @@ jobs:
       #   * ATTACH (below, after tag-and-release) — assemble the complete bundle
       #     (now including the built SBOM), attest it, and upload it to the
       #     Release that now exists as the upload target.
-      # Both steps ship in WARNING mode: continue-on-error tracks the
-      # evidence-enforce flag so even a failure the composite's shell wrapper
-      # cannot catch (a `uses:` attest step) never aborts the release. Promotion
-      # to enforcing (T11) is a single flip of the evidence-enforce default — it
-      # flips both steps' fatality and both continue-on-error guards at once.
+      # Both steps ENFORCE by default (evidence-enforce=true): continue-on-error
+      # tracks the evidence-enforce flag, so incomplete/failed evidence aborts the
+      # release — even a failure the composite's shell wrapper cannot catch (a
+      # `uses:` attest step) is caught by the continue-on-error guard. Passing
+      # evidence-enforce=false demotes both steps to WARNING mode — a temporary
+      # per-repo opt-out, not a permanent soft gate. Enforcing is the T11
+      # promotion (epic .github#140): a single flip of the one default that flips
+      # both steps' fatality and both continue-on-error guards at once.
       - name: Resolve SBOM path for evidence
         id: evidence_sbom
         if: >-
@@ -195,7 +201,8 @@ jobs:
       # Post-publish attach (spec §9): the Release now exists (upload target) and
       # the SBOM has been built by registry-publish (bundle content), so the
       # bundle the pre-publish gate could only validate can now be assembled in
-      # full, attested, and attached. Same WARNING-mode contract as the gate.
+      # full, attested, and attached. Same enforce-mode contract as the gate
+      # (honors the evidence-enforce flag; enforcing by default).
       - name: Attach CI evidence bundle (post-release)
         if: steps.tag_check.outputs.exists == 'false'
         continue-on-error: ${{ !inputs.evidence-enforce }}

--- a/actions/cd/release/ci-evidence-attach/action.yml
+++ b/actions/cd/release/ci-evidence-attach/action.yml
@@ -5,10 +5,10 @@ description: >-
   commit, and attach it to the GitHub Release that tag-and-release just created.
   Runs AFTER tag-and-release (spec §9): the pre-publish completeness gate is done
   by ci-evidence-gate, and by this point both the Release (upload target) and the
-  SBOM (bundle content) exist. Ships in WARNING mode: with enforce=false any
-  failure or timeout is non-fatal and the release always proceeds. Promotion to
-  enforcing (enforce=true) is a single human-gated flag flip — the step's
-  position and steps are identical in both modes. See epic
+  SBOM (bundle content) exist. ENFORCES by default (enforce=true): any failure or
+  timeout aborts the release. Passing enforce=false demotes it to a non-fatal
+  WARNING — a temporary opt-out, never a permanent soft gate; the step's position
+  and steps are identical in both modes. See epic
   vergil-project/.github#140 spec §9, §9.2, §10.
 
 inputs:
@@ -20,12 +20,13 @@ inputs:
     required: true
   enforce:
     description: >-
-      Fatality mode. "false" (default, WARNING) — any bundle/attest/upload
-      failure or timeout emits a loud warning and the job succeeds; the release
-      is never aborted. "true" (ENFORCING) — a non-zero vrg-ci-evidence exit
-      (substantive incompleteness) or a failed attach fails the job.
+      Fatality mode. "true" (default, ENFORCING) — a non-zero vrg-ci-evidence
+      exit (substantive incompleteness) or a failed attach fails the job.
+      "false" (WARNING) — any bundle/attest/upload failure or timeout emits a
+      loud warning and the job succeeds; the release is never aborted (a
+      temporary opt-out).
     required: false
-    default: "false"
+    default: "true"
   timeout-minutes:
     description: >-
       Upper bound (minutes) on the offline assemble step. Composite steps cannot

--- a/actions/cd/release/ci-evidence-gate/action.yml
+++ b/actions/cd/release/ci-evidence-gate/action.yml
@@ -6,10 +6,11 @@ description: >-
   enforcing, no package, tag, or Release is created without complete evidence.
   This step does NOT attest or attach anything: the GitHub Release does not yet
   exist and the SBOM is not yet built at this point in the pipeline — the
-  ci-evidence-attach composite does that AFTER tag-and-release. Ships in WARNING
-  mode: with enforce=false any failure or timeout is non-fatal and the release
-  always proceeds. Promotion to enforcing (enforce=true) is a single human-gated
-  flag flip. See epic vergil-project/.github#140 spec §9, §9.2, §10.
+  ci-evidence-attach composite does that AFTER tag-and-release. ENFORCES by
+  default (enforce=true): any failure or timeout aborts the release before
+  publish. Passing enforce=false demotes it to a non-fatal WARNING — a temporary
+  opt-out, never a permanent soft gate. See epic vergil-project/.github#140
+  spec §9, §9.2, §10.
 
 inputs:
   version:
@@ -17,13 +18,13 @@ inputs:
     required: true
   enforce:
     description: >-
-      Fatality mode. "false" (default, WARNING) — an incomplete/failed harvest
-      emits a loud warning and the job succeeds; the release is never aborted.
-      "true" (ENFORCING) — a non-zero vrg-ci-evidence exit (substantive
-      incompleteness) fails the job here, before publish, gating the release
-      (spec §9.2).
+      Fatality mode. "true" (default, ENFORCING) — a non-zero vrg-ci-evidence
+      exit (substantive incompleteness) fails the job here, before publish,
+      gating the release (the spec §9 publish invariant). "false" (WARNING) — an
+      incomplete/failed harvest emits a loud warning and the job succeeds; the
+      release is never aborted (a temporary opt-out, spec §9.2).
     required: false
-    default: "false"
+    default: "true"
   timeout-minutes:
     description: >-
       Upper bound (minutes) on the harvest+validate step. Composite steps cannot


### PR DESCRIPTION
# Pull Request

## Summary

- Flip the evidence-enforce default to true so incomplete or failed CI evidence now hard-fails a release before publish (the spec §9 publish invariant), after a clean ~4-week warning-mode bake.

## Issue Linkage

- Closes #831

## Notes

- Single-knob promotion (Task T11, epic vergil-project/.github#140). Flips the evidence-enforce default false->true in cd-release.yml, plus the two composites' inert enforce defaults for a self-consistent fail-closed default; cd-release is their only caller and passes enforce explicitly, so the composite change is behavior-neutral. Warning mode survives as a temporary per-repo opt-out (evidence-enforce=false), never a permanent soft gate. Bake evidence: 54/54 vergil-tooling releases v2.1.138-191 attached complete bundles, 100% attachment across containers/claude-plugin/vm within adoption windows, latest manifest missing_gates=[]. Doc-site reflection of the enforcing state is the epic's docs-review bookend (#143), deliberately out of scope here. Post-merge, a vergil-actions v2.1 release is needed for consumers (pinned to @v2.1) to inherit the flip; then the T11 Step 3 live negative-path check (withhold a required-gate artifact, confirm the release fails closed) should be run.