### PR TITLE
fix(ci): provide GH_TOKEN to cd-docs pre-deploy step

### DIFF
--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -42,6 +42,12 @@ jobs:
         shell: bash
         env:
           PRE_DEPLOY_COMMAND: ${{ inputs.pre-deploy-command }}
+          # The default pre-deploy command runs vrg-roadmap / vrg-activity-log,
+          # which shell out to `gh` to read the org `.github` epics. In an
+          # Actions runner `gh` refuses to run without a token, so a token must
+          # be in the env. The org `.github` epic home is public, so the
+          # repo-scoped default token suffices — no App-token minting needed.
+          GH_TOKEN: ${{ github.token }}
         run: eval "$PRE_DEPLOY_COMMAND"
 
       - name: Stage documentation sources


### PR DESCRIPTION
# Pull Request

## Summary

- The cd-docs.yml pre-deploy step runs vrg-roadmap / vrg-activity-log, which shell out to gh to read the org .github epics. In an Actions runner gh refuses to run without a token, so every CD docs-refresh job failed with 'set the GH_TOKEN environment variable'. This sets GH_TOKEN: github.token on that step. The org .github epic home is public, so the repo-scoped default token is sufficient — no App-token minting or secrets threading, and no wrapper (cd-docs-refresh.yml) or caller-repo changes.

## Issue Linkage

- Closes #844

## Notes

- $Single-file change to .github/workflows/cd-docs.yml (adds GH_TOKEN plus an explanatory comment). Validated with vrg-container-run -- vrg-validate (actionlint + yamllint clean). Triage capture: vergil-project/.github#310. Follow-up (deferred): if a docs repo ever points its roadmap at a private self-homing epic home, switch to the App-token pattern used by ops-epic-rollup / ops-epic-sweep / ops-github-config.