### PR TITLE
fix(ci): bridge per-matrix report files into test/audit/quality evidence artifacts

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -98,22 +98,57 @@ jobs:
           CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER: ${{ secrets.CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER }}
         run: vrg-validate --check audit
 
+      # Bridge this matrix leg's report files across the job boundary (#836).
+      # The dependencies job and the evidence job run on separate runners with
+      # separate filesystems, so the reports produced here are stranded unless
+      # uploaded. Rename to version-suffixed basenames so each version's report
+      # stays distinct after the evidence job's emit step (flattens by basename).
+      - name: Stage audit reports for evidence
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p ci-reports
+          for f in pip-audit.json licenses.json; do
+            [ -f "$f" ] || continue
+            cp "$f" "ci-reports/${f%.json}-${VERSION}.json"
+          done
+
+      - name: Upload audit report evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-audit-reports-${{ matrix.version }}
+          path: ci-reports/
+          if-no-files-found: warn
+
   evidence:
     name: evidence
     # Runs only after every matrix audit job succeeds, so the artifact's
-    # presence is itself proof the audit gate passed. Report files (audit /
-    # license JSON) are collected when the audit command emits them; until then
-    # the artifact carries evidence.json alone.
+    # presence is itself proof the audit gate passed. Each dependencies leg
+    # uploads its version-suffixed pip-audit.json / licenses.json as a
+    # per-version partial; the step below pulls every leg's reports back onto
+    # one runner so the emitted bundle carries each version's reports (#836).
     needs: dependencies
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Download per-matrix audit reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ci-evidence-audit-reports-*
+          path: evidence-reports
+          merge-multiple: true
+
       - name: Emit ci-evidence-audit artifact
         uses: ./actions/ci/evidence/emit
         with:
           gate: audit
           files: |
-            pip-audit.json
-            licenses.json
+            evidence-reports/pip-audit-*.json
+            evidence-reports/licenses-*.json
+          tools: '[{"name": "pip-audit"}, {"name": "pip-licenses"}]'

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -92,6 +92,33 @@ jobs:
       - name: Run lint
         run: vrg-validate --check lint
 
+      # Bridge this leg's lint report across the job boundary (#836). The lint
+      # job and the evidence job run on separate runners with separate
+      # filesystems, so the report produced here is stranded unless uploaded.
+      # quality-ruff.json is a locked filename contract with vergil-tooling#2811
+      # (which adds its emission); until #2811 releases the file is absent and
+      # if-no-files-found: warn keeps this non-fatal. Version-suffix the basename
+      # so each leg stays distinct after the evidence emit step.
+      - name: Stage lint report for evidence
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p ci-reports
+          if [ -f quality-ruff.json ]; then
+            cp quality-ruff.json "ci-reports/quality-ruff-${VERSION}.json"
+          fi
+
+      - name: Upload lint report evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-quality-reports-lint-${{ matrix.version }}
+          path: ci-reports/
+          if-no-files-found: warn
+
   typecheck:
     name: typecheck / ${{ matrix.version }}
     needs: matrix
@@ -121,19 +148,61 @@ jobs:
       - name: Run typecheck
         run: vrg-validate --check typecheck
 
+      # Bridge this leg's typecheck report across the job boundary (#836). The
+      # typecheck job and the evidence job run on separate runners with separate
+      # filesystems, so the report produced here is stranded unless uploaded.
+      # quality-mypy.xml is a locked filename contract with vergil-tooling#2811
+      # (which adds its emission); until #2811 releases the file is absent and
+      # if-no-files-found: warn keeps this non-fatal. Version-suffix the basename
+      # so each leg stays distinct after the evidence emit step.
+      - name: Stage typecheck report for evidence
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p ci-reports
+          if [ -f quality-mypy.xml ]; then
+            cp quality-mypy.xml "ci-reports/quality-mypy-${VERSION}.xml"
+          fi
+
+      - name: Upload typecheck report evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-quality-reports-typecheck-${{ matrix.version }}
+          path: ci-reports/
+          if-no-files-found: warn
+
   evidence:
     name: evidence
     # Runs only after the common, lint, and typecheck jobs all succeed, so the
