### PR TITLE
chore(gitignore): reconcile to baseline + add self-policing ops.yml (#849)

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -1,0 +1,20 @@
+name: Ops
+
+on:
+  schedule:
+    - cron: '45 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  github-config:
+    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.1
+    permissions:
+      contents: read
+      issues: write
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,60 @@
 # OS/editor noise
-.DS_Store
-Thumbs.db
-.idea/
-.vscode/
 *.swp
 *.swo
+*~
+*.bak
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
 
 # Env/secrets
 .env
 .env.*
 *.log
 
-# Temp/build artifacts (only if created)
-dist/
-build/
-
-# Parallel AI agent worktrees (see CLAUDE.md)
+# Agent/tooling scratch dirs
+.venv/
 .worktrees/
-
-# Vergil tooling scratch dir
 .vergil/
+.superpowers/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+junit.xml
+pip-audit.json
+licenses.json
+quality-ruff.json
+quality-mypy.xml
+
+# Docs site
+docs/site/site/
+
+# Node/JS
+node_modules/
+*.tsbuildinfo
+*.test
+*.out
+
+# Ruby
+.bundle/
+vendor/bundle/
+
+# Compiled objects
+*.o
+*.obj
+*.a
+*.so


### PR DESCRIPTION
# Pull Request

## Summary

- Reconcile vergil-actions's .gitignore to the centralized baseline (verbatim superset, canonical spellings) and add a self-policing scheduled ops.yml so the repo continuously audits its own compliance. Rollout task for epic #311.

## Issue Linkage

- Closes #849

## Notes

- gitignore: added all missing baseline patterns (*~, *.bak, .venv/, .superpowers/, .claude/scheduled_tasks.lock, .claude/settings.local.json, *.egg-info/, __pycache__/, *.pyc, .pytest_cache/, .mypy_cache/, .ruff_cache/, .coverage, coverage.xml, junit.xml, pip-audit.json, licenses.json, quality-ruff.json, quality-mypy.xml, docs/site/site/, node_modules/, *.tsbuildinfo, *.test, *.out, .bundle/, vendor/bundle/, *.o, *.obj, *.a, *.so) and reorganized existing lines into tidy sections; no variant spellings or repo-specific extras needed replacing. ops.yml: added with scheduled cron minute 45 (45 6 * * *), wired to the audit. Both _check_gitignore and _check_required_workflows return []. Validation: vrg-container-run -- vrg-validate PASSED. Note: agent push was rejected for workflow-file permissions (expected); branch will be pushed by the human at vrg-submit-pr time.