-    # artifact's presence is itself proof the quality gate passed. Lint and
-    # typecheck report to stdout and emit no files today; the artifact carries
-    # evidence.json alone, which is sufficient for completeness.
+    # artifact's presence is itself proof the quality gate passed. Each lint /
+    # typecheck leg uploads its version-suffixed quality-ruff.json /
+    # quality-mypy.xml as a per-version partial; the step below pulls every
+    # leg's reports back onto one runner so the emitted bundle carries each
+    # version's reports. Those filenames are a locked contract with
+    # vergil-tooling#2811 — until it releases the globs match nothing and emit
+    # skips them, so the artifact carries evidence.json alone (#836).
     needs: [common, lint, typecheck]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Download per-matrix quality reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ci-evidence-quality-reports-*
+          path: evidence-reports
+          merge-multiple: true
+
       - name: Emit ci-evidence-quality artifact
         uses: ./actions/ci/evidence/emit
         with:
           gate: quality
+          files: |
+            evidence-reports/quality-ruff-*.json
+            evidence-reports/quality-mypy-*.xml
+          tools: '[{"name": "ruff"}, {"name": "mypy"}]'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -87,22 +87,57 @@ jobs:
       - name: Run unit tests
         run: vrg-validate --check test
 
+      # Bridge this matrix leg's report files across the job boundary (#836).
+      # The unit job and the evidence job run on separate runners with separate
+      # filesystems, so the reports produced here are stranded unless uploaded.
+      # Rename to version-suffixed basenames so each interpreter's report stays
+      # distinct after the evidence job's emit step, which flattens by basename.
+      - name: Stage test reports for evidence
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p ci-reports
+          for f in coverage.xml junit.xml; do
+            [ -f "$f" ] || continue
+            cp "$f" "ci-reports/${f%.xml}-${VERSION}.xml"
+          done
+
+      - name: Upload test report evidence partial
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-evidence-test-reports-${{ matrix.version }}
+          path: ci-reports/
+          if-no-files-found: warn
+
   evidence:
     name: evidence
     # Runs only after every matrix unit job succeeds, so the artifact's presence
-    # is itself proof the test gate passed. Report files (coverage.xml,
-    # junit.xml) are collected when the test command emits them; until then the
-    # artifact carries evidence.json alone, which is sufficient for completeness.
+    # is itself proof the test gate passed. Each unit leg uploads its
+    # version-suffixed coverage.xml / junit.xml as a per-version partial; the
+    # step below pulls every leg's reports back onto one runner so the emitted
+    # bundle carries each interpreter's reports, not a single merged one (#836).
     needs: unit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Download per-matrix test reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ci-evidence-test-reports-*
+          path: evidence-reports
+          merge-multiple: true
+
       - name: Emit ci-evidence-test artifact
         uses: ./actions/ci/evidence/emit
         with:
           gate: test
           files: |
-            coverage.xml
-            junit.xml
+            evidence-reports/coverage-*.xml
+            evidence-reports/junit-*.xml
+          tools: '[{"name": "pytest"}, {"name": "coverage.py"}]'


### PR DESCRIPTION
# Pull Request

## Summary

- Adds an upload-to-download bridge so each matrix leg's report files reach the separate evidence job, fixing the empty test/audit/quality evidence payloads caused by jobs running on separate runner filesystems.

## Issue Linkage

- Closes #836

## Notes

- Mirrors the working ci-security.yml upload/download pattern. Each producing matrix leg (unit; dependencies; lint + typecheck) renames its report to a version-suffixed basename and uploads it as a per-version partial artifact (ci-evidence-<gate>-reports[-<kind>]-<version>, if-no-files-found: warn); the evidence job download-artifacts them all with pattern ci-evidence-<gate>-reports-* + merge-multiple into evidence-reports/ before emit, and emit's files: globs point there. Version-suffixed basenames keep each interpreter's report distinct despite emit flattening by basename. Uploads from EVERY matrix version (not just primary), per request. tools: populated per gate (pytest/coverage.py; pip-audit/pip-licenses; ruff/mypy). Two deliberate choices: (1) metrics left at default {} — no count is available without adding an XML/JSON parse step (over-engineering, out of scope); (2) quality-ruff.json/quality-mypy.xml depend on vergil-tooling#2811 (locked filename contract) and stay skipped-empty (non-fatal) until it releases — verified download-artifact@v7 source that a zero-match pattern succeeds with 0 downloaded, not fatal. Validation (actionlint + yamllint via vrg-container-run -- vrg-validate) is green. Full verification is a live CI run whose ci-evidence-test/audit artifacts now carry each version's real report files.